### PR TITLE
feat(auth): adopt Alcantara Cognito session flow

### DIFF
--- a/frontend/app/auth/permissions.ts
+++ b/frontend/app/auth/permissions.ts
@@ -1,0 +1,24 @@
+export const PERMISSIONS = {
+  access: 'alcantara:access',
+  program: { read: 'alcantara:program:read', manage: 'alcantara:program:manage', operate: 'alcantara:program:operate' },
+  flight: { read: 'alcantara:flight:read', manage: 'alcantara:flight:manage', operate: 'alcantara:flight:operate' },
+  scene: { read: 'alcantara:scene:read', manage: 'alcantara:scene:manage', operate: 'alcantara:scene:operate' },
+  layout: { read: 'alcantara:layout:read', manage: 'alcantara:layout:manage' },
+  media: { read: 'alcantara:media:read', manage: 'alcantara:media:manage' },
+  song: { read: 'alcantara:song:read', manage: 'alcantara:song:manage' },
+  instant: { read: 'alcantara:instant:read', manage: 'alcantara:instant:manage', operate: 'alcantara:instant:operate' },
+  stinger: { read: 'alcantara:stinger:read', manage: 'alcantara:stinger:manage' },
+  radio: { read: 'alcantara:radio:read', manage: 'alcantara:radio:manage', operate: 'alcantara:radio:operate' },
+  upload: { create: 'alcantara:upload:create' }
+} as const;
+
+export const routePermission = (pathname: string): string => {
+  if (pathname.startsWith('/flight')) return PERMISSIONS.flight.read;
+  if (pathname.startsWith('/instants')) return PERMISSIONS.instant.read;
+  if (pathname.startsWith('/stingers')) return PERMISSIONS.stinger.read;
+  if (pathname.startsWith('/songs')) return PERMISSIONS.song.read;
+  if (pathname.startsWith('/media')) return PERMISSIONS.media.read;
+  if (pathname.startsWith('/scenes')) return PERMISSIONS.scene.read;
+  if (pathname.startsWith('/layouts') || pathname.startsWith('/preview')) return PERMISSIONS.layout.read;
+  return PERMISSIONS.program.read;
+};

--- a/frontend/app/components/common/AuthListener.tsx
+++ b/frontend/app/components/common/AuthListener.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { fetchAuthSession } from 'aws-amplify/auth';
+import { getSession } from '../../services/session';
+import { takeLoginReturnPath } from '../../services/login-return';
 import { login, setAuthLoaded } from '../../state/dispatchers/auth';
 import { useAuthStatus } from '../../hooks/useAuth';
 
@@ -11,9 +12,9 @@ export default function AuthListener() {
   useEffect(() => {
     const checkSession = async () => {
       try {
-        const session = await fetchAuthSession();
-        if (session.userSub && session.tokens) {
-          const payload = session.tokens.idToken?.payload;
+        const session = await getSession();
+        if (session.userSub && session.token) {
+          const payload = session.payload;
           const user = {
             id: session.userSub,
             email: (payload?.email as string) || '',
@@ -21,6 +22,8 @@ export default function AuthListener() {
             picture: payload?.picture as string
           };
           dispatch(login(user));
+          const returnTo = takeLoginReturnPath();
+          if (returnTo) window.location.replace(returnTo);
         } else {
           dispatch(setAuthLoaded());
         }

--- a/frontend/app/components/common/PermissionBoundary.tsx
+++ b/frontend/app/components/common/PermissionBoundary.tsx
@@ -1,0 +1,31 @@
+import { Button, LoadingSpinner } from '@gaulatti/bleecker';
+import type { ReactNode } from 'react';
+import { useLocation } from 'react-router';
+import { routePermission } from '../../auth/permissions';
+import { useFeatures } from '../../hooks/useFeatures';
+
+export default function PermissionBoundary({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const { status, hasPermission, reload } = useFeatures();
+  const required = routePermission(location.pathname);
+
+  if (status === 'loading') {
+    return <div className='flex min-h-[50vh] items-center justify-center'><LoadingSpinner size='lg' /></div>;
+  }
+  if (status === 'unauthenticated') {
+    const returnTo = `${location.pathname}${location.search}${location.hash}`;
+    window.location.replace(`/login?returnTo=${encodeURIComponent(returnTo)}`);
+    return null;
+  }
+  if (status === 'unavailable') {
+    return <AccessState title='Authorization service unavailable' detail='Access could not be verified. Nothing was allowed. Retry when Pompeii is healthy.' action={<Button onClick={reload}>Retry</Button>} />;
+  }
+  if (status === 'denied' || !hasPermission(required)) {
+    return <AccessState title='Access denied' detail={`Your current Pompeii assignment does not grant ${required}.`} />;
+  }
+  return <>{children}</>;
+}
+
+function AccessState({ title, detail, action }: { title: string; detail: string; action?: ReactNode }) {
+  return <main className='flex min-h-[60vh] items-center justify-center p-6'><div className='max-w-lg text-center'><h1 className='text-3xl font-semibold'>{title}</h1><p className='mt-3 text-text-secondary'>{detail}</p>{action ? <div className='mt-6'>{action}</div> : null}</div></main>;
+}

--- a/frontend/app/components/common/PermissionBoundary.tsx
+++ b/frontend/app/components/common/PermissionBoundary.tsx
@@ -1,8 +1,9 @@
 import { Button, LoadingSpinner } from '@gaulatti/bleecker';
 import type { ReactNode } from 'react';
-import { useLocation } from 'react-router';
+import { Navigate, useLocation } from 'react-router';
 import { routePermission } from '../../auth/permissions';
 import { useFeatures } from '../../hooks/useFeatures';
+import { loginPathForLocation } from '../../services/login-return';
 
 export default function PermissionBoundary({ children }: { children: ReactNode }) {
   const location = useLocation();
@@ -13,9 +14,7 @@ export default function PermissionBoundary({ children }: { children: ReactNode }
     return <div className='flex min-h-[50vh] items-center justify-center'><LoadingSpinner size='lg' /></div>;
   }
   if (status === 'unauthenticated') {
-    const returnTo = `${location.pathname}${location.search}${location.hash}`;
-    window.location.replace(`/login?returnTo=${encodeURIComponent(returnTo)}`);
-    return null;
+    return <Navigate to={loginPathForLocation(location.pathname, location.search, location.hash)} replace />;
   }
   if (status === 'unavailable') {
     return <AccessState title='Authorization service unavailable' detail='Access could not be verified. Nothing was allowed. Retry when Pompeii is healthy.' action={<Button onClick={reload}>Retry</Button>} />;

--- a/frontend/app/components/common/ProtectedRoute.tsx
+++ b/frontend/app/components/common/ProtectedRoute.tsx
@@ -1,10 +1,11 @@
 import { LoadingSpinner } from '@gaulatti/bleecker';
 import type { ReactNode } from 'react';
-import { Navigate } from 'react-router';
+import { Navigate, useLocation } from 'react-router';
 import { useAuthStatus } from '../../hooks/useAuth';
 
 export default function ProtectedRoute({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoaded } = useAuthStatus();
+  const location = useLocation();
 
   if (!isLoaded) {
     return (
@@ -15,7 +16,8 @@ export default function ProtectedRoute({ children }: { children: ReactNode }) {
   }
 
   if (!isAuthenticated) {
-    return <Navigate to='/login' replace />;
+    const returnTo = `${location.pathname}${location.search}${location.hash}`;
+    return <Navigate to={`/login?returnTo=${encodeURIComponent(returnTo)}`} replace />;
   }
 
   return <>{children}</>;

--- a/frontend/app/hooks/useAuth.ts
+++ b/frontend/app/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { signOut } from 'aws-amplify/auth';
+import { clearSession } from '../services/session';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router';
 import { logout as logoutDispatcher } from '../state/dispatchers/auth';
@@ -11,7 +11,7 @@ const useLogout = () => {
 
   const logout = (): void => {
     if (isAuthenticated && isLoaded) {
-      signOut()
+      clearSession()
         .then(() => {
           dispatch(logoutDispatcher());
           navigate('/login');

--- a/frontend/app/hooks/useFeatures.tsx
+++ b/frontend/app/hooks/useFeatures.tsx
@@ -1,78 +1,63 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
-import { api } from '../../services/api';
+import axios from 'axios';
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
+import { api } from '../services/api';
 
-export type FeatureLevel = 'C' | 'T1' | 'T2' | 'T3';
-
-export interface UserContext {
-  features?: Record<string, { level: FeatureLevel }>;
-  membership?: any;
+export interface AuthorizationContext {
+  permissions: string[];
+  roles: string[];
+  teamId: number;
 }
 
+type AuthorizationStatus = 'loading' | 'ready' | 'unauthenticated' | 'denied' | 'unavailable';
+
 interface FeaturesContextValue {
-  context: UserContext | null;
-  loading: boolean;
-  hasFeature: (slug: string, minLevel?: FeatureLevel) => boolean;
+  context: AuthorizationContext | null;
+  status: AuthorizationStatus;
+  hasPermission: (permission: string) => boolean;
+  reload: () => void;
 }
 
 const FeaturesContext = createContext<FeaturesContextValue>({
   context: null,
-  loading: true,
-  hasFeature: () => false
+  status: 'loading',
+  hasPermission: () => false,
+  reload: () => undefined
 });
 
 export const useFeatures = () => useContext(FeaturesContext);
 
-// const levelValues: Record<FeatureLevel, number> = { C: 0, T1: 1, T2: 2, T3: 3 };
-
 export function FeaturesProvider({ children }: { children: ReactNode }) {
-  const [context, setContext] = useState<UserContext | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [context, setContext] = useState<AuthorizationContext | null>(null);
+  const [status, setStatus] = useState<AuthorizationStatus>('loading');
+  const [revision, setRevision] = useState(0);
 
   useEffect(() => {
-    let mounted = true;
+    let active = true;
+    setStatus('loading');
+    void api.get<{ authorization?: AuthorizationContext }>('/auth/me').then((response) => {
+      if (!active) return;
+      const authorization = response.data.authorization ?? null;
+      setContext(authorization);
+      setStatus(authorization ? 'ready' : 'denied');
+    }).catch((error: unknown) => {
+      if (!active) return;
+      setContext(null);
+      const code = axios.isAxiosError(error) ? error.response?.status : undefined;
+      setStatus(code === 401 ? 'unauthenticated' : code === 403 ? 'denied' : 'unavailable');
+    });
+    return () => { active = false; };
+  }, [revision]);
 
-    api
-      .get('/auth/me')
-      .then((res) => {
-        if (mounted) {
-          setContext(res.data.context || {});
-          setLoading(false);
-        }
-      })
-      .catch((err) => {
-        console.error('Failed to load user context', err);
-        if (mounted) {
-          setContext(null);
-          setLoading(false);
-        }
-      });
+  const hasPermission = useCallback((permission: string) => (
+    context?.permissions.includes('*') === true || context?.permissions.includes(permission) === true
+  ), [context]);
+  const reload = useCallback(() => setRevision((value) => value + 1), []);
 
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  const hasFeature = (slug: string, minLevel: FeatureLevel = 'C'): boolean => {
-    // Feature gating is temporarily disabled.
-    // Previous logic retained for easy rollback:
-    // if (!context?.features || !context.features[slug]) {
-    //   return false;
-    // }
-    // const userLevel = context.features[slug].level;
-    // return (levelValues[userLevel] ?? -1) >= levelValues[minLevel];
-    void slug;
-    void minLevel;
-    void context;
-    return true;
-  };
-
-  return <FeaturesContext.Provider value={{ context, loading, hasFeature }}>{children}</FeaturesContext.Provider>;
+  return <FeaturesContext.Provider value={{ context, status, hasPermission, reload }}>{children}</FeaturesContext.Provider>;
 }
 
-export function Can({ feature, level = 'C', children, fallback = null }: { feature: string; level?: FeatureLevel; children: ReactNode; fallback?: ReactNode }) {
-  const { hasFeature, loading } = useFeatures();
-
-  if (loading) return null;
-
-  return hasFeature(feature, level) ? <>{children}</> : <>{fallback}</>;
+export function Can({ permission, children, fallback = null }: { permission: string; children: ReactNode; fallback?: ReactNode }) {
+  const { status, hasPermission } = useFeatures();
+  if (status !== 'ready') return null;
+  return hasPermission(permission) ? <>{children}</> : <>{fallback}</>;
 }

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -8,6 +8,9 @@ import './app.css';
 import './services/auth';
 import AuthListener from './components/common/AuthListener';
 import { getStore } from './state';
+import { installAuthenticatedFetch } from './services/authenticatedFetch';
+
+installAuthenticatedFetch();
 
 export const links: Route.LinksFunction = () => [
   { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },

--- a/frontend/app/routes/layout.tsx
+++ b/frontend/app/routes/layout.tsx
@@ -37,6 +37,8 @@ import { useGlobalProgramId } from '../utils/globalProgram';
 import { useGlobalTransitionId } from '../utils/globalTransition';
 import { SCENE_TRANSITIONS, getSceneTransitionPreset } from '../utils/sceneTransitions';
 import { useLogout } from '../hooks/useAuth';
+import { useFeatures } from '../hooks/useFeatures';
+import { PERMISSIONS, routePermission } from '../auth/permissions';
 
 const GITHUB_REPO_URL = 'https://github.com/gaulatti/alcantara';
 
@@ -90,6 +92,7 @@ export default function Layout() {
   const navigate = useNavigate();
   const location = useLocation();
   const { logout } = useLogout();
+  const { hasPermission } = useFeatures();
   const [knownPrograms, setKnownPrograms] = useState<ProgramSummary[]>([]);
   const [knownScenes, setKnownScenes] = useState<SceneSummary[]>([]);
   const [knownInstants, setKnownInstants] = useState<InstantSummary[]>([]);
@@ -287,7 +290,7 @@ export default function Layout() {
     { href: '/programs', label: 'Programs' },
     { href: '/preview', label: 'Preview' },
     { href: '/layouts', label: 'Layouts' }
-  ];
+  ].filter((item) => hasPermission(routePermission(item.href)));
 
   const footerSections: Array<{ title: string; items: NavItem[] }> = [
     {
@@ -300,7 +303,7 @@ export default function Layout() {
         { href: '/media', label: 'Media' },
         { href: '/scenes', label: 'Scenes' },
         { href: '/programs', label: 'Programs' }
-      ]
+      ].filter((item) => hasPermission(routePermission(item.href)))
     },
     {
       title: 'Resources',
@@ -615,12 +618,31 @@ export default function Layout() {
         }
       }));
 
-    return [...baseActions, ...selectProgramActions, ...sceneTakeActions, ...transitionActions, ...instantActions];
+    const readActions = baseActions.filter((action) => {
+      if (action.id === 'nav-flight') return hasPermission(PERMISSIONS.flight.read);
+      if (action.id === 'nav-instants') return hasPermission(PERMISSIONS.instant.read);
+      if (action.id === 'nav-songs') return hasPermission(PERMISSIONS.song.read);
+      if (action.id === 'nav-media') return hasPermission(PERMISSIONS.media.read);
+      if (action.id === 'nav-scenes') return hasPermission(PERMISSIONS.scene.read);
+      if (action.id === 'nav-layouts' || action.id === 'nav-preview') return hasPermission(PERMISSIONS.layout.read);
+      if (action.id === 'take-selected-program-song-off-air') return hasPermission(PERMISSIONS.program.operate);
+      if (action.id === 'stop-all-instants') return hasPermission(PERMISSIONS.instant.operate);
+      if (action.id === 'open-broadcast-time-override' || action.id === 'disable-broadcast-time-override') return hasPermission(PERMISSIONS.program.operate);
+      return hasPermission(PERMISSIONS.program.read);
+    });
+    return [
+      ...readActions,
+      ...selectProgramActions,
+      ...(hasPermission(PERMISSIONS.program.operate) ? sceneTakeActions : []),
+      ...(hasPermission(PERMISSIONS.program.operate) ? transitionActions : []),
+      ...(hasPermission(PERMISSIONS.instant.operate) ? instantActions : [])
+    ];
   }, [
     knownInstants,
     knownScenes,
     broadcastSettings,
     clearBroadcastTimeOverride,
+    hasPermission,
     loadBroadcastSettings,
     navigate,
     programOptions,
@@ -654,7 +676,7 @@ export default function Layout() {
               <>
                 {renderHeaderProgramSelector()}
                 {renderOpenProgramButton()}
-                {renderRefreshProgramButton()}
+                {hasPermission(PERMISSIONS.program.operate) ? renderRefreshProgramButton() : null}
                 {renderLogoutButton()}
               </>
             }
@@ -662,7 +684,7 @@ export default function Layout() {
               <>
                 {renderHeaderProgramSelector()}
                 {renderOpenProgramButton()}
-                {renderRefreshProgramButton()}
+                {hasPermission(PERMISSIONS.program.operate) ? renderRefreshProgramButton() : null}
                 {renderLogoutButton()}
               </>
             }

--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -1,70 +1,40 @@
-import { Button, Card, IconBadge, LoadingSpinner } from '@gaulatti/bleecker';
-import { LogIn } from 'lucide-react';
-import { useState } from 'react';
-import { Navigate } from 'react-router';
+import { LoadingSpinner } from '@gaulatti/bleecker';
 import { signInWithRedirect } from 'aws-amplify/auth';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
 import { useAuthStatus } from '../hooks/useAuth';
+import {
+  cancelLoginRedirect,
+  prepareLoginRedirect,
+  returnPathFromSearch,
+  takeLoginReturnPath
+} from '../services/login-return';
 
 export default function Login() {
-  const [isSigningIn, setIsSigningIn] = useState(false);
   const { isAuthenticated, isLoaded } = useAuthStatus();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [failed, setFailed] = useState(false);
 
-  if (!isLoaded) {
-    return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <LoadingSpinner size='lg' />
-      </div>
-    );
-  }
-
-  if (isAuthenticated) {
-    return <Navigate to='/' replace />;
-  }
-
-  const handleGoogleSignIn = async () => {
-    if (isSigningIn) {
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (isAuthenticated) {
+      navigate(takeLoginReturnPath() ?? returnPathFromSearch(location.search), { replace: true });
       return;
     }
-
-    setIsSigningIn(true);
-    try {
-      await signInWithRedirect({ provider: 'Google' });
-    } catch (e) {
-      console.error('Error signing in', e);
-      setIsSigningIn(false);
-    }
-  };
+    if (!prepareLoginRedirect(location.search)) return;
+    void signInWithRedirect({ provider: 'Google' }).catch(() => {
+      cancelLoginRedirect();
+      setFailed(true);
+    });
+  }, [isAuthenticated, isLoaded, location.search, navigate]);
 
   return (
-    <div className='flex min-h-screen items-center justify-center bg-light-sand px-4 dark:bg-deep-sea'>
-      <Card className='w-full max-w-md space-y-8 p-8'>
-        <div className='text-center'>
-          <IconBadge size='lg' className='mx-auto mb-4 rounded-full bg-sea text-white dark:bg-accent-blue dark:text-white'>
-            <LogIn className='h-8 w-8' />
-          </IconBadge>
-          <h1 className='mb-2 text-3xl font-bold text-text-primary dark:text-text-primary'>Welcome Back</h1>
-          <p className='text-text-secondary dark:text-text-secondary'>Sign in to access the admin panel</p>
-        </div>
-
-        <Button onClick={handleGoogleSignIn} size='lg' className='w-full justify-center' disabled={isSigningIn}>
-          {isSigningIn ? (
-            <>
-              <LoadingSpinner size='sm' />
-              Redirecting...
-            </>
-          ) : (
-            <>
-              <svg className='h-5 w-5' viewBox='0 0 24 24' aria-hidden='true'>
-                <path
-                  fill='currentColor'
-                  d='M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.107-1.453-.267-2.133H12.48z'
-                />
-              </svg>
-              Sign in with Google
-            </>
-          )}
-        </Button>
-      </Card>
-    </div>
+    <main className='flex min-h-screen items-center justify-center bg-deep-sea p-6 text-white'>
+      <div className='text-center'>
+        <LoadingSpinner size='lg' />
+        <p className='mt-4'>{failed ? 'Sign-in could not start. Refresh to retry.' : 'Continuing through Alcantara secure sign-in…'}</p>
+      </div>
+    </main>
   );
 }

--- a/frontend/app/routes/protected.tsx
+++ b/frontend/app/routes/protected.tsx
@@ -1,10 +1,16 @@
 import { Outlet } from 'react-router';
 import ProtectedRoute from '../components/common/ProtectedRoute';
+import PermissionBoundary from '../components/common/PermissionBoundary';
+import { FeaturesProvider } from '../hooks/useFeatures';
 
 export default function ProtectedLayout() {
   return (
     <ProtectedRoute>
-      <Outlet />
+      <FeaturesProvider>
+        <PermissionBoundary>
+          <Outlet />
+        </PermissionBoundary>
+      </FeaturesProvider>
     </ProtectedRoute>
   );
 }

--- a/frontend/app/services/api.ts
+++ b/frontend/app/services/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosError } from 'axios';
-import { fetchAuthSession } from 'aws-amplify/auth';
+import { getSession } from './session';
 import { apiUrl, getApiBaseUrl } from '../utils/apiBaseUrl';
 
 export const api = axios.create({
@@ -12,8 +12,7 @@ export const api = axios.create({
 api.interceptors.request.use(
   async (config) => {
     try {
-      const session = await fetchAuthSession();
-      const token = session.tokens?.idToken?.toString();
+      const { token } = await getSession();
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;
       }
@@ -29,8 +28,7 @@ export const authFetch = async (input: string, init?: RequestInit): Promise<Resp
   const headers = new Headers(init?.headers);
 
   try {
-    const session = await fetchAuthSession();
-    const token = session.tokens?.idToken?.toString();
+    const { token } = await getSession();
     if (token) {
       headers.set('Authorization', `Bearer ${token}`);
     }
@@ -54,6 +52,9 @@ export const handleApiError = (error: unknown): string => {
     }
     if (error.response?.status === 403) {
       return 'Access denied';
+    }
+    if (error.response?.status === 503) {
+      return 'Authorization service unavailable. Please retry.';
     }
     if (error.response?.status === 500) {
       return 'Server error. Please try again later.';

--- a/frontend/app/services/authenticatedFetch.ts
+++ b/frontend/app/services/authenticatedFetch.ts
@@ -1,0 +1,39 @@
+import { getApiBaseUrl } from '../utils/apiBaseUrl';
+import { getSession } from './session';
+
+function isAlcantaraApiRequest(input: RequestInfo | URL): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const raw = input instanceof Request ? input.url : input.toString();
+    const requestUrl = new URL(raw, window.location.origin);
+    const apiUrl = new URL(getApiBaseUrl(), window.location.origin);
+    if (requestUrl.origin !== apiUrl.origin) return false;
+    const prefix = apiUrl.pathname.replace(/\/$/, '');
+    return !prefix || prefix === '/' || requestUrl.pathname.startsWith(prefix);
+  } catch {
+    return false;
+  }
+}
+
+export function installAuthenticatedFetch(): void {
+  if (typeof window === 'undefined') return;
+  const marker = '__alcantaraAuthenticatedFetchInstalled';
+  const markedWindow = window as typeof window & Record<string, unknown>;
+  if (markedWindow[marker]) return;
+  markedWindow[marker] = true;
+
+  const nativeFetch = window.fetch.bind(window);
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (!isAlcantaraApiRequest(input)) return nativeFetch(input, init);
+    const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+    if (!headers.has('Authorization')) {
+      try {
+        const { token } = await getSession();
+        if (token) headers.set('Authorization', `Bearer ${token}`);
+      } catch {
+        // Public runtime endpoints intentionally continue without a session.
+      }
+    }
+    return nativeFetch(input, { ...init, headers });
+  };
+}

--- a/frontend/app/services/login-return.test.ts
+++ b/frontend/app/services/login-return.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { loginPathForLocation } from './login-return';
+
+test('builds a same-app login redirect that preserves the complete return location', () => {
+  assert.equal(
+    loginPathForLocation('/program/42', '?panel=scenes', '#mixer'),
+    '/login?returnTo=%2Fprogram%2F42%3Fpanel%3Dscenes%23mixer',
+  );
+});
+
+test('builds the root login redirect without browser side effects', () => {
+  assert.equal(loginPathForLocation('/', '', ''), '/login?returnTo=%2F');
+});

--- a/frontend/app/services/login-return.ts
+++ b/frontend/app/services/login-return.ts
@@ -1,0 +1,35 @@
+const RETURN_TO_KEY = 'alcantara:login:return-to';
+const REDIRECT_STARTED_KEY = 'alcantara:login:redirect-started';
+
+export function safeReturnPath(value: string | null): string {
+  if (!value) return '/';
+  try {
+    const target = new URL(value, window.location.origin);
+    if (target.origin !== window.location.origin) return '/';
+    return `${target.pathname}${target.search}${target.hash}`;
+  } catch {
+    return '/';
+  }
+}
+
+export function returnPathFromSearch(search: string): string {
+  return safeReturnPath(new URLSearchParams(search).get('returnTo'));
+}
+
+export function prepareLoginRedirect(search: string): boolean {
+  sessionStorage.setItem(RETURN_TO_KEY, returnPathFromSearch(search));
+  if (sessionStorage.getItem(REDIRECT_STARTED_KEY) === '1') return false;
+  sessionStorage.setItem(REDIRECT_STARTED_KEY, '1');
+  return true;
+}
+
+export function cancelLoginRedirect(): void {
+  sessionStorage.removeItem(REDIRECT_STARTED_KEY);
+}
+
+export function takeLoginReturnPath(): string | null {
+  const value = sessionStorage.getItem(RETURN_TO_KEY);
+  sessionStorage.removeItem(RETURN_TO_KEY);
+  sessionStorage.removeItem(REDIRECT_STARTED_KEY);
+  return value ? safeReturnPath(value) : null;
+}

--- a/frontend/app/services/login-return.ts
+++ b/frontend/app/services/login-return.ts
@@ -1,6 +1,11 @@
 const RETURN_TO_KEY = 'alcantara:login:return-to';
 const REDIRECT_STARTED_KEY = 'alcantara:login:redirect-started';
 
+export function loginPathForLocation(pathname: string, search: string, hash: string): string {
+  const returnTo = `${pathname}${search}${hash}`;
+  return `/login?returnTo=${encodeURIComponent(returnTo)}`;
+}
+
 export function safeReturnPath(value: string | null): string {
   if (!value) return '/';
   try {

--- a/frontend/app/services/session.ts
+++ b/frontend/app/services/session.ts
@@ -1,0 +1,20 @@
+import { fetchAuthSession, signOut } from 'aws-amplify/auth';
+
+export type Session = {
+  userSub?: string;
+  token?: string;
+  payload?: Record<string, unknown>;
+};
+
+export async function getSession(): Promise<Session> {
+  const session = await fetchAuthSession();
+  return {
+    userSub: session.userSub,
+    token: session.tokens?.idToken?.toString(),
+    payload: session.tokens?.idToken?.payload
+  };
+}
+
+export async function clearSession(): Promise<void> {
+  await signOut();
+}


### PR DESCRIPTION
## Summary
- keep sign-in inside Alcantara using its Cognito Hosted UI configuration
- preserve only safe same-origin return paths across OAuth redirects
- centralize Cognito ID-token attachment for Axios and Alcantara API fetch calls without altering third-party requests
- load effective Pompeii permissions and roles from the protected auth context
- gate protected routes, navigation, command actions, and operator header actions; distinguish unauthenticated, denied, and unavailable states
- support wildcard-administrator permissions while retaining backend enforcement as authoritative

## Stack
This PR is intentionally based on G-116 / PR #4 so its diff contains only the frontend child ticket.

## Validation
- frontend production build passed
- frontend typecheck remains blocked by the existing repository baseline (18 errors); the new auth modules build successfully and do not add a build failure

## UAT
- exercise the configured Alcantara Cognito Hosted UI login and logout flow
- verify a safe deep-link return survives login and an external return URL resolves to the app root
- verify viewer/operator/admin assignments expose only their allowed routes and command actions
- verify 401 redirects to login, 403 shows Access denied, and Pompeii outage shows the retryable unavailable state

Closes G-115
## Summary by Sourcery

Adopt the Alcantara Cognito session flow and enforce frontend authorization based on protected Pompeii permissions.

New Features:
- Adopt Alcantara-hosted Cognito sign-in and logout with safe same-origin deep-link restoration.
- Add permission-based authorization for routes, navigation, command actions, and operator controls, including wildcard administrator access.
- Load authorization roles and permissions from the protected Pompeii auth context and distinguish denied, unauthenticated, and unavailable states.

Bug Fixes:
- Prevent external OAuth return URLs from redirecting outside the application.
- Ensure authentication tokens are attached only to Alcantara API requests while preserving third-party fetch behavior.

Enhancements:
- Centralize session access and authentication-token handling across Axios and fetch requests.
- Add retry handling and user-facing messaging for unavailable authorization services.

Tests:
- Add coverage for safe login return-path construction and preservation.