### PR TITLE
feat(control): finish broadcast switcher workflow (G-86)

### DIFF
--- a/backend/prisma/local-migrations/0002_program_preview_and_fade_to_black/migration.sql
+++ b/backend/prisma/local-migrations/0002_program_preview_and_fade_to_black/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "ProgramState"
+ADD COLUMN "stagedSceneId" INTEGER,
+ADD COLUMN "fadeToBlack" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/migrations/20260820000100_program_preview_and_fade_to_black/migration.sql
+++ b/backend/prisma/migrations/20260820000100_program_preview_and_fade_to_black/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "ProgramState"
+ADD COLUMN "stagedSceneId" INTEGER,
+ADD COLUMN "fadeToBlack" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -38,6 +38,8 @@ model ProgramState {
   type                   String               @default("tv")
   activeSceneId          Int?
   activeScene            Scene?               @relation(fields: [activeSceneId], references: [id])
+  stagedSceneId          Int?
+  fadeToBlack            Boolean              @default(false)
   songSequence           Json?
   shuffleOrder           Json?
   engineState            Json?

--- a/backend/src/program/program.controller.ts
+++ b/backend/src/program/program.controller.ts
@@ -306,6 +306,15 @@ export class ProgramController {
     return this.programService.stageScene(nextSceneId, programId);
   }
 
+  @Put(':programId/fade-to-black')
+  @RequirePermission(ALCANTARA_PERMISSIONS.program.operate)
+  async setFadeToBlackById(
+    @Param('programId') programId: string,
+    @Body() data: { active?: boolean },
+  ) {
+    return this.programService.setFadeToBlack(data?.active === true, programId);
+  }
+
   @Post(':programId/off-air')
   @RequirePermission(ALCANTARA_PERMISSIONS.program.operate)
   async takeProgramOffAirById(@Param('programId') programId: string) {

--- a/backend/src/program/program.service.spec.ts
+++ b/backend/src/program/program.service.spec.ts
@@ -1,0 +1,115 @@
+import { ProgramService } from './program.service';
+
+describe('ProgramService switcher state', () => {
+  const scene = {
+    id: 7,
+    name: 'Camera one',
+    layoutId: 2,
+    layout: {
+      id: 2,
+      name: 'Camera',
+      componentType: 'video-stream',
+      settings: '{}',
+    },
+    chyronText: null,
+    metadata: null,
+  };
+
+  const buildService = (programState: Record<string, unknown>) => {
+    let currentState = programState;
+    const prisma = {
+      programState: {
+        findUnique: jest
+          .fn()
+          .mockImplementation(() => Promise.resolve(currentState)),
+        update: jest
+          .fn()
+          .mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+            currentState = { ...currentState, ...data };
+            return Promise.resolve(currentState);
+          }),
+      },
+    };
+    const service = new ProgramService(
+      prisma as never,
+      {} as never,
+      {} as never,
+    );
+    return { service, prisma };
+  };
+
+  it('persists the selected Preview scene before broadcasting it', async () => {
+    const programState = {
+      id: 1,
+      programId: 'main',
+      activeSceneId: null,
+      stagedSceneId: null,
+      fadeToBlack: false,
+      scenes: [{ sceneId: scene.id, scene }],
+    };
+    const { service, prisma } = buildService(programState);
+
+    const result = await service.stageScene(scene.id, 'main');
+
+    expect(prisma.programState.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { stagedSceneId: scene.id },
+    });
+    expect(result).toMatchObject({
+      stagedSceneId: scene.id,
+      stagedScene: scene,
+    });
+  });
+
+  it('persists fade-to-black without clearing Program or Preview', async () => {
+    const programState = {
+      id: 1,
+      programId: 'main',
+      activeSceneId: scene.id,
+      stagedSceneId: scene.id,
+      fadeToBlack: false,
+      activeScene: scene,
+      scenes: [{ sceneId: scene.id, scene }],
+    };
+    const { service, prisma } = buildService(programState);
+
+    const result = await service.setFadeToBlack(true, 'main');
+
+    expect(prisma.programState.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 1 },
+        data: { fadeToBlack: true },
+      }),
+    );
+    expect(result).toMatchObject({
+      activeSceneId: scene.id,
+      stagedSceneId: scene.id,
+      fadeToBlack: true,
+    });
+  });
+
+  it('treats off-air as an explicit Program and FTB clear while preserving Preview', async () => {
+    const programState = {
+      id: 1,
+      programId: 'main',
+      activeSceneId: scene.id,
+      stagedSceneId: scene.id,
+      fadeToBlack: true,
+      activeScene: scene,
+      scenes: [{ sceneId: scene.id, scene }],
+    };
+    const { service, prisma } = buildService(programState);
+
+    const result = await service.takeProgramOffAir('main');
+
+    expect(prisma.programState.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { activeSceneId: null, fadeToBlack: false },
+    });
+    expect(result).toMatchObject({
+      activeSceneId: null,
+      stagedSceneId: scene.id,
+      fadeToBlack: false,
+    });
+  });
+});

--- a/backend/src/program/program.service.ts
+++ b/backend/src/program/program.service.ts
@@ -97,7 +97,6 @@ export class ProgramService implements OnModuleInit {
     flight: new Map<string, number>(),
   };
   private globalBroadcastVersion = 0;
-  private stagedSceneByProgramId = new Map<string, number | null>();
   private programAudioMeterByProgramId = new Map<
     string,
     ProgramAudioMeterLevels
@@ -156,9 +155,6 @@ export class ProgramService implements OnModuleInit {
         audioMixer: this.createDefaultProgramAudioMixerSettings() as any,
       },
     });
-    if (!this.stagedSceneByProgramId.has(ProgramService.DEFAULT_PROGRAM_ID)) {
-      this.stagedSceneByProgramId.set(ProgramService.DEFAULT_PROGRAM_ID, null);
-    }
   }
 
   private createDefaultBroadcastMixerChannels(): BroadcastMixerChannel[] {
@@ -1155,17 +1151,17 @@ export class ProgramService implements OnModuleInit {
       throw new Error('Program not found');
     }
 
-    return this.withStagedSceneState(normalizedProgramId, state);
+    return this.withStagedSceneState(state);
   }
 
   private withStagedSceneState<T extends { scenes?: unknown }>(
-    programId: string,
     state: T,
   ): T & { stagedSceneId: number | null; stagedScene: any | null } {
-    const normalizedProgramId = this.normalizeProgramId(programId);
     const sceneEntries = Array.isArray(state.scenes) ? state.scenes : [];
     const currentStagedSceneId =
-      this.stagedSceneByProgramId.get(normalizedProgramId);
+      'stagedSceneId' in state
+        ? (state as { stagedSceneId?: unknown }).stagedSceneId
+        : null;
     const stagedSceneId =
       typeof currentStagedSceneId === 'number' ? currentStagedSceneId : null;
     const stagedSceneEntry =
@@ -1180,7 +1176,6 @@ export class ProgramService implements OnModuleInit {
           });
 
     if (stagedSceneId !== null && !stagedSceneEntry) {
-      this.stagedSceneByProgramId.set(normalizedProgramId, null);
       return {
         ...(state as any),
         stagedSceneId: null,
@@ -1223,8 +1218,6 @@ export class ProgramService implements OnModuleInit {
         audioMixer: this.createDefaultProgramAudioMixerSettings() as any,
       },
     });
-    this.stagedSceneByProgramId.set(normalized, null);
-
     return this.getProgramStateWithScenes(normalized);
   }
 
@@ -1303,14 +1296,6 @@ export class ProgramService implements OnModuleInit {
       });
       this.programSceneInstantPlaybackByProgramId.delete(current);
     }
-    if (this.stagedSceneByProgramId.has(current)) {
-      this.stagedSceneByProgramId.set(
-        next,
-        this.stagedSceneByProgramId.get(current) ?? null,
-      );
-      this.stagedSceneByProgramId.delete(current);
-    }
-
     return this.getProgramStateWithScenes(next);
   }
 
@@ -1337,8 +1322,6 @@ export class ProgramService implements OnModuleInit {
     this.programAudioMeterByProgramId.delete(normalized);
     this.programSongPlaybackByProgramId.delete(normalized);
     this.programSceneInstantPlaybackByProgramId.delete(normalized);
-    this.stagedSceneByProgramId.delete(normalized);
-
     return { deletedProgramId: normalized };
   }
 
@@ -1382,7 +1365,7 @@ export class ProgramService implements OnModuleInit {
       },
     });
     return states.map((state) =>
-      this.withStagedSceneState(state.programId, state),
+      this.withStagedSceneState(state),
     );
   }
 
@@ -2104,7 +2087,7 @@ export class ProgramService implements OnModuleInit {
     const normalizedProgramId = this.normalizeProgramId(programId);
     const state = await this.prisma.programState.findUnique({
       where: { programId: normalizedProgramId },
-      select: { id: true, activeSceneId: true },
+      select: { id: true, activeSceneId: true, stagedSceneId: true },
     });
 
     if (!state) {
@@ -2118,12 +2101,6 @@ export class ProgramService implements OnModuleInit {
       },
     });
 
-    if (
-      (this.stagedSceneByProgramId.get(normalizedProgramId) ?? null) === sceneId
-    ) {
-      this.stagedSceneByProgramId.set(normalizedProgramId, null);
-    }
-
     const sceneInstantPlayback =
       this.programSceneInstantPlaybackByProgramId.get(normalizedProgramId);
     if (
@@ -2133,10 +2110,13 @@ export class ProgramService implements OnModuleInit {
       await this.stopProgramSceneInstant(normalizedProgramId);
     }
 
-    if (state.activeSceneId === sceneId) {
+    if (state.activeSceneId === sceneId || state.stagedSceneId === sceneId) {
       await this.prisma.programState.update({
         where: { id: state.id },
-        data: { activeSceneId: null },
+        data: {
+          ...(state.activeSceneId === sceneId ? { activeSceneId: null } : {}),
+          ...(state.stagedSceneId === sceneId ? { stagedSceneId: null } : {}),
+        },
       });
     }
 
@@ -2452,7 +2432,10 @@ export class ProgramService implements OnModuleInit {
       stagedScene = assignedSceneEntry.scene;
     }
 
-    this.stagedSceneByProgramId.set(normalizedProgramId, nextStagedSceneId);
+    await this.prisma.programState.update({
+      where: { id: state.id },
+      data: { stagedSceneId: nextStagedSceneId },
+    });
 
     const payload = {
       type: 'scene_staged',
@@ -2495,30 +2478,17 @@ export class ProgramService implements OnModuleInit {
       throw new Error('Scene is not assigned to this program');
     }
 
-    const updatedState = await this.prisma.programState.update({
+    await this.prisma.programState.update({
       where: { id: state.id },
-      data: { activeSceneId: sceneId },
-      include: {
-        activeScene: {
-          include: { layout: true },
-        },
-        scenes: {
-          orderBy: { position: 'asc' },
-          include: {
-            scene: {
-              include: { layout: true },
-            },
-          },
-        },
-      },
+      data: { activeSceneId: sceneId, stagedSceneId: sceneId },
     });
+    const updatedState =
+      await this.getProgramStateWithScenes(normalizedProgramId);
 
     const normalizedTransitionId =
       typeof transitionId === 'string' && transitionId.trim()
         ? transitionId.trim()
         : null;
-    this.stagedSceneByProgramId.set(normalizedProgramId, sceneId);
-
     const sceneInstantId = updatedState.activeScene?.metadata
       ? this.parseSceneInstantIdFromSceneMetadata(
           updatedState.activeScene.metadata,
@@ -2571,6 +2541,45 @@ export class ProgramService implements OnModuleInit {
     };
   }
 
+  async setFadeToBlack(
+    active: boolean,
+    programId: string = ProgramService.DEFAULT_PROGRAM_ID,
+  ) {
+    const normalizedProgramId = this.normalizeProgramId(programId);
+    const existing = await this.prisma.programState.findUnique({
+      where: { programId: normalizedProgramId },
+      select: { id: true, fadeToBlack: true },
+    });
+    if (!existing) {
+      throw new Error('Program not found');
+    }
+
+    if (existing.fadeToBlack !== active) {
+      await this.prisma.programState.update({
+        where: { id: existing.id },
+        data: { fadeToBlack: active },
+      });
+    }
+    const state =
+      await this.getProgramStateWithScenes(normalizedProgramId);
+
+    const broadcastPayload = this.broadcastUpdate(normalizedProgramId, {
+      type: 'fade_to_black',
+      programId: normalizedProgramId,
+      active,
+      state: this.withStagedSceneState(state),
+      updatedAt: new Date().toISOString(),
+    });
+
+    return {
+      ...this.withStagedSceneState(state),
+      version:
+        broadcastPayload && typeof broadcastPayload.version === 'number'
+          ? broadcastPayload.version
+          : this.getProgramTopicVersion(normalizedProgramId, 'state'),
+    };
+  }
+
   async takeProgramOffAir(
     programId: string = ProgramService.DEFAULT_PROGRAM_ID,
   ) {
@@ -2583,7 +2592,7 @@ export class ProgramService implements OnModuleInit {
       throw new Error('Program not found');
     }
 
-    if (!state.activeSceneId) {
+    if (!state.activeSceneId && !state.fadeToBlack) {
       const currentState =
         await this.getProgramStateWithScenes(normalizedProgramId);
       return {
@@ -2592,23 +2601,12 @@ export class ProgramService implements OnModuleInit {
       };
     }
 
-    const updatedState = await this.prisma.programState.update({
+    await this.prisma.programState.update({
       where: { id: state.id },
-      data: { activeSceneId: null },
-      include: {
-        activeScene: {
-          include: { layout: true },
-        },
-        scenes: {
-          orderBy: { position: 'asc' },
-          include: {
-            scene: {
-              include: { layout: true },
-            },
-          },
-        },
-      },
+      data: { activeSceneId: null, fadeToBlack: false },
     });
+    const updatedState =
+      await this.getProgramStateWithScenes(normalizedProgramId);
 
     const sceneInstantPlayback =
       this.programSceneInstantPlaybackByProgramId.get(normalizedProgramId);

--- a/frontend/app/components/BroadcastSwitcherDeck.tsx
+++ b/frontend/app/components/BroadcastSwitcherDeck.tsx
@@ -1,0 +1,399 @@
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  Expand,
+  Keyboard,
+  MonitorPlay,
+  PanelRight,
+  Smartphone,
+  Wifi,
+  WifiOff,
+} from "lucide-react";
+import type { Scene } from "../models/broadcast";
+import { SCENE_TRANSITIONS } from "../utils/sceneTransitions";
+
+export type ConsoleWorkspace = "director" | "audio" | "graphics" | "compact";
+
+const WORKSPACES: Array<{ id: ConsoleWorkspace; label: string }> = [
+  { id: "director", label: "Director" },
+  { id: "audio", label: "Audio" },
+  { id: "graphics", label: "Graphics" },
+  { id: "compact", label: "Compact / touch" },
+];
+
+const WORKSPACE_KEY = "alcantara.console.workspace";
+const DOCK_WIDTH_KEY = "alcantara.console.dockWidth";
+const TOUCH_KEY = "alcantara.console.touchMode";
+const SHORTCUTS_KEY = "alcantara.console.shortcutsEnabled";
+
+export function readStoredConsoleWorkspace(): ConsoleWorkspace {
+  if (typeof window === "undefined") return "director";
+  const value = window.localStorage.getItem(WORKSPACE_KEY);
+  return WORKSPACES.some((workspace) => workspace.id === value)
+    ? (value as ConsoleWorkspace)
+    : "director";
+}
+
+function blocksBroadcastShortcut(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return Boolean(
+    target.closest(
+      'input, textarea, select, button, a, [contenteditable="true"], [role="button"], [role="slider"], [role="dialog"]',
+    ),
+  );
+}
+
+function ConfidenceMonitor({
+  label,
+  tone,
+  scene,
+  src,
+}: {
+  label: string;
+  tone: "preview" | "program";
+  scene: Scene | null;
+  src: string;
+}) {
+  const monitorRef = useRef<HTMLDivElement | null>(null);
+  const [scale, setScale] = useState(0);
+
+  useEffect(() => {
+    const monitor = monitorRef.current;
+    if (!monitor) return;
+    const update = () => {
+      const bounds = monitor.getBoundingClientRect();
+      setScale(Math.min(bounds.width / 1920, bounds.height / 1080));
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(monitor);
+    return () => observer.disconnect();
+  }, []);
+
+  const preview = tone === "preview";
+  return (
+    <section
+      className={`min-w-0 overflow-hidden border bg-black ${preview ? "border-amber-400/80" : "border-red-500/90"}`}
+    >
+      <header
+        className={`flex h-8 items-center justify-between px-3 ${preview ? "bg-amber-400 text-zinc-950" : "bg-red-600 text-white"}`}
+      >
+        <span className="text-xs font-black tracking-[0.18em]">{label}</span>
+        <span className="max-w-[70%] truncate text-xs font-semibold">
+          {scene?.name || (preview ? "Preview is clear" : "Program is clear")}
+        </span>
+      </header>
+      <div
+        ref={monitorRef}
+        className="relative aspect-video overflow-hidden bg-[radial-gradient(circle_at_center,#202631_0%,#08090b_72%)]"
+      >
+        {scene ? (
+          <iframe
+            title={`${label} confidence monitor`}
+            src={src}
+            tabIndex={-1}
+            aria-hidden="true"
+            className="pointer-events-none absolute left-0 top-0 border-0"
+            style={{
+              width: 1920,
+              height: 1080,
+              transform: `scale(${scale})`,
+              transformOrigin: "top left",
+              visibility: scale > 0 ? "visible" : "hidden",
+            }}
+          />
+        ) : (
+          <div className="absolute inset-0 flex flex-col items-center justify-center text-zinc-600">
+            <MonitorPlay size={30} strokeWidth={1.4} />
+            <span className="mt-2 text-xs font-semibold uppercase tracking-widest">
+              No scene selected
+            </span>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+interface Props {
+  programId: string;
+  activeScene: Scene | null;
+  stagedScene: Scene | null;
+  scenes: Scene[];
+  transitionId: string;
+  realtimeConnected: boolean;
+  fadeToBlack: boolean;
+  workspace: ConsoleWorkspace;
+  onWorkspaceChange: (workspace: ConsoleWorkspace) => void;
+  onTransitionChange: (transitionId: string) => void;
+  onStageScene: (sceneId: number | null) => Promise<void> | void;
+  onTake: () => void;
+  onCut: () => void;
+  onFadeToBlack: () => void;
+}
+
+export function BroadcastSwitcherDeck(props: Props) {
+  const latestPropsRef = useRef(props);
+  latestPropsRef.current = props;
+  const [touchMode, setTouchMode] = useState(false);
+  const [shortcutsEnabled, setShortcutsEnabled] = useState(true);
+  const [dockWidth, setDockWidth] = useState(320);
+  const pendingStageRef = useRef<Promise<void>>(Promise.resolve());
+
+  const stageScene = (sceneId: number | null) => {
+    const pending = Promise.resolve(props.onStageScene(sceneId));
+    pendingStageRef.current = pending;
+    return pending;
+  };
+  const takeStagedScene = async () => {
+    await pendingStageRef.current;
+    await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    latestPropsRef.current.onTake();
+  };
+  const cutStagedScene = async () => {
+    await pendingStageRef.current;
+    await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    latestPropsRef.current.onCut();
+  };
+
+  useEffect(() => {
+    try {
+      setTouchMode(
+        window.localStorage.getItem(TOUCH_KEY) === "true" ||
+          new URLSearchParams(window.location.search).get("surface") ===
+            "touch",
+      );
+      setShortcutsEnabled(
+        window.localStorage.getItem(SHORTCUTS_KEY) !== "false",
+      );
+      const width = Number(window.localStorage.getItem(DOCK_WIDTH_KEY));
+      setDockWidth(
+        Number.isFinite(width) && width >= 260 && width <= 520 ? width : 320,
+      );
+    } catch {
+      setTouchMode(false);
+      setShortcutsEnabled(true);
+      setDockWidth(320);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!shortcutsEnabled) return;
+    const handleShortcut = (event: KeyboardEvent) => {
+      if (blocksBroadcastShortcut(event.target)) return;
+      if (event.altKey && event.key.toLowerCase() === "b") {
+        event.preventDefault();
+        props.onFadeToBlack();
+      } else if (
+        !event.altKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.shiftKey &&
+        event.code === "Space"
+      ) {
+        event.preventDefault();
+        void takeStagedScene();
+      } else if (
+        !event.altKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.shiftKey &&
+        event.key.toLowerCase() === "c"
+      ) {
+        event.preventDefault();
+        void cutStagedScene();
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        void stageScene(null);
+      }
+    };
+    window.addEventListener("keydown", handleShortcut);
+    return () => window.removeEventListener("keydown", handleShortcut);
+  }, [
+    props.onCut,
+    props.onFadeToBlack,
+    props.onStageScene,
+    props.onTake,
+    shortcutsEnabled,
+  ]);
+
+  const selectWorkspace = (workspace: ConsoleWorkspace) => {
+    window.localStorage.setItem(WORKSPACE_KEY, workspace);
+    props.onWorkspaceChange(workspace);
+  };
+  const toggleTouch = () => {
+    const next = !touchMode;
+    setTouchMode(next);
+    window.localStorage.setItem(TOUCH_KEY, String(next));
+  };
+  const toggleShortcuts = () => {
+    const next = !shortcutsEnabled;
+    setShortcutsEnabled(next);
+    window.localStorage.setItem(SHORTCUTS_KEY, String(next));
+  };
+
+  return (
+    <section
+      className={`border-b border-zinc-700 bg-zinc-950 text-zinc-100 ${touchMode ? "text-base" : "text-sm"}`}
+      data-console-workspace={props.workspace}
+      data-touch-mode={touchMode}
+    >
+      <div className="flex min-h-12 flex-wrap items-center gap-2 border-b border-zinc-800 px-3 py-2">
+        <div className="mr-2 flex items-center gap-2 font-semibold">
+          {props.realtimeConnected ? (
+            <Wifi size={16} className="text-emerald-400" />
+          ) : (
+            <WifiOff size={16} className="text-amber-400" />
+          )}
+          <span>{props.programId}</span>
+        </div>
+        {WORKSPACES.map((workspace) => (
+          <button
+            key={workspace.id}
+            type="button"
+            onClick={() => selectWorkspace(workspace.id)}
+            className={`rounded px-3 py-2 font-semibold ${props.workspace === workspace.id ? "bg-sky-500 text-zinc-950" : "bg-zinc-800 text-zinc-300 hover:bg-zinc-700"}`}
+          >
+            {workspace.label}
+          </button>
+        ))}
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            aria-label="Toggle keyboard shortcuts"
+            aria-pressed={shortcutsEnabled}
+            onClick={toggleShortcuts}
+            title="Keyboard shortcuts: Space TAKE, C CUT, Escape clear Preview, Alt+B FTB"
+            className={`rounded p-2 ${shortcutsEnabled ? "bg-sky-900 text-sky-200" : "bg-zinc-800 text-zinc-500"}`}
+          >
+            <Keyboard size={17} />
+          </button>
+          <button
+            type="button"
+            aria-label="Toggle touch mode"
+            aria-pressed={touchMode}
+            onClick={toggleTouch}
+            className={`rounded p-2 ${touchMode ? "bg-sky-900 text-sky-200" : "bg-zinc-800 text-zinc-400"}`}
+          >
+            <Smartphone size={17} />
+          </button>
+          <button
+            type="button"
+            aria-label="Enter fullscreen"
+            onClick={() => void document.documentElement.requestFullscreen?.()}
+            className="rounded bg-zinc-800 p-2 text-zinc-400"
+          >
+            <Expand size={17} />
+          </button>
+        </div>
+      </div>
+
+      <div
+        className="grid gap-3 p-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_var(--dock-width)]"
+        style={{ "--dock-width": `${dockWidth}px` } as CSSProperties}
+      >
+        <ConfidenceMonitor
+          label="PREVIEW"
+          tone="preview"
+          scene={props.stagedScene}
+          src={`/program/${encodeURIComponent(props.programId)}?confidence=preview`}
+        />
+        <ConfidenceMonitor
+          label="PROGRAM"
+          tone="program"
+          scene={props.activeScene}
+          src={`/program/${encodeURIComponent(props.programId)}?confidence=program`}
+        />
+        <aside className="min-w-0 border border-zinc-700 bg-zinc-900 p-3">
+          <div className="mb-3 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-zinc-400">
+            <PanelRight size={15} />
+            Switcher
+          </div>
+          <label className="block text-xs text-zinc-400">
+            Transition
+            <select
+              value={props.transitionId}
+              onChange={(event) => props.onTransitionChange(event.target.value)}
+              className="mt-1 w-full rounded border border-zinc-600 bg-zinc-950 px-2 py-2 text-zinc-100"
+            >
+              {SCENE_TRANSITIONS.map((transition) => (
+                <option key={transition.id} value={transition.id}>
+                  {transition.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              disabled={!props.stagedScene}
+              onClick={() => void cutStagedScene()}
+              className="rounded bg-zinc-100 px-3 py-3 font-black text-zinc-950 disabled:opacity-40"
+            >
+              CUT <span className="text-xs font-normal">(C)</span>
+            </button>
+            <button
+              type="button"
+              disabled={!props.stagedScene}
+              onClick={() => void takeStagedScene()}
+              className="rounded bg-sky-500 px-3 py-3 font-black text-zinc-950 disabled:opacity-40"
+            >
+              TAKE <span className="text-xs font-normal">(Space)</span>
+            </button>
+          </div>
+          <button
+            type="button"
+            aria-pressed={props.fadeToBlack}
+            onClick={props.onFadeToBlack}
+            className={`mt-3 w-full rounded border px-3 py-3 font-black ${props.fadeToBlack ? "border-red-400 bg-red-600 text-white" : "border-zinc-600 bg-black text-zinc-200"}`}
+          >
+            {props.fadeToBlack ? "FTB ACTIVE" : "FADE TO BLACK"}{" "}
+            <span className="text-xs font-normal">(Alt+B)</span>
+          </button>
+          <label className="mt-4 block text-xs text-zinc-500">
+            Dock width
+            <input
+              type="range"
+              min={260}
+              max={520}
+              value={dockWidth}
+              onChange={(event) => {
+                const next = Number(event.target.value);
+                setDockWidth(next);
+                window.localStorage.setItem(DOCK_WIDTH_KEY, String(next));
+              }}
+              className="mt-1 w-full"
+            />
+          </label>
+        </aside>
+      </div>
+
+      <div className="border-t border-zinc-800 px-3 py-3">
+        <div
+          className={`grid gap-2 ${touchMode ? "grid-cols-2 sm:grid-cols-3 lg:grid-cols-5" : "grid-cols-3 sm:grid-cols-5 lg:grid-cols-8"}`}
+        >
+          {props.scenes.map((scene) => {
+            const isPreview = scene.id === props.stagedScene?.id;
+            const isProgram = scene.id === props.activeScene?.id;
+            return (
+              <button
+                key={scene.id}
+                type="button"
+                onClick={() => void stageScene(scene.id)}
+                className={`min-h-14 rounded border px-3 py-2 text-left ${isProgram ? "border-red-500 bg-red-950/70" : isPreview ? "border-amber-400 bg-amber-950/60" : "border-zinc-700 bg-zinc-900 hover:border-zinc-500"}`}
+              >
+                <span className="block truncate font-semibold">
+                  {scene.name}
+                </span>
+                <span
+                  className={`text-[10px] font-bold uppercase tracking-wider ${isProgram ? "text-red-400" : isPreview ? "text-amber-300" : "text-zinc-500"}`}
+                >
+                  {isProgram ? "PGM" : isPreview ? "PVW" : "Source"}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/components/ModoItalianoPodcastPlayer.tsx
+++ b/frontend/app/components/ModoItalianoPodcastPlayer.tsx
@@ -6,6 +6,7 @@ export interface ModoItalianoPodcastPlayerProps {
   episodeTitle?: string;
   showName?: string;
   audioUrl?: string;
+  masterGain?: number;
 }
 
 const ACCENT_COLOR = '#e91e8c';
@@ -26,7 +27,8 @@ export const ModoItalianoPodcastPlayer: React.FC<ModoItalianoPodcastPlayerProps>
   coverUrl = '',
   episodeTitle = '',
   showName = '',
-  audioUrl = ''
+  audioUrl = '',
+  masterGain = 1
 }) => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const bgCanvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -48,6 +50,12 @@ export const ModoItalianoPodcastPlayer: React.FC<ModoItalianoPodcastPlayerProps>
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const [autoplayBlocked, setAutoplayBlocked] = useState(false);
+
+  useEffect(() => {
+    if (!audioRef.current) return;
+    audioRef.current.volume = Math.max(0, Math.min(1, masterGain));
+    audioRef.current.muted = masterGain <= 0.0001;
+  }, [masterGain]);
 
   // ── Background canvas animation ──────────────────────────────────────────
   // Smooth animated mesh gradient: 4 color orbs drifting on slow sine paths,

--- a/frontend/app/components/PlaybackBar.tsx
+++ b/frontend/app/components/PlaybackBar.tsx
@@ -64,7 +64,6 @@ export function PlaybackBar({
   onTakeOffAir,
   onStopAllInstants,
   onStageScene,
-  onTakeScene,
 }: PlaybackBarProps) {
   const sequence = useMemo(() => {
     const n = normalizeProgramSongSequence(_sequence);
@@ -160,8 +159,7 @@ export function PlaybackBar({
               <Button
                 key={a.id}
                 onClick={() => onStageScene?.(a.id)}
-                onDoubleClick={() => onTakeScene?.(a.id)}
-                title={`${a.name} (click to stage, double-click to take)`}
+                title={`${a.name} (click to stage in Preview)`}
                 variant='ghost'
                 size='sm'
                 className={`relative min-w-[150px] max-w-[240px] shrink-0 overflow-hidden rounded border px-2 py-1.5 text-left text-[11px] font-medium leading-tight transition-colors ${a.isActive ? 'border-terracotta/80 bg-terracotta/35 text-white ring-1 ring-terracotta/50' : a.isStaged ? 'border-accent-blue/80 bg-accent-blue/35 text-white ring-1 ring-accent-blue/50' : 'border-sand/25 bg-dark-sand/80 text-text-primary hover:border-sea/40 hover:bg-sea/10'}`}

--- a/frontend/app/components/RelojDigitalLoopClock.tsx
+++ b/frontend/app/components/RelojDigitalLoopClock.tsx
@@ -13,6 +13,7 @@ interface RelojDigitalLoopClockProps {
   countdownTargetSceneId?: number | null;
   countdownTransitionId?: string | null;
   countdownCommand?: number;
+  allowProgramActivation?: boolean;
 }
 
 interface LoopTimezone {
@@ -76,7 +77,8 @@ export default function RelojDigitalLoopClock({
   countdownDuration = 300,
   countdownTargetSceneId,
   countdownTransitionId = 'cut',
-  countdownCommand
+  countdownCommand,
+  allowProgramActivation = true
 }: RelojDigitalLoopClockProps) {
   const defaultIndex = useMemo(() => {
     const idx = LOOP_TIMEZONES.findIndex((item) => item.timezone === timezone);
@@ -185,7 +187,7 @@ export default function RelojDigitalLoopClock({
 
       if (countdownRunning && remaining <= 0 && !countdownFiredRef.current) {
         countdownFiredRef.current = true;
-        if (programId && countdownTargetSceneId) {
+        if (allowProgramActivation && programId && countdownTargetSceneId) {
           activateScene(programId, countdownTargetSceneId, countdownTransitionId);
         }
         return;
@@ -202,7 +204,7 @@ export default function RelojDigitalLoopClock({
       cancelAnimationFrame(rafId);
       window.clearTimeout(animationId);
     };
-  }, [mode, countdownRunning, countdownDuration, countdownTargetSceneId, countdownTransitionId, programId]);
+  }, [allowProgramActivation, mode, countdownRunning, countdownDuration, countdownTargetSceneId, countdownTransitionId, programId]);
 
   useEffect(() => {
     if (mode !== 'clock') return;

--- a/frontend/app/components/StreamWall.tsx
+++ b/frontend/app/components/StreamWall.tsx
@@ -4,6 +4,7 @@ interface StreamWallProps {
   urls: string[];
   maxStreams?: number;
   title?: string;
+  suspended?: boolean;
 }
 
 function isValidHttpUrl(value: string): boolean {
@@ -15,7 +16,7 @@ function isValidHttpUrl(value: string): boolean {
   }
 }
 
-export function StreamWall({ urls, maxStreams = 4, title = 'Stream Wall' }: StreamWallProps) {
+export function StreamWall({ urls, maxStreams = 4, title = 'Stream Wall', suspended = false }: StreamWallProps) {
   const streams = useMemo(() => {
     const deduped = Array.from(new Set(urls.map((u) => u.trim()).filter(Boolean)));
     return deduped.filter(isValidHttpUrl).slice(0, maxStreams);
@@ -36,7 +37,9 @@ export function StreamWall({ urls, maxStreams = 4, title = 'Stream Wall' }: Stre
         ) : null}
 
         <main className='min-h-0 flex-1'>
-          {streams.length === 0 ? (
+          {suspended ? (
+            <div className='flex h-full items-center justify-center bg-black text-xs uppercase tracking-widest text-white/50'>Stream wall suspended</div>
+          ) : streams.length === 0 ? (
             <div className='flex h-full items-center justify-center px-6 text-center text-sm text-white/70'>
               No valid stream URLs provided. Use query params like <code className='rounded bg-white/10 px-1.5 py-0.5'>?url=https://vdo.ninja/?view=...</code>{' '}
               (repeat up to {maxStreams}).

--- a/frontend/app/models/broadcast.ts
+++ b/frontend/app/models/broadcast.ts
@@ -36,6 +36,7 @@ export interface ProgramState {
   activeScene?: Scene | null;
   stagedSceneId?: number | null;
   stagedScene?: Scene | null;
+  fadeToBlack: boolean;
   scenes: ProgramSceneEntry[];
   mediaGroups: ProgramMediaGroupEntry[];
 }

--- a/frontend/app/programs/fifthbell/FifthBellProgram.tsx
+++ b/frontend/app/programs/fifthbell/FifthBellProgram.tsx
@@ -58,6 +58,7 @@ interface FifthBellProgramProps {
   embedded?: boolean;
   sceneMetadata?: Record<string, unknown> | null;
   activeComponents?: string[];
+  masterGain?: number;
 }
 
 interface FifthBellConfig {
@@ -355,7 +356,7 @@ function normalizeLaunchDate(rawDate: string): Date {
   return parsed;
 }
 
-export default function FifthBellProgram({ programId = 'fifthbell', embedded = false, sceneMetadata, activeComponents }: FifthBellProgramProps) {
+export default function FifthBellProgram({ programId = 'fifthbell', embedded = false, sceneMetadata, activeComponents, masterGain = 1 }: FifthBellProgramProps) {
   const encodedProgramId = encodeURIComponent(programId);
   const [state, setState] = useState<ProgramState | null>(null);
   const [showLogoSlide, setShowLogoSlide] = useState(false);
@@ -604,6 +605,12 @@ export default function FifthBellProgram({ programId = 'fifthbell', embedded = f
     audioRef.current.load();
     audioInitialized.current = true;
   }, []);
+
+  useEffect(() => {
+    if (!audioRef.current) return;
+    audioRef.current.volume = Math.max(0, Math.min(1, masterGain));
+    audioRef.current.muted = masterGain <= 0.0001;
+  }, [masterGain]);
 
   useEffect(() => {
     if (!config.audioCueEnabled) {

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -16,6 +16,7 @@ export default [
       route('layouts', 'routes/layouts.tsx'),
       route('preview', 'routes/preview.tsx'),
       route('layout-demo', 'routes/layout-demo.tsx'),
+      route('console-fixture', 'routes/console-fixture.tsx'),
       route('flight', 'routes/flight.tsx')
     ]),
     route('overlay', 'routes/overlay.tsx')

--- a/frontend/app/routes/console-fixture.tsx
+++ b/frontend/app/routes/console-fixture.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { useSearchParams } from "react-router";
+import {
+  BroadcastSwitcherDeck,
+  type ConsoleWorkspace,
+} from "../components/BroadcastSwitcherDeck";
+import type { Scene } from "../models/broadcast";
+
+const layout = {
+  id: 1,
+  name: "Fixture layout",
+  componentType: "full-screen",
+  settings: "{}",
+};
+const previewScene: Scene = {
+  id: 1,
+  name: "Wide camera",
+  layoutId: 1,
+  layout,
+  chyronText: null,
+  metadata: '{"full-screen":{"text":"PREVIEW FIXTURE"}}',
+};
+const programScene: Scene = {
+  id: 2,
+  name: "Anchor desk",
+  layoutId: 1,
+  layout,
+  chyronText: null,
+  metadata: '{"full-screen":{"text":"PROGRAM FIXTURE"}}',
+};
+
+export default function ConsoleFixture() {
+  const [params] = useSearchParams();
+  const fixture = params.get("state") || "normal";
+  const [workspace, setWorkspace] = useState<ConsoleWorkspace>("director");
+  const [transition, setTransition] = useState("crescendo-prism");
+  const [staged, setStaged] = useState<Scene | null>(
+    fixture === "empty-preview"
+      ? null
+      : fixture === "on-air"
+        ? programScene
+        : previewScene,
+  );
+  const [ftb, setFtb] = useState(fixture === "ftb");
+
+  return (
+    <main className="min-h-screen bg-zinc-950" data-visual-fixture={fixture}>
+      <BroadcastSwitcherDeck
+        programId="fixture"
+        activeScene={programScene}
+        stagedScene={staged}
+        scenes={[previewScene, programScene]}
+        transitionId={transition}
+        realtimeConnected={fixture !== "disconnected"}
+        fadeToBlack={ftb}
+        workspace={workspace}
+        onWorkspaceChange={setWorkspace}
+        onTransitionChange={setTransition}
+        onStageScene={(sceneId) =>
+          setStaged(
+            sceneId === previewScene.id
+              ? previewScene
+              : sceneId === programScene.id
+                ? programScene
+                : null,
+          )
+        }
+        onTake={() => undefined}
+        onCut={() => undefined}
+        onFadeToBlack={() => setFtb((current) => !current)}
+      />
+    </main>
+  );
+}

--- a/frontend/app/routes/control.tsx
+++ b/frontend/app/routes/control.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { useSSE } from '../hooks/useSSE';
 import { OVERLAY_COMPONENTS, getDefaultPropsForComponent as getStaticDefaultProps, hasConfigurableSceneAttributes } from '../models/components';
 import { apiUrl } from '../utils/apiBaseUrl';
+import { authFetch } from '../services/api';
 import { dbToFader, faderToGain } from '../utils/audioTaper';
 import { useGlobalProgramId } from '../utils/globalProgram';
 import { useGlobalTransitionId } from '../utils/globalTransition';
@@ -18,6 +19,7 @@ import type { Route } from './+types/control';
 
 import { PanelColumn } from '../components/editors';
 import { PlaybackBar } from '../components/PlaybackBar';
+import { BroadcastSwitcherDeck, readStoredConsoleWorkspace, type ConsoleWorkspace } from '../components/BroadcastSwitcherDeck';
 import { RadioPanel } from '../components/RadioPanel';
 import { InstantsPanel, PlaylistPanel, PlaylistSheetPanel, SceneAttributesPanel } from '../components/panels';
 import type {
@@ -350,7 +352,8 @@ export default function Control() {
   const [sceneComponentProps, setSceneComponentProps] = useState<Record<string, any>>({});
   const [sceneErrors, setSceneErrors] = useState({ name: '', layout: '', props: '' });
   const [isCreatingScene, setIsCreatingScene] = useState(false);
-  const [selectedTransitionId] = useGlobalTransitionId(activeProgramId);
+  const [selectedTransitionId, setSelectedTransitionId] = useGlobalTransitionId(activeProgramId);
+  const [consoleWorkspace, setConsoleWorkspace] = useState<ConsoleWorkspace>(() => readStoredConsoleWorkspace());
   const [programAudioBusSettings, setProgramAudioBusSettings] = useState<ProgramAudioBusSettings>({
     songSequence: createProgramSongSequence('manual')
   });
@@ -630,7 +633,7 @@ export default function Control() {
 
   const syncProgramStateAndStagedScene = useCallback((nextProgramState: ProgramState | null) => {
     setProgramState(nextProgramState);
-    setSelectedScene((previousStagedSceneId) => {
+    setSelectedScene(() => {
       if (!nextProgramState) {
         return null;
       }
@@ -640,15 +643,7 @@ export default function Control() {
           ? nextProgramState.stagedSceneId
           : null;
 
-      if (nextStagedSceneId !== null) {
-        return nextStagedSceneId;
-      }
-
-      if (previousStagedSceneId !== null && nextProgramState.scenes.some((entry) => entry.sceneId === previousStagedSceneId)) {
-        return previousStagedSceneId;
-      }
-
-      return nextProgramState.activeSceneId ?? null;
+      return nextStagedSceneId;
     });
   }, []);
 
@@ -660,16 +655,28 @@ export default function Control() {
     let disposed = false;
     let reconnectTimer: number | null = null;
 
-    const connect = () => {
+    const connect = async () => {
       if (disposed) {
         return;
       }
 
       let socket: WebSocket;
       try {
-        socket = new WebSocket(getProgramRealtimeSocketUrl(activeProgramId, 'control'));
+        const ticketResponse = await authFetch('/auth/realtime-ticket', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ programId: activeProgramId })
+        });
+        if (!ticketResponse.ok) {
+          throw new Error(`Realtime ticket HTTP ${ticketResponse.status}`);
+        }
+        const ticketPayload = (await ticketResponse.json()) as { ticket?: unknown };
+        if (disposed || typeof ticketPayload.ticket !== 'string' || !ticketPayload.ticket) {
+          return;
+        }
+        socket = new WebSocket(getProgramRealtimeSocketUrl(activeProgramId, 'control', ticketPayload.ticket));
       } catch {
-        reconnectTimer = window.setTimeout(connect, 1500);
+        reconnectTimer = window.setTimeout(() => void connect(), 1500);
         return;
       }
 
@@ -750,6 +757,12 @@ export default function Control() {
               stagedScene: payload.scene && typeof payload.scene === 'object' ? (payload.scene as Scene) : null
             };
           });
+          return;
+        }
+
+        if (payload.type === 'fade_to_black') {
+          const normalizedProgramState = normalizeProgramState(payload.state);
+          syncProgramStateAndStagedScene(normalizedProgramState);
           return;
         }
 
@@ -874,7 +887,7 @@ export default function Control() {
         }
         setIsProgramRealtimeConnected(false);
         if (!disposed) {
-          reconnectTimer = window.setTimeout(connect, 1500);
+          reconnectTimer = window.setTimeout(() => void connect(), 1500);
         }
       });
 
@@ -887,7 +900,7 @@ export default function Control() {
       });
     };
 
-    connect();
+    void connect();
 
     return () => {
       disposed = true;
@@ -1538,27 +1551,26 @@ export default function Control() {
         stagedScene?: unknown;
         version?: unknown;
       };
-      if (shouldApplyControlUpdatePayload(result, 'state')) {
-        const stagedSceneId =
-          typeof result.stagedSceneId === 'number' && Number.isFinite(result.stagedSceneId)
-            ? result.stagedSceneId
-            : null;
-        const stagedScene =
-          result.stagedScene && typeof result.stagedScene === 'object'
-            ? (result.stagedScene as Scene)
-            : null;
+      shouldApplyControlUpdatePayload(result, 'state');
+      const stagedSceneId =
+        typeof result.stagedSceneId === 'number' && Number.isFinite(result.stagedSceneId)
+          ? result.stagedSceneId
+          : null;
+      const stagedScene =
+        result.stagedScene && typeof result.stagedScene === 'object'
+          ? (result.stagedScene as Scene)
+          : null;
 
-        setSelectedScene(stagedSceneId);
-        setProgramState((previous) =>
-          previous
-            ? {
-                ...previous,
-                stagedSceneId,
-                stagedScene
-              }
-            : previous
-        );
-      }
+      setSelectedScene(stagedSceneId);
+      setProgramState((previous) =>
+        previous
+          ? {
+              ...previous,
+              stagedSceneId,
+              stagedScene
+            }
+          : previous
+      );
 
       if (!isProgramRealtimeConnected) {
         await fetchProgramState(activeProgramId);
@@ -1568,7 +1580,7 @@ export default function Control() {
     }
   };
 
-  const activateScene = async (sceneId: number) => {
+  const activateScene = async (sceneId: number, transitionIdOverride?: string) => {
     try {
       if (!isSceneAssigned(sceneId)) {
         await assignSceneToProgram(sceneId);
@@ -1576,7 +1588,7 @@ export default function Control() {
       await fetch(apiUrl(`/program/${encodeURIComponent(activeProgramId)}/activate`), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sceneId, transitionId: selectedTransitionId })
+        body: JSON.stringify({ sceneId, transitionId: transitionIdOverride ?? selectedTransitionId })
       });
       setSelectedScene(sceneId);
       if (!isProgramRealtimeConnected) {
@@ -1587,16 +1599,31 @@ export default function Control() {
     }
   };
 
-  const takeStagedSceneLive = async () => {
+  const takeStagedSceneLive = async (transitionIdOverride?: string) => {
     if (!selectedScene) {
       return;
     }
 
     try {
       await flushSceneAttributeAutosaveForScene(selectedScene);
-      await activateScene(selectedScene);
+      await activateScene(selectedScene, transitionIdOverride);
     } catch (err) {
       console.error('Could not save staged scene attributes before taking live:', err);
+    }
+  };
+
+  const setFadeToBlack = async (active: boolean) => {
+    try {
+      const response = await fetch(apiUrl(`/program/${encodeURIComponent(activeProgramId)}/fade-to-black`), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ active })
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const nextState = normalizeProgramState(await response.json());
+      if (nextState) syncProgramStateAndStagedScene(nextState);
+    } catch (err) {
+      console.error('Failed to change fade-to-black state:', err);
     }
   };
 
@@ -2375,12 +2402,6 @@ export default function Control() {
         return;
       }
 
-      if (event.code === 'Enter') {
-        event.preventDefault();
-        void takeStagedSceneLive();
-        return;
-      }
-
       const match = event.code.match(/^Digit(\d)$/);
       if (match && Date.now() <= sceneHotkeyArmedUntil) {
         const pressedDigit = Number(match[1]);
@@ -2449,6 +2470,11 @@ export default function Control() {
         if (data.type === 'program_media_groups_changed') {
           void fetchMediaGroups(activeProgramId);
         }
+        return;
+      }
+
+      if (data.type === 'fade_to_black') {
+        syncProgramStateAndStagedScene(normalizeProgramState(data.state));
         return;
       }
 
@@ -2653,9 +2679,26 @@ export default function Control() {
           }
         `}
       </style>
-      <div className='flex-1 min-h-0 w-full overflow-hidden'>
+      <BroadcastSwitcherDeck
+        programId={activeProgramId}
+        activeScene={programState?.activeScene ?? null}
+        stagedScene={stagedSceneData}
+        scenes={assignedScenes}
+        transitionId={selectedTransitionId}
+        realtimeConnected={isProgramRealtimeConnected}
+        fadeToBlack={programState?.fadeToBlack === true}
+        workspace={consoleWorkspace}
+        onWorkspaceChange={setConsoleWorkspace}
+        onTransitionChange={setSelectedTransitionId}
+        onStageScene={stageSceneForProgram}
+        onTake={() => void takeStagedSceneLive()}
+        onCut={() => void takeStagedSceneLive('cut')}
+        onFadeToBlack={() => void setFadeToBlack(programState?.fadeToBlack !== true)}
+      />
+      <div className={`flex-1 min-h-0 w-full overflow-hidden ${consoleWorkspace === 'compact' ? 'hidden' : ''}`} data-workspace-content={consoleWorkspace}>
         <PanelLayout className='w-full h-full min-h-0' padding='p-0'>
           <PanelColumn className='min-w-0' {...controlDeckGrowProps}>
+            {consoleWorkspace !== 'graphics' ? (
             <Panel title='Mixer' accent='#38bdf8' variant='monitor' className='min-h-0' grow>
               <div className='space-y-4'>
                 <div className='flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between'>
@@ -2949,8 +2992,9 @@ export default function Control() {
                 </div>
               </div>
             </Panel>
+            ) : null}
 
-            {programState?.type !== 'radio' ? (
+            {consoleWorkspace !== 'audio' ? (
             <Panel title='Stage Attributes' accent='#14b8a6' variant='monitor' className='min-h-0' grow>
               <SceneAttributesPanel
                 selectedScene={selectedScene}
@@ -3068,9 +3112,6 @@ export default function Control() {
           }}
           onStageScene={(sceneId) => {
             void stageSceneForProgram(sceneId);
-          }}
-          onTakeScene={(sceneId) => {
-            void activateScene(sceneId);
           }}
         />
       </div>

--- a/frontend/app/routes/control.tsx
+++ b/frontend/app/routes/control.tsx
@@ -8,6 +8,7 @@ import { dbToFader, faderToGain } from '../utils/audioTaper';
 import { useGlobalProgramId } from '../utils/globalProgram';
 import { useGlobalTransitionId } from '../utils/globalTransition';
 import { getProgramRealtimeSocketUrl } from '../utils/programRealtimeSocket';
+import { acceptStageSceneResponse, type StageSceneResponse } from '../utils/stageSceneResponse';
 import {
   createProgramSongSequence,
   createProgramTextSequence,
@@ -1546,20 +1547,12 @@ export default function Control() {
         throw new Error(`HTTP ${response.status}`);
       }
 
-      const result = (await response.json()) as {
-        stagedSceneId?: unknown;
-        stagedScene?: unknown;
-        version?: unknown;
-      };
-      shouldApplyControlUpdatePayload(result, 'state');
-      const stagedSceneId =
-        typeof result.stagedSceneId === 'number' && Number.isFinite(result.stagedSceneId)
-          ? result.stagedSceneId
-          : null;
-      const stagedScene =
-        result.stagedScene && typeof result.stagedScene === 'object'
-          ? (result.stagedScene as Scene)
-          : null;
+      const result = (await response.json()) as StageSceneResponse;
+      const acceptedResult = acceptStageSceneResponse<Scene>(result, shouldApplyControlUpdatePayload);
+      if (!acceptedResult) {
+        return;
+      }
+      const { stagedSceneId, stagedScene } = acceptedResult;
 
       setSelectedScene(stagedSceneId);
       setProgramState((previous) =>

--- a/frontend/app/routes/program.tsx
+++ b/frontend/app/routes/program.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useParams } from 'react-router';
+import { useParams, useSearchParams } from 'react-router';
 import { useSSE } from '../hooks/useSSE';
 import { apiUrl } from '../utils/apiBaseUrl';
 import {
@@ -72,6 +72,7 @@ interface ProgramState {
   activeScene: Scene | null;
   stagedSceneId?: number | null;
   stagedScene?: Scene | null;
+  fadeToBlack?: boolean;
   updatedAt: string;
 }
 
@@ -291,6 +292,7 @@ function resolveProgramUpdateTopicFromType(type: unknown): ProgramUpdateTopic | 
     case 'program_state_snapshot':
     case 'scene_change':
     case 'scene_staged':
+    case 'fade_to_black':
     case 'scene_update':
     case 'scene_cleared':
     case 'program_scenes_changed':
@@ -664,12 +666,14 @@ function buildSceneInstantPlaybackToken(sceneId: number | null, instantId: numbe
 
 export default function Program() {
   const { id } = useParams();
+  const [searchParams] = useSearchParams();
   const programId = id ?? 'main';
+  const confidenceMode = searchParams.get('confidence');
 
-  return <SceneProgram programId={programId} />;
+  return <SceneProgram programId={programId} confidenceMode={confidenceMode === 'preview' ? 'preview' : confidenceMode === 'program' ? 'program' : null} />;
 }
 
-function SceneProgram({ programId }: { programId: string }) {
+function SceneProgram({ programId, confidenceMode }: { programId: string; confidenceMode: 'preview' | 'program' | null }) {
   const [state, setState] = useState<ProgramState | null>(null);
   const [audioBusSettings, setAudioBusSettings] = useState<ProgramAudioBusSettings | null>(null);
   const [broadcastSettings, setBroadcastSettings] = useState<BroadcastSettings | null>(null);
@@ -677,6 +681,8 @@ function SceneProgram({ programId }: { programId: string }) {
   const [programStingers, setProgramStingers] = useState<Array<{ id: number; name: string; videoUrl: string; cutPointMs: number }>>([]);
   const [earoneLookup, setEaroneLookup] = useState<EaroneRealtimeLookup | null>(null);
   const [activeTransition, setActiveTransition] = useState<ActiveTransition | null>(null);
+  const [fadeToBlackAudioGain, setFadeToBlackAudioGain] = useState(1);
+  const previousFadeToBlackRef = useRef<boolean | null>(null);
   const [bracketDrawCommands, setBracketDrawCommands] = useState<Record<number, any>>({});
   const transitionTimersRef = useRef<number[]>([]);
   const transitionSequenceRef = useRef(0);
@@ -763,10 +769,37 @@ function SceneProgram({ programId }: { programId: string }) {
   const resolvedSceneInstantChannelGain = sceneInstantMuted ? 0 : faderToGain(effectiveSceneInstantMasterFader);
   const resolvedStreamChannelGain = streamMuted ? 0 : faderToGain(effectiveStreamMasterFader);
   const mainMasterGain = faderToGain(mainMasterFader);
-  const resolvedSongMasterVolume = normalizeMasterVolume(resolvedSongChannelGain * mainMasterGain, 0);
-  const resolvedInstantMasterVolume = normalizeMasterVolume(resolvedInstantChannelGain * mainMasterGain, 0);
-  const resolvedSceneInstantMasterVolume = normalizeMasterVolume(resolvedSceneInstantChannelGain * mainMasterGain, 0);
-  const resolvedStreamMasterVolume = normalizeMasterVolume(resolvedStreamChannelGain * mainMasterGain, 0);
+  const outputGain = confidenceMode ? 0 : fadeToBlackAudioGain;
+  const resolvedSongMasterVolume = normalizeMasterVolume(resolvedSongChannelGain * mainMasterGain * outputGain, 0);
+  const resolvedInstantMasterVolume = normalizeMasterVolume(resolvedInstantChannelGain * mainMasterGain * outputGain, 0);
+  const resolvedSceneInstantMasterVolume = normalizeMasterVolume(resolvedSceneInstantChannelGain * mainMasterGain * outputGain, 0);
+  const resolvedStreamMasterVolume = normalizeMasterVolume(resolvedStreamChannelGain * mainMasterGain * outputGain, 0);
+  useEffect(() => {
+    if (confidenceMode) {
+      setFadeToBlackAudioGain(0);
+      return;
+    }
+
+    const target = state?.fadeToBlack ? 0 : 1;
+    if (!state || previousFadeToBlackRef.current === null) {
+      setFadeToBlackAudioGain(target);
+      if (state) previousFadeToBlackRef.current = state.fadeToBlack === true;
+      return;
+    }
+    let animationFrame = 0;
+    const startedAt = performance.now();
+    const startGain = fadeToBlackAudioGain;
+    const renderFrame = (now: number) => {
+      const progress = Math.min(1, (now - startedAt) / 1000);
+      setFadeToBlackAudioGain(startGain + (target - startGain) * progress);
+      if (progress < 1) {
+        animationFrame = window.requestAnimationFrame(renderFrame);
+      }
+    };
+    animationFrame = window.requestAnimationFrame(renderFrame);
+    previousFadeToBlackRef.current = state.fadeToBlack === true;
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [confidenceMode, state?.fadeToBlack]);
   const resolvedManualSong = useMemo(
     () =>
       normalizedSongSequence?.mode === 'manual'
@@ -1296,7 +1329,19 @@ function SceneProgram({ programId }: { programId: string }) {
         return;
       }
 
-      if (data.type === 'scene_staged') {
+      if (data.type === 'program_state_snapshot') {
+        if (data.state && typeof data.state === 'object') {
+          setState(data.state as ProgramState);
+        }
+      } else if (data.type === 'audio_bus_snapshot') {
+        setAudioBusSettings(normalizeProgramAudioBusSettings(data.settings));
+      } else if (data.type === 'broadcast_settings_snapshot') {
+        setBroadcastSettings(normalizeBroadcastSettings(data.settings));
+      } else if (data.type === 'fade_to_black') {
+        if (data.state && typeof data.state === 'object') {
+          setState(data.state as ProgramState);
+        }
+      } else if (data.type === 'scene_staged') {
         const eventProgramId = typeof data.programId === 'string' ? data.programId : '';
         if (eventProgramId && eventProgramId !== programId) {
           return;
@@ -1403,6 +1448,7 @@ function SceneProgram({ programId }: { programId: string }) {
       } else if (data.type === 'broadcast_settings_update') {
         setBroadcastSettings(normalizeBroadcastSettings(data.settings));
       } else if (data.type === 'instant_play') {
+        if (confidenceMode) return;
         const eventProgramId = typeof data.programId === 'string' ? data.programId : '';
         if (eventProgramId && eventProgramId !== programId) {
           return;
@@ -1415,6 +1461,7 @@ function SceneProgram({ programId }: { programId: string }) {
         }
         stopAllInstantAudio();
       } else if (data.type === 'scene_instant_take') {
+        if (confidenceMode) return;
         const eventProgramId = typeof data.programId === 'string' ? data.programId : '';
         if (eventProgramId && eventProgramId !== programId) {
           return;
@@ -1427,6 +1474,7 @@ function SceneProgram({ programId }: { programId: string }) {
         }
         stopSceneInstantAudio(data.fadeMs || 0);
       } else if (data.type === 'scene_instant_state') {
+        if (confidenceMode) return;
         const event = data as SceneInstantStateEvent;
         const eventProgramId = typeof event.programId === 'string' ? event.programId : '';
         if (eventProgramId && eventProgramId !== programId) {
@@ -1529,6 +1577,7 @@ function SceneProgram({ programId }: { programId: string }) {
     },
     [
       programId,
+      confidenceMode,
       state?.activeScene,
       state?.activeSceneId,
       playInstantAudio,
@@ -1760,10 +1809,16 @@ function SceneProgram({ programId }: { programId: string }) {
   }, [programId, shouldApplyProgramUpdatePayload]);
 
   useEffect(() => {
+    if (confidenceMode) {
+      return;
+    }
     setProgramAudioBusMasterVolume(programId, resolvedSongMasterVolume);
-  }, [programId, resolvedSongMasterVolume]);
+  }, [confidenceMode, programId, resolvedSongMasterVolume]);
 
   useEffect(() => {
+    if (confidenceMode) {
+      return;
+    }
     let lastEndedToken = '';
 
     return subscribeProgramAudioBus(programId, (snapshot) => {
@@ -1783,10 +1838,10 @@ function SceneProgram({ programId }: { programId: string }) {
         // The flight timeout remains the fallback if the connection drops at song end.
       }
     });
-  }, [programId]);
+  }, [confidenceMode, programId]);
 
   useEffect(() => {
-    if (!audioBusSettings || normalizedSongSequence?.mode !== 'manual') {
+    if (confidenceMode || !audioBusSettings || normalizedSongSequence?.mode !== 'manual') {
       return;
     }
 
@@ -1819,6 +1874,7 @@ function SceneProgram({ programId }: { programId: string }) {
     });
   }, [
     programId,
+    confidenceMode,
     audioBusSettings,
     normalizedSongSequence?.mode,
     resolvedManualSong?.id,
@@ -1879,7 +1935,7 @@ function SceneProgram({ programId }: { programId: string }) {
   }, [activeSlideshowMediaGroupId]);
 
   useEffect(() => {
-    if (typeof window === 'undefined') {
+    if (confidenceMode || typeof window === 'undefined') {
       return;
     }
 
@@ -1937,7 +1993,7 @@ function SceneProgram({ programId }: { programId: string }) {
         socket.close();
       }
     };
-  }, [programId]);
+  }, [confidenceMode, programId]);
 
   useEffect(() => {
     const componentTypes = state?.activeScene?.layout.componentType.split(',').filter(Boolean) || [];
@@ -2164,6 +2220,7 @@ function SceneProgram({ programId }: { programId: string }) {
                     urls={Array.isArray(props.urls) ? props.urls : []}
                     maxStreams={typeof props.maxStreams === 'number' ? props.maxStreams : 4}
                     title={typeof props.title === 'string' ? props.title : ''}
+                    suspended={outputGain <= 0.0001}
                   />
                 );
               case 'scoreboard':
@@ -2199,6 +2256,7 @@ function SceneProgram({ programId }: { programId: string }) {
                     countdownTargetSceneId={typeof props.countdownTargetSceneId === 'number' ? props.countdownTargetSceneId : null}
                     countdownTransitionId={props.countdownTransitionId || 'cut'}
                     countdownCommand={typeof props.countdownCommand === 'number' ? props.countdownCommand : 0}
+                    allowProgramActivation={!confidenceMode}
                   />
                 );
               case 'toni-chyron':
@@ -2326,6 +2384,7 @@ function SceneProgram({ programId }: { programId: string }) {
                     episodeTitle={typeof props.episodeTitle === 'string' ? props.episodeTitle : ''}
                     showName={typeof props.showName === 'string' ? props.showName : ''}
                     audioUrl={typeof props.audioUrl === 'string' ? props.audioUrl : ''}
+                    masterGain={outputGain}
                   />
                 );
               case 'toni-logo':
@@ -2347,7 +2406,7 @@ function SceneProgram({ programId }: { programId: string }) {
                 }
                 return (
                   <div key={componentType} className='absolute inset-0'>
-                    <FifthBellProgram programId={programId} embedded sceneMetadata={metadata} activeComponents={components} />
+                    <FifthBellProgram programId={programId} embedded sceneMetadata={metadata} activeComponents={components} masterGain={outputGain} />
                   </div>
                 );
               case 'corner-bug':
@@ -2427,8 +2486,25 @@ function SceneProgram({ programId }: { programId: string }) {
 
   const activeScene = state?.activeScene ?? null;
   const stagedScene = state?.stagedScene ?? null;
+  const confidenceScene = confidenceMode === 'preview' ? stagedScene : activeScene;
   const stagedSceneHasVideoStream = sceneIncludesVideoStream(stagedScene);
   const stagedSceneIsOnAir = stagedSceneHasVideoStream && stagedScene !== null && activeScene !== null && stagedScene.id === activeScene.id;
+  const shouldAnimateFadeToBlack = previousFadeToBlackRef.current !== null;
+
+  if (confidenceMode) {
+    return (
+      <div className='relative overflow-hidden bg-black' style={{ width: '1920px', height: '1080px' }} data-confidence-monitor={confidenceMode}>
+        <div className='absolute inset-0'>{renderScene(confidenceScene, { forceStreamMuted: true })}</div>
+        {confidenceMode === 'program' ? (
+          <div
+            className='pointer-events-none absolute inset-0 z-[2000] bg-black'
+            data-confidence-fade-to-black={state?.fadeToBlack ? 'active' : 'inactive'}
+            style={{ opacity: state?.fadeToBlack ? 1 : 0, transition: shouldAnimateFadeToBlack ? 'opacity 1000ms linear' : 'none' }}
+          />
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div className='relative overflow-hidden bg-transparent' style={{ width: '1920px', height: '1080px' }}>
@@ -2437,6 +2513,11 @@ function SceneProgram({ programId }: { programId: string }) {
       </div>
       <div className='absolute inset-0'>{!stagedSceneIsOnAir ? renderScene(activeScene, { forceStreamMuted: false }) : null}</div>
       {activeTransition && <SceneTransitionOverlay key={activeTransition.sequence} transition={activeTransition.preset} />}
+      <div
+        className='pointer-events-none absolute inset-0 z-[2000] bg-black'
+        data-fade-to-black={state?.fadeToBlack ? 'active' : 'inactive'}
+        style={{ opacity: state?.fadeToBlack ? 1 : 0, transition: shouldAnimateFadeToBlack ? 'opacity 1000ms linear' : 'none' }}
+      />
     </div>
   );
 }

--- a/frontend/app/utils/broadcast.ts
+++ b/frontend/app/utils/broadcast.ts
@@ -251,7 +251,7 @@ export function normalizeUpdateVersion(value: unknown): number | null {
 export function resolveControlUpdateTopicFromType(type: unknown): ProgramUpdateTopic | null {
   if (typeof type !== 'string') return null;
   switch (type) {
-    case 'program_state_snapshot': case 'scene_change': case 'scene_staged': case 'scene_update': case 'scene_cleared': case 'program_scenes_changed': case 'program_media_groups_changed': return 'state';
+    case 'program_state_snapshot': case 'scene_change': case 'scene_staged': case 'fade_to_black': case 'scene_update': case 'scene_cleared': case 'program_scenes_changed': case 'program_media_groups_changed': return 'state';
     case 'audio_bus_snapshot': case 'audio_bus_update': return 'audioBus';
     case 'audio_meter_update': return 'audioMeter';
     case 'song_playback_update': case 'song_off_air': return 'songPlayback';
@@ -304,6 +304,7 @@ export function normalizeProgramState(value: unknown): ProgramState | null {
     mediaGroups: Array.isArray(record.mediaGroups) ? record.mediaGroups : [],
     activeSceneId: typeof record.activeSceneId === 'number' ? record.activeSceneId : null,
     stagedSceneId: typeof record.stagedSceneId === 'number' ? record.stagedSceneId : null,
+    fadeToBlack: record.fadeToBlack === true,
     activeScene: record.activeScene && typeof record.activeScene === 'object' ? (record.activeScene as Scene) : null,
     stagedScene: record.stagedScene && typeof record.stagedScene === 'object' ? (record.stagedScene as Scene) : null
   };

--- a/frontend/app/utils/programRealtimeSocket.ts
+++ b/frontend/app/utils/programRealtimeSocket.ts
@@ -5,10 +5,12 @@ export type ProgramRealtimeRole = 'program' | 'control';
 export function getProgramRealtimeSocketUrl(
   programId: string,
   role: ProgramRealtimeRole,
+  ticket?: string | null,
 ): string {
   const socketUrl = new URL('/program/ws', getApiBaseUrl());
   socketUrl.protocol = socketUrl.protocol === 'https:' ? 'wss:' : 'ws:';
   socketUrl.searchParams.set('programId', programId);
   socketUrl.searchParams.set('role', role);
+  if (ticket) socketUrl.searchParams.set('ticket', ticket);
   return socketUrl.toString();
 }

--- a/frontend/app/utils/stageSceneResponse.test.ts
+++ b/frontend/app/utils/stageSceneResponse.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { acceptStageSceneResponse } from './stageSceneResponse';
+
+test('rejects an out-of-order stage response without exposing stale scene state', () => {
+  const staleScene = { id: 12, name: 'Stale scene' };
+  const accepted = acceptStageSceneResponse(
+    { stagedSceneId: 12, stagedScene: staleScene, version: 4 },
+    (payload, topic) => {
+      assert.equal(topic, 'state');
+      assert.equal((payload as { version: number }).version, 4);
+      return false;
+    },
+  );
+
+  assert.equal(accepted, null);
+});
+
+test('normalizes an accepted stage response for the control UI', () => {
+  const scene = { id: 18, name: 'Accepted scene' };
+  const accepted = acceptStageSceneResponse<typeof scene>(
+    { stagedSceneId: 18, stagedScene: scene, version: 5 },
+    () => true,
+  );
+
+  assert.deepEqual(accepted, { stagedSceneId: 18, stagedScene: scene });
+  assert.deepEqual(
+    acceptStageSceneResponse({ stagedSceneId: Number.NaN, stagedScene: null }, () => true),
+    { stagedSceneId: null, stagedScene: null },
+  );
+});

--- a/frontend/app/utils/stageSceneResponse.ts
+++ b/frontend/app/utils/stageSceneResponse.ts
@@ -1,0 +1,32 @@
+export type StageSceneResponse = {
+  stagedSceneId?: unknown;
+  stagedScene?: unknown;
+  version?: unknown;
+};
+
+export type AcceptedStageSceneResponse<TScene extends object> = {
+  stagedSceneId: number | null;
+  stagedScene: TScene | null;
+};
+
+type AcceptControlUpdate = (payload: unknown, topicOverride: 'state') => boolean;
+
+export function acceptStageSceneResponse<TScene extends object>(
+  result: StageSceneResponse,
+  acceptControlUpdate: AcceptControlUpdate,
+): AcceptedStageSceneResponse<TScene> | null {
+  if (!acceptControlUpdate(result, 'state')) {
+    return null;
+  }
+
+  return {
+    stagedSceneId:
+      typeof result.stagedSceneId === 'number' && Number.isFinite(result.stagedSceneId)
+        ? result.stagedSceneId
+        : null,
+    stagedScene:
+      result.stagedScene && typeof result.stagedScene === 'object'
+        ? (result.stagedScene as TScene)
+        : null,
+  };
+}


### PR DESCRIPTION
## Summary

- replace implicit source activation with an explicit Preview → CUT/TAKE switcher workflow
- persist Preview and fade-to-black state so reconnects, renderer restarts, and multiple control clients remain authoritative
- add amber Preview and red Program confidence monitors using muted, side-effect-free renderer modes
- add true reversible one-second FTB for video and the complete managed audio mix while preserving Program, Preview, mixer, Flight, playback, and workspace state
- add Director, Audio, Graphics, and Compact/touch workspaces plus validated local preferences and guarded broadcast shortcuts
- add stable normal, disconnected, empty Preview, on-air, and FTB visual fixture states

## UAT

- backend: 6 suites, 19 tests passed; build passed
- frontend production build passed
- authenticated clean Compose stack passed with seeded Pompeii authorization
- exercised rapid stage → CUT ordering, selected-transition TAKE, immediate CUT, clear Preview, FTB down/up, renderer restart while FTB, and two simultaneous control clients
- verified Space TAKE, C CUT, Escape clear Preview, Alt+B FTB, and suppression while typing or activating controls
- verified workspace/touch/dock/shortcut persistence and invalid-value fallback
- visually checked the production console at 1280×720 and in Compact/touch mode
- frontend typecheck was run; it remains blocked by existing base-branch errors in legacy auth Redux types, broadcast media typed arrays, `captureStream`, and program-sequence nullability. No G-86 component or fixture error is reported.

## Review notes

- This is stacked on G-117 / #6 so local UAT uses the self-contained authenticated stack.
- Visual fixture URLs: `/console-fixture?state=normal`, `disconnected`, `empty-preview`, `on-air`, and `ftb`; add `&surface=touch` for the touch surface.

Closes G-86
## Summary by Sourcery

Complete the broadcast control workflow with authoritative Preview, CUT/TAKE, confidence monitoring, and reversible fade-to-black operation.

New Features:
- Add an explicit Preview-to-Program switcher with configurable CUT and TAKE transitions, confidence monitors, workspaces, touch mode, and guarded keyboard shortcuts.
- Add reversible fade-to-black control for video and managed audio output.

Bug Fixes:
- Prevent stale or out-of-order staging responses from overwriting authoritative control state.
- Prevent confidence monitors and countdown or instant actions from activating live program behavior.

Enhancements:
- Persist Preview and fade-to-black state in program storage and synchronize it across reconnecting or concurrent control clients.
- Provide muted, side-effect-free confidence rendering and stable console visual fixtures for key broadcast states.

Tests:
- Add backend coverage for persisted Preview, fade-to-black, and off-air state behavior.
- Add frontend coverage for rejecting stale stage responses and normalizing accepted responses.