### PR TITLE
feat(webrtc): ship six-guest return workflow (G-85)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ BACKEND_PORT=3000
 
 # Frontend dev server port (also set in frontend/.env as VITE_PORT)
 VITE_PORT=5173
+
+# Local LiveKit ports are fixed by the supported Compose workflow.
+# Production WebSocket and credentials are backend-owned configuration.
+LIVEKIT_SIGNAL_PORT=7880

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'backend/**'
+      - 'infra/**'
       - '.github/workflows/backend-deploy.yml'
 
 jobs:
@@ -36,6 +37,19 @@ jobs:
     needs: build
 
     steps:
+      - name: Checkout deployment definitions
+        uses: actions/checkout@v4
+
+      - name: Upload LiveKit deployment definition
+        uses: appleboy/scp-action@v1.0.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: infra/compose.production.yml
+          target: /services/alcantara
+          strip_components: 1
+
       - name: Deploy to on-premises host
         uses: appleboy/ssh-action@v1.2.0
         with:
@@ -47,12 +61,20 @@ jobs:
             docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.DEPLOYMENT_TOKEN }}
             docker pull ghcr.io/${{ github.repository }}:latest
 
+            test -n "${{ secrets.LIVEKIT_CONFIG_B64 }}"
+            mkdir -p /services/alcantara/livekit-redis
+            printf "%s" "${{ secrets.LIVEKIT_CONFIG_B64 }}" | base64 --decode > /services/alcantara/livekit.yaml
+            chmod 600 /services/alcantara/livekit.yaml
+            docker compose -f /services/alcantara/compose.production.yml up -d
+            docker network inspect alcantara >/dev/null
+
             docker stop alcantara-backend || true
             docker rm alcantara-backend || true
 
             LOG_STREAM_UUID=$(uuidgen)
 
             docker run -d --name alcantara-backend \
+            --network alcantara \
             -p ${{ vars.HTTP_PORT }}:${{ vars.HTTP_PORT }} \
             -e HTTP_PORT="${{ vars.HTTP_PORT }}" \
             -e PORT="${{ vars.HTTP_PORT }}" \
@@ -64,6 +86,12 @@ jobs:
             -e POMPEII_GRPC_TLS="${{ vars.POMPEII_GRPC_TLS }}" \
             -e POMPEII_GRPC_TIMEOUT_MS="${{ vars.POMPEII_GRPC_TIMEOUT_MS }}" \
             -e MEDIA_S3_BUCKET="${{ secrets.MEDIA_S3_BUCKET }}" \
+            -e LIVEKIT_WS_URL="${{ vars.LIVEKIT_WS_URL }}" \
+            -e LIVEKIT_API_URL="http://alcantara-livekit:7880" \
+            -e LIVEKIT_API_KEY="${{ secrets.LIVEKIT_API_KEY }}" \
+            -e LIVEKIT_API_SECRET="${{ secrets.LIVEKIT_API_SECRET }}" \
+            -e WEBRTC_SESSION_SECRET="${{ secrets.WEBRTC_SESSION_SECRET }}" \
+            -e WEBRTC_RENDERER_KEY="${{ secrets.WEBRTC_RENDERER_KEY }}" \
             -e CONTAINERIZED=true \
             --restart=always \
             --log-driver=awslogs \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A professional TV broadcast overlay control system built with a modern tech stac
 
 From this repository, `docker compose up --build` starts Alcantara PostgreSQL,
 Pompeii PostgreSQL, both migration paths, deterministic fictional seeds,
-Pompeii authorization, the Alcantara backend, and the frontend. The only
+Pompeii authorization, self-hosted LiveKit, the Alcantara backend, and the frontend. The only
 one-time prerequisite is a sibling checkout at `../pompeii`; no Cognito, AWS,
 cloud database, production secret, or host process is used.
 
@@ -29,7 +29,7 @@ start after Pompeii migrations complete.
 
 - **Frontend**: React Router v7 + Vite + Tailwind CSS
 - **Backend**: NestJS + Fastify + Prisma
-- **Database**: SQLite
+- **Database**: PostgreSQL
 - **Monorepo**: pnpm workspace
 
 ## Project Structure
@@ -61,6 +61,75 @@ alcantara/
 ```
 
 ## Features
+
+### Six-guest WebRTC contribution
+
+The Calls console at `/calls` provides six reusable guest slots. An operator
+with `alcantara:webrtc:operate` can create a persisted private invitation,
+choose its one-to-seven-day lifetime (24 hours by default), copy it, replace or
+revoke it, remove its current session, and select the guest's Program, Preview,
+or no return video plus Program/Master, monitor, or Aux 1-8 return audio.
+Invitation secrets are shown only at creation/replacement; the database stores
+only their SHA-256 hash. Guest and operator LiveKit credentials expire after
+five minutes and are scoped to one program room. The LiveKit API secret never
+enters either browser.
+
+Guests enter `/guest/:invitation` without Cognito, select devices, preview their
+camera, test their speaker/network, and confirm headphones before explicitly
+joining. A documented acoustic-risk override is available when headphones are
+impossible. Each invitation permits one active browser session. A signed
+session lease refreshed every 20 seconds preserves the stable slot for a
+60-second network-reconnect window; a second browser fails closed. Revocation
+disconnects the guest and prevents future credentials.
+
+Operator mute is immediate. Camera/microphone enable is delivered as a request
+that the guest accepts or rejects. Standby/live/wrap cues and private messages
+persist requested, delivered, acknowledged/read, rejected, or failed state.
+Private talkback publishes only to the target guest's N-1 route and never to the
+Program feed. Removing or disconnecting a guest does not mutate Preview or
+Program.
+
+Layouts use the `webrtc-guest` component with a generic slot number from 1-6,
+not a person or invitation identifier. Assigning a replacement invitation to
+the same slot therefore preserves reusable layouts. The normal Preview, CUT,
+and TAKE workflow remains the only way a guest reaches air.
+
+#### Return routing
+
+Alana remains the owner of captured Program/Preview output publication. Start
+its Program renderer with `?renderer=1` so guest microphones are excluded from
+the captured base bus, and publish the output to the matching
+`alcantara-<programId>` LiveKit room as `program-feed-<programId>` (and optional
+`preview-feed-<programId>`). Run one isolated
+`/return-router/<programId>#key=<WEBRTC_RENDERER_KEY>` renderer alongside it.
+The fragment is immediately moved to session storage and removed from browser
+history; it is never sent in a URL request.
+
+The return router subscribes to the selected processed base bus, connected
+guest microphones, and targeted producer talkback. It creates and publishes a
+distinct Web Audio destination for every guest, excluding only that guest's
+own microphone. Guests subscribe only to their selected video output and their
+own `mixminus:<identity>:<bus>` track. This replaces the earlier fixed 250 ms
+browser relay and keeps isolated guest tracks out of the guest UI.
+
+#### Local and production operations
+
+`docker compose up --build` includes LiveKit 1.13.4 with fixed local-only
+credentials and TCP/UDP media ports. From `/calls`, create six fictional guest
+links and open them in separate browser contexts. Chrome's fake-device flags
+may be used for repeatable automated media UAT. Verify all six show as connected
+without appearing on Preview/Program, assign slots to a reusable layout, then
+exercise Preview and TAKE deliberately. Restart one guest and verify its slot
+is held for 60 seconds. The machine-only return router requires the local
+`WEBRTC_RENDERER_KEY` from Compose.
+
+Production owns LiveKit, Redis, TLS, TURN/TLS, firewall rules, health checks,
+and secrets through Alcantara deployment infrastructure. Start from
+`infra/livekit.production.example.yaml`, generate real API/session/renderer
+secrets in the application-scoped secret, and expose HTTPS/TURN 443, WebRTC TCP
+7881, TURN UDP 3478, and the configured UDP media/relay ranges. Validate TURN
+from a restrictive external network before scheduling remote guests. Never use
+the committed local credentials outside Compose.
 
 ### Program Page (`/program`)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,3 +12,12 @@ COGNITO_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Optional media uploads (instants/artwork) to S3
 MEDIA_S3_BUCKET="your-bucket-name"
+
+# Self-hosted LiveKit guest contribution. Store all secret values in the
+# application-scoped production secret, never in frontend configuration.
+LIVEKIT_WS_URL="wss://livekit.example.invalid"
+LIVEKIT_API_URL="https://livekit.internal:7880"
+LIVEKIT_API_KEY="replace-api-key"
+LIVEKIT_API_SECRET="replace-with-at-least-32-random-characters"
+WEBRTC_SESSION_SECRET="replace-with-a-separate-random-secret"
+WEBRTC_RENDERER_KEY="replace-with-a-separate-machine-bootstrap-secret"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,4 +14,4 @@ COPY . .
 RUN pnpm run prisma:generate
 RUN pnpm run build
 
-CMD ["sh", "-c", "pnpm prisma db push && pnpm start:prod"]
+CMD ["sh", "-c", "pnpm prisma migrate deploy && pnpm start:prod"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "^7.5.0",
     "jsonwebtoken": "^9.0.3",
+    "livekit-server-sdk": "2.17.0",
     "music-metadata": "^11.12.3",
     "pg": "^8.20.0",
     "reflect-metadata": "^0.2.2",

--- a/backend/prisma/local-migrations/0003_webrtc_guest_calls/migration.sql
+++ b/backend/prisma/local-migrations/0003_webrtc_guest_calls/migration.sql
@@ -1,0 +1,47 @@
+CREATE TABLE "GuestInvitation" (
+  "id" TEXT NOT NULL,
+  "tokenHash" TEXT NOT NULL,
+  "programId" TEXT NOT NULL,
+  "displayName" TEXT NOT NULL,
+  "slotNumber" INTEGER,
+  "returnVideo" TEXT NOT NULL DEFAULT 'program',
+  "returnAudioBus" TEXT NOT NULL DEFAULT 'master',
+  "sourceGain" DOUBLE PRECISION NOT NULL DEFAULT 1,
+  "sourceMuted" BOOLEAN NOT NULL DEFAULT false,
+  "sourceDelayMs" INTEGER NOT NULL DEFAULT 0,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "revokedAt" TIMESTAMP(3),
+  "activeSessionId" TEXT,
+  "activeSessionUntil" TIMESTAMP(3),
+  "createdByIdentity" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "GuestInvitation_pkey" PRIMARY KEY ("id")
+);
+CREATE TABLE "GuestCommand" (
+  "id" TEXT NOT NULL,
+  "invitationId" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "payload" JSONB NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'requested',
+  "failureReason" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deliveredAt" TIMESTAMP(3),
+  "acknowledgedAt" TIMESTAMP(3),
+  CONSTRAINT "GuestCommand_pkey" PRIMARY KEY ("id")
+);
+CREATE TABLE "GuestEvent" (
+  "id" TEXT NOT NULL,
+  "invitationId" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "details" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "GuestEvent_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "GuestInvitation_tokenHash_key" ON "GuestInvitation"("tokenHash");
+CREATE INDEX "GuestInvitation_programId_expiresAt_idx" ON "GuestInvitation"("programId", "expiresAt");
+CREATE UNIQUE INDEX "GuestInvitation_programId_slotNumber_key" ON "GuestInvitation"("programId", "slotNumber");
+CREATE INDEX "GuestCommand_invitationId_createdAt_idx" ON "GuestCommand"("invitationId", "createdAt");
+CREATE INDEX "GuestEvent_invitationId_createdAt_idx" ON "GuestEvent"("invitationId", "createdAt");
+ALTER TABLE "GuestCommand" ADD CONSTRAINT "GuestCommand_invitationId_fkey" FOREIGN KEY ("invitationId") REFERENCES "GuestInvitation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "GuestEvent" ADD CONSTRAINT "GuestEvent_invitationId_fkey" FOREIGN KEY ("invitationId") REFERENCES "GuestInvitation"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260821000100_webrtc_guest_calls/migration.sql
+++ b/backend/prisma/migrations/20260821000100_webrtc_guest_calls/migration.sql
@@ -1,0 +1,50 @@
+CREATE TABLE "GuestInvitation" (
+  "id" TEXT NOT NULL,
+  "tokenHash" TEXT NOT NULL,
+  "programId" TEXT NOT NULL,
+  "displayName" TEXT NOT NULL,
+  "slotNumber" INTEGER,
+  "returnVideo" TEXT NOT NULL DEFAULT 'program',
+  "returnAudioBus" TEXT NOT NULL DEFAULT 'master',
+  "sourceGain" DOUBLE PRECISION NOT NULL DEFAULT 1,
+  "sourceMuted" BOOLEAN NOT NULL DEFAULT false,
+  "sourceDelayMs" INTEGER NOT NULL DEFAULT 0,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "revokedAt" TIMESTAMP(3),
+  "activeSessionId" TEXT,
+  "activeSessionUntil" TIMESTAMP(3),
+  "createdByIdentity" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "GuestInvitation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "GuestCommand" (
+  "id" TEXT NOT NULL,
+  "invitationId" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "payload" JSONB NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'requested',
+  "failureReason" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deliveredAt" TIMESTAMP(3),
+  "acknowledgedAt" TIMESTAMP(3),
+  CONSTRAINT "GuestCommand_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "GuestEvent" (
+  "id" TEXT NOT NULL,
+  "invitationId" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "details" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "GuestEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "GuestInvitation_tokenHash_key" ON "GuestInvitation"("tokenHash");
+CREATE INDEX "GuestInvitation_programId_expiresAt_idx" ON "GuestInvitation"("programId", "expiresAt");
+CREATE UNIQUE INDEX "GuestInvitation_programId_slotNumber_key" ON "GuestInvitation"("programId", "slotNumber");
+CREATE INDEX "GuestCommand_invitationId_createdAt_idx" ON "GuestCommand"("invitationId", "createdAt");
+CREATE INDEX "GuestEvent_invitationId_createdAt_idx" ON "GuestEvent"("invitationId", "createdAt");
+ALTER TABLE "GuestCommand" ADD CONSTRAINT "GuestCommand_invitationId_fkey" FOREIGN KEY ("invitationId") REFERENCES "GuestInvitation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "GuestEvent" ADD CONSTRAINT "GuestEvent_invitationId_fkey" FOREIGN KEY ("invitationId") REFERENCES "GuestInvitation"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -222,3 +222,54 @@ model NowPlayingConsumer {
   @@unique([programStateId, name])
   @@unique([programStateId, position])
 }
+
+model GuestInvitation {
+  id                 String         @id @default(uuid())
+  tokenHash          String         @unique
+  programId          String
+  displayName        String
+  slotNumber         Int?
+  returnVideo        String         @default("program")
+  returnAudioBus     String         @default("master")
+  sourceGain         Float          @default(1)
+  sourceMuted        Boolean        @default(false)
+  sourceDelayMs      Int            @default(0)
+  expiresAt          DateTime
+  revokedAt          DateTime?
+  activeSessionId    String?
+  activeSessionUntil DateTime?
+  createdByIdentity  String
+  createdAt          DateTime       @default(now())
+  updatedAt          DateTime       @updatedAt
+  commands           GuestCommand[]
+  events             GuestEvent[]
+
+  @@index([programId, expiresAt])
+  @@unique([programId, slotNumber])
+}
+
+model GuestCommand {
+  id             String          @id @default(uuid())
+  invitationId   String
+  invitation     GuestInvitation @relation(fields: [invitationId], references: [id], onDelete: Cascade)
+  type           String
+  payload        Json
+  status         String          @default("requested")
+  failureReason  String?
+  createdAt      DateTime        @default(now())
+  deliveredAt    DateTime?
+  acknowledgedAt DateTime?
+
+  @@index([invitationId, createdAt])
+}
+
+model GuestEvent {
+  id           String          @id @default(uuid())
+  invitationId String
+  invitation   GuestInvitation @relation(fields: [invitationId], references: [id], onDelete: Cascade)
+  type         String
+  details      Json?
+  createdAt    DateTime        @default(now())
+
+  @@index([invitationId, createdAt])
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { StingersModule } from './stingers/stingers.module';
 import { RadioModule } from './radio/radio.module';
 import { AuthModule } from './auth/auth.module';
 import { TestAuthController } from './auth/test-auth.controller';
+import { WebrtcModule } from './webrtc/webrtc.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { TestAuthController } from './auth/test-auth.controller';
     MediaGroupsModule,
     StingersModule,
     RadioModule,
+    WebrtcModule,
   ],
   controllers: [AppController, TestAuthController],
   providers: [AppService],

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -66,7 +66,7 @@ async function bootstrap() {
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Renderer-Key'],
   });
 
   await app.listen(port, '0.0.0.0');
@@ -81,4 +81,4 @@ async function bootstrap() {
       : app.getHttpServer();
   programRealtimeService.attachToServer(upgradeServer as HttpServer);
 }
-bootstrap();
+void bootstrap();

--- a/backend/src/webrtc/webrtc.controller.ts
+++ b/backend/src/webrtc/webrtc.controller.ts
@@ -1,0 +1,151 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  Param,
+  Patch,
+  Post,
+  Req,
+} from '@nestjs/common';
+import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
+import { Public } from '../auth/public.decorator';
+import { RequirePermission } from '../auth/require-permission.decorator';
+import { WebrtcService } from './webrtc.service';
+
+type OperatorRequest = { user: { sub: string } };
+
+@Controller('webrtc')
+@RequirePermission(ALCANTARA_PERMISSIONS.webrtc.read)
+export class WebrtcController {
+  constructor(private readonly webrtc: WebrtcService) {}
+
+  @Get('config')
+  @Public()
+  config() {
+    return this.webrtc.getPublicConfig();
+  }
+
+  @Get('invitations')
+  listInvitations() {
+    return this.webrtc.listInvitations();
+  }
+
+  @Post('invitations')
+  @RequirePermission(ALCANTARA_PERMISSIONS.webrtc.operate)
+  createInvitation(
+    @Req() request: OperatorRequest,
+    @Body() body: Record<string, unknown>,
+  ) {
+    return this.webrtc.createInvitation(request.user.sub, body);
+  }
+
+  @Post('invitations/:id/replace')
+  @RequirePermission(ALCANTARA_PERMISSIONS.webrtc.operate)
+  replaceInvitation(@Req() request: OperatorRequest, @Param('id') id: string) {
+    return this.webrtc.replaceInvitation(request.user.sub, id);
+  }
+
+  @Delete('invitations/:id')
+  @RequirePermission(ALCANTARA_PERMISSIONS.webrtc.operate)
+  revokeInvitation(@Req() request: OperatorRequest, @Param('id') id: string) {
+    return this.webrtc.revokeInvitation(request.user.sub, id);
+  }
+
+  @Patch('invitations/:id/return')
+  @RequirePermission(ALCANTARA_PERMISSIONS.webrtc.operate)
+  updateReturn(
+    @Req() request: OperatorRequest,
+    @Param('id') id: string,
+    @Body() body: Record<string, unknown>,
+  ) {
+    return this.webrtc.updateReturn(request.user.sub, id, body);
+  }
+
+  @Post('join')
+  @Public()
+  join(@Body() body: Record<string, unknown>) {
+    return this.webrtc.redeemInvitation(body.invitation, body.sessionToken);
+  }
+
+  @Post('session/heartbeat')
+  @Public()
+  heartbeat(@Body() body: Record<string, unknown>) {
+    return this.webrtc.heartbeat(body.sessionToken, body.telemetry);
+  }
+
+  @Post('commands/:commandId/ack')
+  @Public()
+  acknowledge(
+    @Param('commandId') commandId: string,
+    @Body() body: Record<string, unknown>,
+  ) {
+    return this.webrtc.acknowledgeCommand(
+      body.sessionToken,
+      commandId,
+      body.status,
+    );
+  }
+
+  @Get('rooms/:programId/participants')
+  listParticipants(@Param('programId') programId: string) {
+    return this.webrtc.listParticipants(programId);
+  }
+
+  @Post('operator-token')
+  @RequirePermission(ALCANTARA_PERMISSIONS.webrtc.operate)
+  operatorToken(
+    @Req() request: OperatorRequest,
+    @Body() body: Record<string, unknown>,
+  ) {
+    return this.webrtc.createOperatorToken(request.user.sub, body.programId);
+  }
+
+  @Post('rooms/:programId/participants/:identity/control')
+  @RequirePermission(ALCANTARA_PERMISSIONS.webrtc.operate)
+  controlParticipant(
+    @Param('programId') programId: string,
+    @Param('identity') identity: string,
+    @Body() body: Record<string, unknown>,
+  ) {
+    return this.webrtc.controlParticipant(programId, identity, body);
+  }
+
+  @Delete('rooms/:programId/participants/:identity')
+  @RequirePermission(ALCANTARA_PERMISSIONS.webrtc.operate)
+  removeParticipant(
+    @Req() request: OperatorRequest,
+    @Param('programId') programId: string,
+    @Param('identity') identity: string,
+  ) {
+    return this.webrtc.removeParticipant(request.user.sub, programId, identity);
+  }
+
+  @Post('renderer-token')
+  @Public()
+  rendererToken(
+    @Headers('x-renderer-key') rendererKey: string | undefined,
+    @Body() body: Record<string, unknown>,
+  ) {
+    return this.webrtc.createRendererToken(rendererKey, body.programId);
+  }
+
+  @Post('renderer-state')
+  @Public()
+  rendererState(
+    @Headers('x-renderer-key') rendererKey: string | undefined,
+    @Body() body: Record<string, unknown>,
+  ) {
+    return this.webrtc.getRendererState(rendererKey, body.programId);
+  }
+
+  @Post('renderer-source-token')
+  @Public()
+  rendererSourceToken(
+    @Headers('x-renderer-key') rendererKey: string | undefined,
+    @Body() body: Record<string, unknown>,
+  ) {
+    return this.webrtc.createRendererSourceToken(rendererKey, body.programId);
+  }
+}

--- a/backend/src/webrtc/webrtc.module.ts
+++ b/backend/src/webrtc/webrtc.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { WebrtcController } from './webrtc.controller';
+import { WebrtcService } from './webrtc.service';
+
+@Module({
+  controllers: [WebrtcController],
+  providers: [WebrtcService, PrismaService],
+})
+export class WebrtcModule {}

--- a/backend/src/webrtc/webrtc.service.spec.ts
+++ b/backend/src/webrtc/webrtc.service.spec.ts
@@ -1,0 +1,186 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matchers are intentionally typed as any. */
+import {
+  ConflictException,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'node:crypto';
+import { WebrtcService } from './webrtc.service';
+
+describe('WebrtcService', () => {
+  const invitation = {
+    id: '11111111-1111-4111-8111-111111111111',
+    tokenHash: '',
+    programId: 'main',
+    displayName: 'Fictional Guest',
+    slotNumber: 1,
+    returnVideo: 'program',
+    returnAudioBus: 'master',
+    expiresAt: new Date(Date.now() + 86_400_000),
+    revokedAt: null as Date | null,
+    activeSessionId: null as string | null,
+    activeSessionUntil: null as Date | null,
+    createdByIdentity: 'operator-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  const token = `${invitation.id}.private-invitation-secret`;
+  invitation.tokenHash = createHash('sha256').update(token).digest('hex');
+
+  function setup() {
+    const prisma = {
+      guestInvitation: {
+        findMany: jest.fn().mockResolvedValue([]),
+        findUnique: jest.fn().mockResolvedValue({ ...invitation }),
+        findFirst: jest.fn().mockResolvedValue({ ...invitation }),
+        create: jest.fn().mockImplementation(({ data }) =>
+          Promise.resolve({
+            ...invitation,
+            ...data,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          }),
+        ),
+        update: jest
+          .fn()
+          .mockImplementation(({ data }) =>
+            Promise.resolve({ ...invitation, ...data }),
+          ),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      guestCommand: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      guestEvent: { create: jest.fn().mockResolvedValue({}) },
+    };
+    const livekit = {
+      listRooms: jest.fn().mockResolvedValue([]),
+      createRoom: jest.fn().mockResolvedValue({}),
+      listParticipants: jest.fn().mockResolvedValue([]),
+      removeParticipant: jest.fn().mockResolvedValue(undefined),
+      sendData: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = new WebrtcService(
+      new ConfigService({
+        LIVEKIT_WS_URL: 'ws://localhost:7880',
+        LIVEKIT_API_URL: 'http://localhost:7880',
+        LIVEKIT_API_KEY: 'devkey',
+        LIVEKIT_API_SECRET: 'devsecret-devsecret-devsecret-devsecret',
+        WEBRTC_SESSION_SECRET: 'session-secret-session-secret-session-secret',
+        WEBRTC_RENDERER_KEY: 'renderer-secret',
+      }),
+      prisma as never,
+    );
+    jest.spyOn(service as never, 'roomService', 'get').mockReturnValue(livekit);
+    return { service, prisma, livekit };
+  }
+
+  it('persists a default 24-hour invitation in the first reusable slot', async () => {
+    const { service, prisma, livekit } = setup();
+    const created = await service.createInvitation('operator-1', {
+      programId: 'MAIN',
+      displayName: ' Fictional Guest ',
+    });
+    expect(created).toMatchObject({
+      programId: 'main',
+      displayName: 'Fictional Guest',
+      slotNumber: 1,
+      status: 'available',
+    });
+    expect(created.invitation).toMatch(/^[0-9a-f-]{36}\.[A-Za-z0-9_-]+$/);
+    expect(prisma.guestInvitation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          tokenHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+          createdByIdentity: 'operator-1',
+        }),
+      }),
+    );
+    expect(livekit.createRoom).toHaveBeenCalledWith(
+      expect.objectContaining({ maxParticipants: 8, departureTimeout: 60 }),
+    );
+  });
+
+  it('issues a short-lived credential and signed reconnect session', async () => {
+    const { service, prisma } = setup();
+    const joined = await service.redeemInvitation(token, undefined);
+    expect(joined).toMatchObject({
+      roomName: 'alcantara-main',
+      participantIdentity: `guest-${invitation.id}`,
+      reconnectWindowSeconds: 60,
+    });
+    expect(joined.token.split('.')).toHaveLength(3);
+    expect(joined.sessionToken.split('.')).toHaveLength(3);
+    expect(prisma.guestInvitation.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ revokedAt: null }),
+        data: expect.objectContaining({
+          activeSessionId: expect.any(String),
+          activeSessionUntil: expect.any(Date),
+        }),
+      }),
+    );
+  });
+
+  it('prevents a second concurrent session from claiming the invitation', async () => {
+    const { service, prisma } = setup();
+    prisma.guestInvitation.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      service.redeemInvitation(token, undefined),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('rejects tampered, revoked, and expired invitations', async () => {
+    const { service, prisma } = setup();
+    await expect(
+      service.redeemInvitation(`${token}x`, undefined),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+    prisma.guestInvitation.findUnique.mockResolvedValueOnce({
+      ...invitation,
+      revokedAt: new Date(),
+    });
+    await expect(
+      service.redeemInvitation(token, undefined),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    prisma.guestInvitation.findUnique.mockResolvedValueOnce({
+      ...invitation,
+      expiresAt: new Date(0),
+    });
+    await expect(
+      service.redeemInvitation(token, undefined),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('revokes persistence and removes an active participant', async () => {
+    const { service, prisma, livekit } = setup();
+    await expect(
+      service.revokeInvitation('operator-1', invitation.id),
+    ).resolves.toEqual({ id: invitation.id, status: 'revoked' });
+    expect(prisma.guestInvitation.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: invitation.id },
+        data: expect.objectContaining({
+          revokedAt: expect.any(Date),
+          activeSessionId: null,
+        }),
+      }),
+    );
+    expect(livekit.removeParticipant).toHaveBeenCalledWith(
+      'alcantara-main',
+      `guest-${invitation.id}`,
+    );
+  });
+
+  it('requires an explicit renderer machine credential', async () => {
+    const { service } = setup();
+    await expect(
+      service.createRendererToken(undefined, 'main'),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+    await expect(
+      service.createRendererToken('renderer-secret', 'main'),
+    ).resolves.toMatchObject({ roomName: 'alcantara-main' });
+  });
+});

--- a/backend/src/webrtc/webrtc.service.ts
+++ b/backend/src/webrtc/webrtc.service.ts
@@ -1,0 +1,1001 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { GuestCommand, GuestInvitation, Prisma } from '@prisma/client';
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from 'node:crypto';
+import {
+  AccessToken,
+  DataPacket_Kind,
+  RoomServiceClient,
+  TrackSource,
+} from 'livekit-server-sdk';
+import { PrismaService } from '../prisma.service';
+
+type ReturnVideo = 'program' | 'preview' | 'none';
+type ReturnAudioBus = 'master' | 'monitor' | `aux-${number}`;
+type CommandStatus = 'accepted' | 'rejected' | 'read' | 'acknowledged';
+
+const MAX_GUESTS = 6;
+const SESSION_LEASE_MS = 60_000;
+const JOIN_TOKEN_TTL = '5m';
+
+@Injectable()
+export class WebrtcService {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  getPublicConfig() {
+    return { enabled: this.hasConfiguration(), maxGuests: MAX_GUESTS };
+  }
+
+  async listInvitations() {
+    const now = new Date();
+    const invitations = await this.prisma.guestInvitation.findMany({
+      orderBy: [
+        { programId: 'asc' },
+        { slotNumber: 'asc' },
+        { createdAt: 'desc' },
+      ],
+      include: { commands: { orderBy: { createdAt: 'desc' }, take: 10 } },
+    });
+    return invitations.map((invitation) =>
+      this.presentInvitation(invitation, now),
+    );
+  }
+
+  async createInvitation(
+    operatorIdentity: string,
+    body: Record<string, unknown>,
+  ) {
+    this.requireConfiguration();
+    const programId = this.normalizeProgramId(body.programId);
+    const displayName = this.normalizeDisplayName(body.displayName);
+    const expiresInHours = this.normalizeExpiration(body.expiresInHours);
+    const slotNumber = await this.resolveSlot(programId, body.slotNumber);
+    const returnVideo = this.normalizeReturnVideo(body.returnVideo);
+    const returnAudioBus = this.normalizeReturnAudioBus(body.returnAudioBus);
+    const sourceGain = this.normalizeSourceGain(body.sourceGain);
+    const sourceMuted = this.normalizeSourceMuted(body.sourceMuted);
+    const sourceDelayMs = this.normalizeSourceDelay(body.sourceDelayMs);
+    const secret = randomBytes(32).toString('base64url');
+    const id = randomUUID();
+    const invitationToken = `${id}.${secret}`;
+    const expiresAt = new Date(Date.now() + expiresInHours * 60 * 60 * 1000);
+
+    await this.ensureRoom(programId);
+    const invitation = await this.prisma.guestInvitation.create({
+      data: {
+        id,
+        tokenHash: this.hash(invitationToken),
+        programId,
+        displayName,
+        slotNumber,
+        returnVideo,
+        returnAudioBus,
+        sourceGain,
+        sourceMuted,
+        sourceDelayMs,
+        expiresAt,
+        createdByIdentity: operatorIdentity,
+        events: {
+          create: { type: 'created', details: { expiresInHours, slotNumber } },
+        },
+      },
+    });
+    return {
+      ...this.presentInvitation(invitation, new Date()),
+      invitation: invitationToken,
+      invitationPath: `/guest/${encodeURIComponent(invitationToken)}`,
+    };
+  }
+
+  async replaceInvitation(operatorIdentity: string, id: string) {
+    const existing = await this.requireInvitation(id);
+    await this.revokeInvitation(operatorIdentity, id);
+    return this.createInvitation(operatorIdentity, {
+      programId: existing.programId,
+      displayName: existing.displayName,
+      expiresInHours: Math.max(
+        1,
+        Math.ceil((existing.expiresAt.getTime() - Date.now()) / 3_600_000),
+      ),
+      slotNumber: existing.slotNumber,
+      returnVideo: existing.returnVideo,
+      returnAudioBus: existing.returnAudioBus,
+      sourceGain: existing.sourceGain,
+      sourceMuted: existing.sourceMuted,
+      sourceDelayMs: existing.sourceDelayMs,
+    });
+  }
+
+  async revokeInvitation(operatorIdentity: string, id: string) {
+    const invitation = await this.requireInvitation(id);
+    if (!invitation.revokedAt) {
+      await this.prisma.guestInvitation.update({
+        where: { id },
+        data: {
+          revokedAt: new Date(),
+          slotNumber: null,
+          activeSessionId: null,
+          activeSessionUntil: null,
+          events: {
+            create: { type: 'revoked', details: { operatorIdentity } },
+          },
+        },
+      });
+    }
+    await this.disconnectIfPresent(
+      invitation.programId,
+      this.guestIdentity(id),
+    );
+    return { id, status: 'revoked' };
+  }
+
+  async updateReturn(
+    operatorIdentity: string,
+    id: string,
+    body: Record<string, unknown>,
+  ) {
+    await this.requireInvitation(id);
+    const returnVideo = this.normalizeReturnVideo(body.returnVideo);
+    const returnAudioBus = this.normalizeReturnAudioBus(body.returnAudioBus);
+    const sourceGain = this.normalizeSourceGain(body.sourceGain);
+    const sourceMuted = this.normalizeSourceMuted(body.sourceMuted);
+    const sourceDelayMs = this.normalizeSourceDelay(body.sourceDelayMs);
+    const updated = await this.prisma.guestInvitation.update({
+      where: { id },
+      data: {
+        returnVideo,
+        returnAudioBus,
+        sourceGain,
+        sourceMuted,
+        sourceDelayMs,
+        events: {
+          create: {
+            type: 'return_changed',
+            details: {
+              operatorIdentity,
+              returnVideo,
+              returnAudioBus,
+              sourceGain,
+              sourceMuted,
+              sourceDelayMs,
+            },
+          },
+        },
+      },
+    });
+    await this.sendGuestData(updated, {
+      version: 1,
+      id: randomUUID(),
+      type: 'return',
+      returnVideo,
+      returnAudioBus,
+      sourceGain,
+      sourceMuted,
+      sourceDelayMs,
+    });
+    return this.presentInvitation(updated, new Date());
+  }
+
+  async redeemInvitation(invitationValue: unknown, sessionTokenValue: unknown) {
+    this.requireConfiguration();
+    const invitationToken = this.requireString(invitationValue, 'Invitation');
+    const invitation = await this.verifyInvitationToken(invitationToken);
+    const now = new Date();
+    if (invitation.revokedAt)
+      throw new ForbiddenException('This invitation was revoked.');
+    if (invitation.expiresAt <= now)
+      throw new UnauthorizedException('This invitation expired.');
+
+    let sessionId: string | null = null;
+    if (typeof sessionTokenValue === 'string' && sessionTokenValue) {
+      sessionId = this.verifySessionToken(sessionTokenValue, invitation.id);
+    }
+    if (!sessionId) sessionId = randomUUID();
+
+    const claimed = await this.prisma.guestInvitation.updateMany({
+      where: {
+        id: invitation.id,
+        revokedAt: null,
+        expiresAt: { gt: now },
+        OR: [
+          { activeSessionId: null },
+          { activeSessionUntil: { lt: now } },
+          { activeSessionId: sessionId },
+        ],
+      },
+      data: {
+        activeSessionId: sessionId,
+        activeSessionUntil: new Date(now.getTime() + SESSION_LEASE_MS),
+      },
+    });
+    if (claimed.count !== 1) {
+      throw new ConflictException(
+        'This invitation is already active in another session.',
+      );
+    }
+
+    const identity = this.guestIdentity(invitation.id);
+    const token = new AccessToken(this.apiKey, this.apiSecret, {
+      identity,
+      name: invitation.displayName,
+      ttl: JOIN_TOKEN_TTL,
+      metadata: JSON.stringify({
+        role: 'guest',
+        invitationId: invitation.id,
+        slotNumber: invitation.slotNumber,
+      }),
+    });
+    token.addGrant({
+      room: this.roomName(invitation.programId),
+      roomJoin: true,
+      canPublish: true,
+      canPublishSources: [TrackSource.CAMERA, TrackSource.MICROPHONE],
+      canSubscribe:
+        invitation.returnVideo !== 'none' || Boolean(invitation.returnAudioBus),
+      canPublishData: true,
+    });
+    await this.prisma.guestEvent.create({
+      data: { invitationId: invitation.id, type: 'token_issued' },
+    });
+    return {
+      serverUrl: this.wsUrl,
+      token: await token.toJwt(),
+      sessionToken: this.signSessionToken(invitation.id, sessionId),
+      roomName: this.roomName(invitation.programId),
+      participantIdentity: identity,
+      displayName: invitation.displayName,
+      programId: invitation.programId,
+      slotNumber: invitation.slotNumber,
+      returnVideo: invitation.returnVideo,
+      returnAudioBus: invitation.returnAudioBus,
+      sourceGain: invitation.sourceGain,
+      sourceMuted: invitation.sourceMuted,
+      sourceDelayMs: invitation.sourceDelayMs,
+      reconnectWindowSeconds: SESSION_LEASE_MS / 1000,
+    };
+  }
+
+  async heartbeat(sessionTokenValue: unknown, telemetryValue: unknown) {
+    const session = await this.requireActiveSession(sessionTokenValue);
+    const telemetry = this.normalizeTelemetry(telemetryValue);
+    const activeSessionUntil = new Date(Date.now() + SESSION_LEASE_MS);
+    await this.prisma.guestInvitation.update({
+      where: { id: session.invitation.id },
+      data: {
+        activeSessionUntil,
+        ...(telemetry
+          ? { events: { create: { type: 'telemetry', details: telemetry } } }
+          : {}),
+      },
+    });
+    return { activeSessionUntil: activeSessionUntil.toISOString() };
+  }
+
+  async acknowledgeCommand(
+    sessionTokenValue: unknown,
+    commandId: string,
+    statusValue: unknown,
+  ) {
+    const session = await this.requireActiveSession(sessionTokenValue);
+    const status = this.normalizeCommandStatus(statusValue);
+    const command = await this.prisma.guestCommand.findFirst({
+      where: { id: commandId, invitationId: session.invitation.id },
+    });
+    if (!command) throw new NotFoundException('Command not found.');
+    const acknowledgedAt = new Date();
+    return this.prisma.guestCommand.update({
+      where: { id: commandId },
+      data: { status, acknowledgedAt },
+    });
+  }
+
+  async listParticipants(programIdValue: unknown) {
+    this.requireConfiguration();
+    const programId = this.normalizeProgramId(programIdValue);
+    const invitations = await this.prisma.guestInvitation.findMany({
+      where: { programId, revokedAt: null, expiresAt: { gt: new Date() } },
+      include: { commands: { orderBy: { createdAt: 'desc' }, take: 10 } },
+      orderBy: { slotNumber: 'asc' },
+    });
+    let participants: Awaited<
+      ReturnType<RoomServiceClient['listParticipants']>
+    > = [];
+    try {
+      participants = await this.roomService.listParticipants(
+        this.roomName(programId),
+      );
+    } catch (error) {
+      if (!this.isRoomMissing(error)) throw this.livekitUnavailable(error);
+    }
+    const liveByIdentity = new Map(
+      participants.map((participant) => [participant.identity, participant]),
+    );
+    return {
+      roomName: this.roomName(programId),
+      participants: invitations.map((invitation) => {
+        const identity = this.guestIdentity(invitation.id);
+        const participant = liveByIdentity.get(identity);
+        return {
+          invitationId: invitation.id,
+          identity,
+          name: invitation.displayName,
+          slotNumber: invitation.slotNumber,
+          connectionState: participant
+            ? 'connected'
+            : invitation.activeSessionUntil &&
+                invitation.activeSessionUntil > new Date()
+              ? 'reconnecting'
+              : 'offline',
+          reconnectUntil: invitation.activeSessionUntil?.toISOString() ?? null,
+          returnVideo: invitation.returnVideo,
+          returnAudioBus: invitation.returnAudioBus,
+          sourceGain: invitation.sourceGain,
+          sourceMuted: invitation.sourceMuted,
+          sourceDelayMs: invitation.sourceDelayMs,
+          tracks:
+            participant?.tracks.map((track) => ({
+              sid: track.sid,
+              source: TrackSource[track.source].toLowerCase(),
+              muted: track.muted,
+              width: track.width,
+              height: track.height,
+              mimeType: track.mimeType,
+            })) ?? [],
+          commands: invitation.commands,
+        };
+      }),
+    };
+  }
+
+  async controlParticipant(
+    programIdValue: unknown,
+    identityValue: unknown,
+    body: Record<string, unknown>,
+  ) {
+    this.requireConfiguration();
+    const programId = this.normalizeProgramId(programIdValue);
+    const identity = this.normalizeGuestIdentity(identityValue);
+    const invitation = await this.invitationForIdentity(programId, identity);
+    const command = this.normalizeCommand(body);
+    const persisted = await this.prisma.guestCommand.create({
+      data: {
+        invitationId: invitation.id,
+        type: command.type,
+        payload: command as unknown as Prisma.InputJsonValue,
+      },
+    });
+    try {
+      if (command.type === 'media' && command.enabled === false) {
+        const participant = await this.roomService.getParticipant(
+          this.roomName(programId),
+          identity,
+        );
+        const source =
+          command.device === 'camera'
+            ? TrackSource.CAMERA
+            : TrackSource.MICROPHONE;
+        const track = participant.tracks.find(
+          (candidate) => candidate.source === source,
+        );
+        if (!track)
+          throw new BadRequestException(
+            `${command.device} track is unavailable.`,
+          );
+        await this.roomService.mutePublishedTrack(
+          this.roomName(programId),
+          identity,
+          track.sid,
+          true,
+        );
+      } else {
+        await this.sendGuestData(invitation, {
+          ...command,
+          id: persisted.id,
+          sentAt: persisted.createdAt.toISOString(),
+        });
+      }
+      return this.prisma.guestCommand.update({
+        where: { id: persisted.id },
+        data: { status: 'delivered', deliveredAt: new Date() },
+      });
+    } catch (error) {
+      const failureReason =
+        error instanceof Error
+          ? error.message.slice(0, 240)
+          : 'LiveKit command failed';
+      await this.prisma.guestCommand.update({
+        where: { id: persisted.id },
+        data: { status: 'failed', failureReason },
+      });
+      throw this.livekitUnavailable(error);
+    }
+  }
+
+  async removeParticipant(
+    operatorIdentity: string,
+    programIdValue: unknown,
+    identityValue: unknown,
+  ) {
+    const programId = this.normalizeProgramId(programIdValue);
+    const identity = this.normalizeGuestIdentity(identityValue);
+    const invitation = await this.invitationForIdentity(programId, identity);
+    await this.disconnectIfPresent(programId, identity);
+    await this.prisma.guestInvitation.update({
+      where: { id: invitation.id },
+      data: {
+        activeSessionId: null,
+        activeSessionUntil: null,
+        events: { create: { type: 'removed', details: { operatorIdentity } } },
+      },
+    });
+    return { identity, status: 'removed' };
+  }
+
+  async createRendererToken(
+    rendererKey: string | undefined,
+    programIdValue: unknown,
+  ) {
+    this.requireConfiguration();
+    this.requireRendererKey(rendererKey);
+    const programId = this.normalizeProgramId(programIdValue);
+    const token = new AccessToken(this.apiKey, this.apiSecret, {
+      identity: `renderer-${programId}-${randomUUID()}`,
+      name: `Alcantara return publisher ${programId}`,
+      ttl: '5m',
+      metadata: JSON.stringify({ role: 'renderer', programId }),
+    });
+    token.addGrant({
+      room: this.roomName(programId),
+      roomJoin: true,
+      canPublish: true,
+      canPublishSources: [
+        TrackSource.CAMERA,
+        TrackSource.MICROPHONE,
+        TrackSource.SCREEN_SHARE,
+        TrackSource.SCREEN_SHARE_AUDIO,
+      ],
+      canSubscribe: true,
+      canPublishData: true,
+      hidden: false,
+    });
+    return {
+      serverUrl: this.wsUrl,
+      token: await token.toJwt(),
+      roomName: this.roomName(programId),
+    };
+  }
+
+  async getRendererState(
+    rendererKey: string | undefined,
+    programIdValue: unknown,
+  ) {
+    this.requireConfiguration();
+    this.requireRendererKey(rendererKey);
+    const programId = this.normalizeProgramId(programIdValue);
+    const invitations = await this.prisma.guestInvitation.findMany({
+      where: { programId, revokedAt: null, expiresAt: { gt: new Date() } },
+      orderBy: { slotNumber: 'asc' },
+    });
+    return {
+      programId,
+      routes: invitations.map((invitation) => ({
+        participantIdentity: this.guestIdentity(invitation.id),
+        slotNumber: invitation.slotNumber,
+        returnVideo: invitation.returnVideo,
+        returnAudioBus: invitation.returnAudioBus,
+        sourceGain: invitation.sourceGain,
+        sourceMuted: invitation.sourceMuted,
+        sourceDelayMs: invitation.sourceDelayMs,
+      })),
+    };
+  }
+
+  async createRendererSourceToken(
+    rendererKey: string | undefined,
+    programIdValue: unknown,
+  ) {
+    this.requireConfiguration();
+    this.requireRendererKey(rendererKey);
+    const programId = this.normalizeProgramId(programIdValue);
+    const token = new AccessToken(this.apiKey, this.apiSecret, {
+      identity: `renderer-source-${programId}-${randomUUID()}`,
+      name: `Alcantara guest source ${programId}`,
+      ttl: '5m',
+      metadata: JSON.stringify({ role: 'renderer-source', programId }),
+    });
+    token.addGrant({
+      room: this.roomName(programId),
+      roomJoin: true,
+      canPublish: false,
+      canSubscribe: true,
+      canPublishData: false,
+      hidden: true,
+    });
+    return {
+      serverUrl: this.wsUrl,
+      token: await token.toJwt(),
+      roomName: this.roomName(programId),
+    };
+  }
+
+  async createOperatorToken(operatorIdentity: string, programIdValue: unknown) {
+    this.requireConfiguration();
+    const programId = this.normalizeProgramId(programIdValue);
+    const token = new AccessToken(this.apiKey, this.apiSecret, {
+      identity: `operator-${createHash('sha256').update(operatorIdentity).digest('hex').slice(0, 20)}-${randomUUID()}`,
+      name: 'Alcantara operator',
+      ttl: '5m',
+      metadata: JSON.stringify({ role: 'operator' }),
+    });
+    token.addGrant({
+      room: this.roomName(programId),
+      roomJoin: true,
+      canPublish: true,
+      canPublishSources: [TrackSource.MICROPHONE],
+      canSubscribe: true,
+      canPublishData: true,
+      hidden: true,
+    });
+    return {
+      serverUrl: this.wsUrl,
+      token: await token.toJwt(),
+      roomName: this.roomName(programId),
+    };
+  }
+
+  private async requireActiveSession(sessionTokenValue: unknown) {
+    const token = this.requireString(sessionTokenValue, 'Session token');
+    const [invitationId] = token.split('.');
+    if (!invitationId)
+      throw new UnauthorizedException('Invalid guest session.');
+    const sessionId = this.verifySessionToken(token, invitationId);
+    const invitation = await this.prisma.guestInvitation.findFirst({
+      where: {
+        id: invitationId,
+        activeSessionId: sessionId,
+        activeSessionUntil: { gt: new Date() },
+        revokedAt: null,
+        expiresAt: { gt: new Date() },
+      },
+    });
+    if (!invitation)
+      throw new UnauthorizedException('Guest session is inactive.');
+    return { invitation, sessionId };
+  }
+
+  private async verifyInvitationToken(token: string) {
+    const [id, secret, extra] = token.split('.');
+    if (!id || !secret || extra)
+      throw new UnauthorizedException('Invalid guest invitation.');
+    const invitation = await this.prisma.guestInvitation.findUnique({
+      where: { id },
+    });
+    if (
+      !invitation ||
+      !this.safeEqual(this.hash(token), invitation.tokenHash)
+    ) {
+      throw new UnauthorizedException('Invalid guest invitation.');
+    }
+    return invitation;
+  }
+
+  private signSessionToken(invitationId: string, sessionId: string) {
+    const payload = `${invitationId}.${sessionId}`;
+    const signature = createHmac('sha256', this.sessionSecret)
+      .update(payload)
+      .digest('base64url');
+    return `${payload}.${signature}`;
+  }
+
+  private verifySessionToken(token: string, invitationId: string) {
+    const [tokenInvitationId, sessionId, signature, extra] = token.split('.');
+    if (
+      !tokenInvitationId ||
+      tokenInvitationId !== invitationId ||
+      !sessionId ||
+      !signature ||
+      extra
+    ) {
+      throw new UnauthorizedException('Invalid guest session.');
+    }
+    const payload = `${tokenInvitationId}.${sessionId}`;
+    const expected = createHmac('sha256', this.sessionSecret)
+      .update(payload)
+      .digest('base64url');
+    if (!this.safeEqual(signature, expected))
+      throw new UnauthorizedException('Invalid guest session.');
+    return sessionId;
+  }
+
+  private normalizeCommand(body: Record<string, unknown>) {
+    if (body.type === 'media') {
+      if (
+        !['camera', 'microphone'].includes(String(body.device)) ||
+        typeof body.enabled !== 'boolean'
+      ) {
+        throw new BadRequestException(
+          'A media command requires camera/microphone and enabled state.',
+        );
+      }
+      return {
+        version: 1 as const,
+        type: 'media' as const,
+        device: body.device as 'camera' | 'microphone',
+        enabled: body.enabled,
+      };
+    }
+    if (body.type === 'cue') {
+      if (!['standby', 'live', 'wrap'].includes(String(body.cue)))
+        throw new BadRequestException('Invalid cue.');
+      return {
+        version: 1 as const,
+        type: 'cue' as const,
+        cue: body.cue as string,
+      };
+    }
+    if (body.type === 'message') {
+      const text = this.requireString(body.text, 'Message').slice(0, 500);
+      return { version: 1 as const, type: 'message' as const, text };
+    }
+    if (body.type === 'talkback') {
+      if (typeof body.enabled !== 'boolean')
+        throw new BadRequestException('Talkback requires enabled state.');
+      return {
+        version: 1 as const,
+        type: 'talkback' as const,
+        enabled: body.enabled,
+      };
+    }
+    throw new BadRequestException('Unsupported participant command.');
+  }
+
+  private normalizeTelemetry(value: unknown): Prisma.InputJsonValue | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+      return null;
+    const source = value as Record<string, unknown>;
+    const allowed: Record<string, string | number | boolean> = {};
+    for (const key of [
+      'connectionState',
+      'iceTransport',
+      'quality',
+      'returnFeedHealth',
+      'mixMinusHealth',
+      'cameraEnabled',
+      'microphoneEnabled',
+    ]) {
+      const candidate = source[key];
+      if (typeof candidate === 'string') allowed[key] = candidate.slice(0, 40);
+      if (typeof candidate === 'boolean') allowed[key] = candidate;
+    }
+    for (const key of [
+      'packetLoss',
+      'jitterMs',
+      'roundTripMs',
+      'bitrateKbps',
+      'width',
+      'height',
+      'frameRate',
+    ]) {
+      const candidate = source[key];
+      if (typeof candidate === 'number' && Number.isFinite(candidate))
+        allowed[key] = Math.max(0, Math.min(candidate, 1_000_000));
+    }
+    return allowed;
+  }
+
+  private normalizeCommandStatus(value: unknown): CommandStatus {
+    if (
+      value === 'accepted' ||
+      value === 'rejected' ||
+      value === 'read' ||
+      value === 'acknowledged'
+    )
+      return value;
+    throw new BadRequestException('Invalid acknowledgement status.');
+  }
+
+  private normalizeProgramId(value: unknown) {
+    const normalized = this.requireString(value, 'programId')
+      .trim()
+      .toLowerCase();
+    if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(normalized))
+      throw new BadRequestException('Invalid programId.');
+    return normalized;
+  }
+
+  private normalizeDisplayName(value: unknown) {
+    return this.requireString(value, 'displayName').trim().slice(0, 80);
+  }
+
+  private normalizeExpiration(value: unknown) {
+    if (value === undefined) return 24;
+    if (
+      typeof value !== 'number' ||
+      !Number.isInteger(value) ||
+      value < 1 ||
+      value > 168
+    ) {
+      throw new BadRequestException(
+        'expiresInHours must be an integer from 1 to 168.',
+      );
+    }
+    return value;
+  }
+
+  private normalizeReturnVideo(value: unknown): ReturnVideo {
+    if (value === undefined) return 'program';
+    if (value === 'program' || value === 'preview' || value === 'none')
+      return value;
+    throw new BadRequestException(
+      'returnVideo must be program, preview, or none.',
+    );
+  }
+
+  private normalizeReturnAudioBus(value: unknown): ReturnAudioBus {
+    if (value === undefined) return 'master';
+    if (
+      value === 'master' ||
+      value === 'monitor' ||
+      (typeof value === 'string' && /^aux-[1-8]$/.test(value))
+    )
+      return value as ReturnAudioBus;
+    throw new BadRequestException(
+      'returnAudioBus must be master, monitor, or aux-1 through aux-8.',
+    );
+  }
+
+  private normalizeSourceGain(value: unknown) {
+    if (value === undefined) return 1;
+    if (
+      typeof value !== 'number' ||
+      !Number.isFinite(value) ||
+      value < 0 ||
+      value > 1
+    ) {
+      throw new BadRequestException('sourceGain must be between 0 and 1.');
+    }
+    return value;
+  }
+
+  private normalizeSourceMuted(value: unknown) {
+    if (value === undefined) return false;
+    if (typeof value !== 'boolean')
+      throw new BadRequestException('sourceMuted must be boolean.');
+    return value;
+  }
+
+  private normalizeSourceDelay(value: unknown) {
+    if (value === undefined) return 0;
+    if (
+      typeof value !== 'number' ||
+      !Number.isInteger(value) ||
+      value < 0 ||
+      value > 2000
+    ) {
+      throw new BadRequestException(
+        'sourceDelayMs must be an integer from 0 to 2000.',
+      );
+    }
+    return value;
+  }
+
+  private async resolveSlot(programId: string, value: unknown) {
+    const occupied = await this.prisma.guestInvitation.findMany({
+      where: {
+        programId,
+        revokedAt: null,
+        expiresAt: { gt: new Date() },
+        slotNumber: { not: null },
+      },
+      select: { slotNumber: true },
+    });
+    const occupiedSlots = new Set(occupied.map((item) => item.slotNumber));
+    if (value !== undefined) {
+      if (
+        typeof value !== 'number' ||
+        !Number.isInteger(value) ||
+        value < 1 ||
+        value > MAX_GUESTS
+      )
+        throw new BadRequestException('slotNumber must be 1 through 6.');
+      if (occupiedSlots.has(value))
+        throw new ConflictException(`Guest slot ${value} is already assigned.`);
+      return value;
+    }
+    for (let slot = 1; slot <= MAX_GUESTS; slot += 1)
+      if (!occupiedSlots.has(slot)) return slot;
+    throw new ConflictException('All six guest slots are assigned.');
+  }
+
+  private presentInvitation(
+    invitation: GuestInvitation & { commands?: GuestCommand[] },
+    now: Date,
+  ) {
+    const status = invitation.revokedAt
+      ? 'revoked'
+      : invitation.expiresAt <= now
+        ? 'expired'
+        : invitation.activeSessionUntil && invitation.activeSessionUntil > now
+          ? 'active'
+          : 'available';
+    return {
+      id: invitation.id,
+      programId: invitation.programId,
+      displayName: invitation.displayName,
+      slotNumber: invitation.slotNumber,
+      returnVideo: invitation.returnVideo,
+      returnAudioBus: invitation.returnAudioBus,
+      sourceGain: invitation.sourceGain,
+      sourceMuted: invitation.sourceMuted,
+      sourceDelayMs: invitation.sourceDelayMs,
+      expiresAt: invitation.expiresAt.toISOString(),
+      revokedAt: invitation.revokedAt?.toISOString() ?? null,
+      createdAt: invitation.createdAt.toISOString(),
+      status,
+      commands: invitation.commands ?? [],
+    };
+  }
+
+  private async ensureRoom(programId: string) {
+    try {
+      const roomName = this.roomName(programId);
+      const rooms = await this.roomService.listRooms([roomName]);
+      if (!rooms.length)
+        await this.roomService.createRoom({
+          name: roomName,
+          maxParticipants: 8,
+          emptyTimeout: 300,
+          departureTimeout: 60,
+        });
+    } catch (error) {
+      throw this.livekitUnavailable(error);
+    }
+  }
+
+  private async sendGuestData(
+    invitation: { id: string; programId: string },
+    payload: object,
+  ) {
+    await this.roomService.sendData(
+      this.roomName(invitation.programId),
+      Buffer.from(JSON.stringify(payload)),
+      DataPacket_Kind.RELIABLE,
+      {
+        destinationIdentities: [this.guestIdentity(invitation.id)],
+        topic: 'alcantara-director',
+      },
+    );
+  }
+
+  private async disconnectIfPresent(programId: string, identity: string) {
+    try {
+      await this.roomService.removeParticipant(
+        this.roomName(programId),
+        identity,
+      );
+    } catch (error) {
+      if (
+        !this.isRoomMissing(error) &&
+        !/participant.*not found/i.test(this.errorMessage(error))
+      )
+        throw this.livekitUnavailable(error);
+    }
+  }
+
+  private async invitationForIdentity(programId: string, identity: string) {
+    const id = identity.replace(/^guest-/, '');
+    const invitation = await this.prisma.guestInvitation.findFirst({
+      where: { id, programId, revokedAt: null, expiresAt: { gt: new Date() } },
+    });
+    if (!invitation)
+      throw new NotFoundException('Active invitation not found.');
+    return invitation;
+  }
+
+  private async requireInvitation(id: string) {
+    const invitation = await this.prisma.guestInvitation.findUnique({
+      where: { id },
+    });
+    if (!invitation) throw new NotFoundException('Invitation not found.');
+    return invitation;
+  }
+
+  private normalizeGuestIdentity(value: unknown) {
+    const identity = this.requireString(value, 'participant identity');
+    if (!/^guest-[0-9a-f-]{36}$/.test(identity))
+      throw new BadRequestException('Invalid guest identity.');
+    return identity;
+  }
+
+  private requireString(value: unknown, name: string) {
+    if (typeof value !== 'string' || !value.trim())
+      throw new BadRequestException(`${name} is required.`);
+    return value.trim();
+  }
+
+  private hash(value: string) {
+    return createHash('sha256').update(value).digest('hex');
+  }
+
+  private safeEqual(left: string, right: string) {
+    const leftBuffer = Buffer.from(left);
+    const rightBuffer = Buffer.from(right);
+    return (
+      leftBuffer.length === rightBuffer.length &&
+      timingSafeEqual(leftBuffer, rightBuffer)
+    );
+  }
+
+  private requireRendererKey(rendererKey: string | undefined) {
+    const expected = this.config.get<string>('WEBRTC_RENDERER_KEY') ?? '';
+    if (!expected || !rendererKey || !this.safeEqual(rendererKey, expected)) {
+      throw new UnauthorizedException('Renderer credential required.');
+    }
+  }
+
+  private guestIdentity(invitationId: string) {
+    return `guest-${invitationId}`;
+  }
+  private roomName(programId: string) {
+    return `alcantara-${programId}`;
+  }
+  private isRoomMissing(error: unknown) {
+    return /room.*not found|does not exist/i.test(this.errorMessage(error));
+  }
+  private errorMessage(error: unknown) {
+    return error instanceof Error ? error.message : 'Unknown LiveKit error';
+  }
+  private livekitUnavailable(error: unknown) {
+    return new ServiceUnavailableException(
+      `WebRTC control plane unavailable: ${this.errorMessage(error)}`,
+    );
+  }
+
+  private get roomService() {
+    return new RoomServiceClient(this.apiUrl, this.apiKey, this.apiSecret);
+  }
+  private get wsUrl() {
+    return this.config.get<string>('LIVEKIT_WS_URL') ?? '';
+  }
+  private get apiUrl() {
+    return (
+      this.config.get<string>('LIVEKIT_API_URL') ??
+      this.wsUrl.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:')
+    );
+  }
+  private get apiKey() {
+    return this.config.get<string>('LIVEKIT_API_KEY') ?? '';
+  }
+  private get apiSecret() {
+    return this.config.get<string>('LIVEKIT_API_SECRET') ?? '';
+  }
+  private get sessionSecret() {
+    return this.config.get<string>('WEBRTC_SESSION_SECRET') ?? '';
+  }
+  private hasConfiguration() {
+    return Boolean(
+      this.wsUrl && this.apiKey && this.apiSecret && this.sessionSecret,
+    );
+  }
+  private requireConfiguration() {
+    if (!this.hasConfiguration())
+      throw new ServiceUnavailableException('WebRTC is not configured.');
+  }
+}

--- a/compose.yml
+++ b/compose.yml
@@ -2,6 +2,22 @@
 name: alcantara-local
 
 services:
+  livekit:
+    image: livekit/livekit-server:v1.13.4
+    command: ['--config', '/etc/livekit.yaml', '--bind', '0.0.0.0']
+    volumes:
+      - ./infra/livekit.dev.yaml:/etc/livekit.yaml:ro
+    ports:
+      - '7880:7880'
+      - '7881:7881'
+      - '7882:7882/udp'
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -q -O /dev/null http://localhost:7880 || exit 1']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
   alcantara-postgres:
     image: postgres:17-alpine
     environment:
@@ -82,6 +98,12 @@ services:
       POMPEII_GRPC_TLS: 'false'
       AUTH_MODE: test
       TEST_AUTH_SECRET: alcantara-pompeii-local-test-secret-change-me
+      LIVEKIT_WS_URL: ws://localhost:7880
+      LIVEKIT_API_URL: http://livekit:7880
+      LIVEKIT_API_KEY: devkey
+      LIVEKIT_API_SECRET: devsecret-devsecret-devsecret-devsecret
+      WEBRTC_SESSION_SECRET: alcantara-local-session-secret-change-me-now
+      WEBRTC_RENDERER_KEY: alcantara-local-renderer-secret-change-me-now
       CHOKIDAR_USEPOLLING: 'true'
     ports:
       - '${BACKEND_PORT:-3000}:${BACKEND_PORT:-3000}'
@@ -96,6 +118,8 @@ services:
         condition: service_healthy
       pompeii-seed:
         condition: service_completed_successfully
+      livekit:
+        condition: service_healthy
     healthcheck:
       test: ['CMD', 'node', '-e', "fetch('http://localhost:${BACKEND_PORT:-3000}/').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
       interval: 5s

--- a/frontend/app/auth/permissions.ts
+++ b/frontend/app/auth/permissions.ts
@@ -1,14 +1,41 @@
 export const PERMISSIONS = {
   access: 'alcantara:access',
-  program: { read: 'alcantara:program:read', manage: 'alcantara:program:manage', operate: 'alcantara:program:operate' },
-  flight: { read: 'alcantara:flight:read', manage: 'alcantara:flight:manage', operate: 'alcantara:flight:operate' },
-  scene: { read: 'alcantara:scene:read', manage: 'alcantara:scene:manage', operate: 'alcantara:scene:operate' },
+  program: {
+    read: 'alcantara:program:read',
+    manage: 'alcantara:program:manage',
+    operate: 'alcantara:program:operate'
+  },
+  flight: {
+    read: 'alcantara:flight:read',
+    manage: 'alcantara:flight:manage',
+    operate: 'alcantara:flight:operate'
+  },
+  scene: {
+    read: 'alcantara:scene:read',
+    manage: 'alcantara:scene:manage',
+    operate: 'alcantara:scene:operate'
+  },
   layout: { read: 'alcantara:layout:read', manage: 'alcantara:layout:manage' },
   media: { read: 'alcantara:media:read', manage: 'alcantara:media:manage' },
   song: { read: 'alcantara:song:read', manage: 'alcantara:song:manage' },
-  instant: { read: 'alcantara:instant:read', manage: 'alcantara:instant:manage', operate: 'alcantara:instant:operate' },
-  stinger: { read: 'alcantara:stinger:read', manage: 'alcantara:stinger:manage' },
-  radio: { read: 'alcantara:radio:read', manage: 'alcantara:radio:manage', operate: 'alcantara:radio:operate' },
+  instant: {
+    read: 'alcantara:instant:read',
+    manage: 'alcantara:instant:manage',
+    operate: 'alcantara:instant:operate'
+  },
+  stinger: {
+    read: 'alcantara:stinger:read',
+    manage: 'alcantara:stinger:manage'
+  },
+  radio: {
+    read: 'alcantara:radio:read',
+    manage: 'alcantara:radio:manage',
+    operate: 'alcantara:radio:operate'
+  },
+  webrtc: {
+    read: 'alcantara:webrtc:read',
+    operate: 'alcantara:webrtc:operate'
+  },
   upload: { create: 'alcantara:upload:create' }
 } as const;
 
@@ -18,6 +45,7 @@ export const routePermission = (pathname: string): string => {
   if (pathname.startsWith('/stingers')) return PERMISSIONS.stinger.read;
   if (pathname.startsWith('/songs')) return PERMISSIONS.song.read;
   if (pathname.startsWith('/media')) return PERMISSIONS.media.read;
+  if (pathname.startsWith('/calls')) return PERMISSIONS.webrtc.read;
   if (pathname.startsWith('/scenes')) return PERMISSIONS.scene.read;
   if (pathname.startsWith('/layouts') || pathname.startsWith('/preview')) return PERMISSIONS.layout.read;
   return PERMISSIONS.program.read;

--- a/frontend/app/components/WebrtcGuestSource.tsx
+++ b/frontend/app/components/WebrtcGuestSource.tsx
@@ -1,0 +1,120 @@
+import { ConnectionState, Room, RoomEvent, Track, type RemoteParticipant, type RemoteTrack, type RemoteTrackPublication } from 'livekit-client';
+import { useEffect, useRef, useState } from 'react';
+import { apiUrl } from '../utils/apiBaseUrl';
+
+export function WebrtcGuestSource({
+  programId,
+  slotNumber,
+  objectFit = 'cover',
+  channelGain = 1,
+  showStatus = true,
+  suppressAudio = false
+}: {
+  programId: string;
+  slotNumber?: unknown;
+  objectFit?: unknown;
+  channelGain?: unknown;
+  showStatus?: unknown;
+  suppressAudio?: boolean;
+}) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [connectionState, setConnectionState] = useState(ConnectionState.Disconnected);
+  const [hasGuest, setHasGuest] = useState(false);
+  const normalizedSlot = typeof slotNumber === 'number' && slotNumber >= 1 && slotNumber <= 6 ? slotNumber : 1;
+  const gain = typeof channelGain === 'number' && Number.isFinite(channelGain) ? Math.max(0, Math.min(1, channelGain)) : 1;
+
+  useEffect(() => {
+    let cancelled = false;
+    const room = new Room({ adaptiveStream: true, dynacast: false });
+    const isTarget = (participant: RemoteParticipant) => {
+      if (!participant.identity.startsWith('guest-')) return false;
+      try {
+        const metadata = JSON.parse(participant.metadata || '{}') as {
+          slotNumber?: number;
+        };
+        return metadata.slotNumber === normalizedSlot;
+      } catch {
+        return false;
+      }
+    };
+    const attach = (track: RemoteTrack, _publication: RemoteTrackPublication, participant: RemoteParticipant) => {
+      if (!isTarget(participant)) return;
+      setHasGuest(true);
+      if (track.kind === Track.Kind.Video && videoRef.current) track.attach(videoRef.current);
+      if (track.kind === Track.Kind.Audio && audioRef.current) track.attach(audioRef.current);
+    };
+    const refresh = () => {
+      const target = Array.from(room.remoteParticipants.values()).find(isTarget);
+      setHasGuest(Boolean(target));
+      target?.trackPublications.forEach((publication) => {
+        if (publication.track) attach(publication.track, publication, target);
+      });
+    };
+    room.on(RoomEvent.ConnectionStateChanged, setConnectionState);
+    room.on(RoomEvent.TrackSubscribed, attach);
+    room.on(RoomEvent.TrackUnsubscribed, (track, _publication, participant) => {
+      if (isTarget(participant)) {
+        track.detach();
+        refresh();
+      }
+    });
+    room.on(RoomEvent.ParticipantConnected, refresh);
+    room.on(RoomEvent.ParticipantDisconnected, refresh);
+
+    const connect = async () => {
+      const fragment = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+      const rendererKey = fragment.get('key') || window.sessionStorage.getItem('alcantara-renderer-key') || '';
+      if (rendererKey) window.sessionStorage.setItem('alcantara-renderer-key', rendererKey);
+      if (!rendererKey) throw new Error('Renderer source credential is missing.');
+      const response = await fetch(apiUrl('/webrtc/renderer-source-token'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Renderer-Key': rendererKey
+        },
+        body: JSON.stringify({ programId })
+      });
+      if (!response.ok) throw new Error(`Guest source authorization failed (${response.status}).`);
+      const credentials = (await response.json()) as {
+        serverUrl: string;
+        token: string;
+      };
+      if (cancelled) return;
+      await room.connect(credentials.serverUrl, credentials.token, {
+        autoSubscribe: true
+      });
+      if (!cancelled) refresh();
+    };
+    void connect().catch((error) => {
+      console.error('WebRTC guest slot failed:', error);
+      if (!cancelled) setConnectionState(ConnectionState.Disconnected);
+    });
+    return () => {
+      cancelled = true;
+      room.disconnect();
+    };
+  }, [normalizedSlot, programId]);
+
+  useEffect(() => {
+    if (!audioRef.current) return;
+    audioRef.current.volume = suppressAudio ? 0 : gain;
+    audioRef.current.muted = suppressAudio || gain <= 0.0001;
+  }, [gain, suppressAudio]);
+
+  return (
+    <div className='absolute inset-0 overflow-hidden bg-black'>
+      <video ref={videoRef} autoPlay playsInline className='h-full w-full bg-black' style={{ objectFit: objectFit === 'contain' ? 'contain' : 'cover' }} />
+      <audio ref={audioRef} autoPlay playsInline muted={suppressAudio || gain <= 0.0001} />
+      {showStatus !== false && (connectionState !== ConnectionState.Connected || !hasGuest) ? (
+        <div className='absolute inset-0 flex items-center justify-center bg-zinc-950 text-center text-white'>
+          <div>
+            <div className={`mx-auto mb-3 h-3 w-3 rounded-full ${connectionState === ConnectionState.Connected ? 'bg-amber-400' : 'animate-pulse bg-sky-400'}`} />
+            <p className='text-2xl font-semibold'>{connectionState === ConnectionState.Connected ? `Guest slot ${normalizedSlot} offline` : 'Connecting guest source'}</p>
+            <p className='mt-2 text-sm text-white/50'>Assignment is retained for the 60-second reconnect window.</p>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/app/components/editors/ComponentPropsFields.tsx
+++ b/frontend/app/components/editors/ComponentPropsFields.tsx
@@ -52,7 +52,10 @@ export function ComponentPropsFields({
 }) {
   const timezoneOptions = useMemo(() => {
     const baseDate = new Date();
-    return getTimezonesSortedByOffset(baseDate).map((tz) => ({ value: tz, label: getTimezoneOptionLabel(tz, baseDate) }));
+    return getTimezonesSortedByOffset(baseDate).map((tz) => ({
+      value: tz,
+      label: getTimezoneOptionLabel(tz, baseDate)
+    }));
   }, []);
 
   switch (componentType) {
@@ -125,15 +128,7 @@ export function ComponentPropsFields({
     case 'toni-logo':
       return <p className='text-xs text-text-secondary italic'>No configurable attributes.</p>;
     case 'slideshow':
-      return (
-        <SlideshowEditorFields
-          componentType={componentType}
-          props={props}
-          updateProp={updateProp}
-          mediaGroups={mediaGroups}
-          isLoadingMediaGroups={isLoadingMediaGroups}
-        />
-      );
+      return <SlideshowEditorFields componentType={componentType} props={props} updateProp={updateProp} mediaGroups={mediaGroups} isLoadingMediaGroups={isLoadingMediaGroups} />;
     case 'video-stream':
       return (
         <div className='space-y-3'>
@@ -173,21 +168,11 @@ export function ComponentPropsFields({
           </div>
           <div className='grid grid-cols-1 sm:grid-cols-2 gap-3'>
             <label className='flex items-center gap-2 text-sm text-text-primary'>
-              <Input
-                type='checkbox'
-                checked={toBoolean(props.autoPlay, true)}
-                onChange={(e) => updateProp(componentType, 'autoPlay', e.target.checked)}
-                className='h-4 w-4'
-              />
+              <Input type='checkbox' checked={toBoolean(props.autoPlay, true)} onChange={(e) => updateProp(componentType, 'autoPlay', e.target.checked)} className='h-4 w-4' />
               Autoplay
             </label>
             <label className='flex items-center gap-2 text-sm text-text-primary'>
-              <Input
-                type='checkbox'
-                checked={toBoolean(props.loop, false)}
-                onChange={(e) => updateProp(componentType, 'loop', e.target.checked)}
-                className='h-4 w-4'
-              />
+              <Input type='checkbox' checked={toBoolean(props.loop, false)} onChange={(e) => updateProp(componentType, 'loop', e.target.checked)} className='h-4 w-4' />
               Loop
             </label>
             <label className='flex items-center gap-2 text-sm text-text-primary'>
@@ -201,6 +186,45 @@ export function ComponentPropsFields({
             </label>
           </div>
           <p className='text-xs text-text-secondary'>Audio is controlled by mixer Song + Main faders (including mute/solo behavior).</p>
+        </div>
+      );
+    case 'webrtc-guest':
+      return (
+        <div className='grid gap-3 sm:grid-cols-3'>
+          <label className='text-sm text-text-primary'>
+            <span className='mb-1 block text-xs text-text-secondary'>Reusable guest slot</span>
+            <Select
+              value={String(typeof props.slotNumber === 'number' ? props.slotNumber : 1)}
+              onChange={(value) => updateProp(componentType, 'slotNumber', Number(value))}
+              options={Array.from({ length: 6 }, (_, index) => ({
+                value: String(index + 1),
+                label: `Guest ${index + 1}`
+              }))}
+            />
+          </label>
+          <label className='text-sm text-text-primary'>
+            <span className='mb-1 block text-xs text-text-secondary'>Fit</span>
+            <Select
+              value={props.objectFit === 'contain' ? 'contain' : 'cover'}
+              onChange={(value) => updateProp(componentType, 'objectFit', value)}
+              options={[
+                { value: 'cover', label: 'Cover' },
+                { value: 'contain', label: 'Contain' }
+              ]}
+            />
+          </label>
+          <label className='flex items-center gap-2 self-end pb-2 text-sm text-text-primary'>
+            <Input
+              type='checkbox'
+              checked={toBoolean(props.showStatus, true)}
+              onChange={(event) => updateProp(componentType, 'showStatus', event.target.checked)}
+              className='h-4 w-4'
+            />
+            Show offline state
+          </label>
+          <p className='sm:col-span-3 text-xs text-text-secondary'>
+            Layouts stay bound to this generic slot. Assign or replace a guest from the Calls console without rebuilding the composition.
+          </p>
         </div>
       );
     case 'stream-wall': {
@@ -343,21 +367,11 @@ export function ComponentPropsFields({
           </div>
           <div className='grid grid-cols-1 sm:grid-cols-2 gap-3'>
             <label className='flex items-center gap-2 text-sm text-text-primary'>
-              <Input
-                type='checkbox'
-                checked={toBoolean(props.showPeriod, true)}
-                onChange={(e) => updateProp(componentType, 'showPeriod', e.target.checked)}
-                className='h-4 w-4'
-              />
+              <Input type='checkbox' checked={toBoolean(props.showPeriod, true)} onChange={(e) => updateProp(componentType, 'showPeriod', e.target.checked)} className='h-4 w-4' />
               Show Period
             </label>
             <label className='flex items-center gap-2 text-sm text-text-primary'>
-              <Input
-                type='checkbox'
-                checked={toBoolean(props.showClock, true)}
-                onChange={(e) => updateProp(componentType, 'showClock', e.target.checked)}
-                className='h-4 w-4'
-              />
+              <Input type='checkbox' checked={toBoolean(props.showClock, true)} onChange={(e) => updateProp(componentType, 'showClock', e.target.checked)} className='h-4 w-4' />
               Show Clock
             </label>
           </div>
@@ -410,12 +424,7 @@ export function ComponentPropsFields({
           </div>
           <div className='col-span-2'>
             <label className='flex items-center gap-2 text-sm text-text-primary'>
-              <Input
-                type='checkbox'
-                checked={toBoolean(props.showChyron, false)}
-                onChange={(e) => updateProp(componentType, 'showChyron', e.target.checked)}
-                className='h-4 w-4'
-              />
+              <Input type='checkbox' checked={toBoolean(props.showChyron, false)} onChange={(e) => updateProp(componentType, 'showChyron', e.target.checked)} className='h-4 w-4' />
               Show Chyron
             </label>
           </div>
@@ -506,13 +515,9 @@ export function ComponentPropsFields({
       );
     case 'toni-chyron':
     case 'fifthbell-chyron':
-      return (
-        <ToniChyronEditorFields componentType={componentType} props={props} updateProp={updateProp} replaceProps={replaceProps} commitProps={commitProps} />
-      );
+      return <ToniChyronEditorFields componentType={componentType} props={props} updateProp={updateProp} replaceProps={replaceProps} commitProps={commitProps} />;
     case 'modoitaliano-chyron':
-      return (
-        <ProgramChyronEditorFields componentType={componentType} props={props} updateProp={updateProp} replaceProps={replaceProps} commitProps={commitProps} />
-      );
+      return <ProgramChyronEditorFields componentType={componentType} props={props} updateProp={updateProp} replaceProps={replaceProps} commitProps={commitProps} />;
     case 'modoitaliano-clock':
       return (
         <div className='space-y-4'>
@@ -527,12 +532,7 @@ export function ComponentPropsFields({
               Show World Clocks
             </label>
             <label className='flex items-center gap-2 text-sm text-text-primary'>
-              <Input
-                type='checkbox'
-                checked={toBoolean(props.showLogo, true)}
-                onChange={(e) => updateProp(componentType, 'showLogo', e.target.checked)}
-                className='h-4 w-4'
-              />
+              <Input type='checkbox' checked={toBoolean(props.showLogo, true)} onChange={(e) => updateProp(componentType, 'showLogo', e.target.checked)} className='h-4 w-4' />
               Show Logo
             </label>
             <label className='flex items-center gap-2 text-sm text-text-primary'>
@@ -667,12 +667,7 @@ export function ComponentPropsFields({
           </div>
           <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3'>
             <label className='flex items-center gap-2 text-sm text-text-primary'>
-              <Input
-                type='checkbox'
-                checked={toBoolean(props.show, true)}
-                onChange={(e) => updateProp(componentType, 'show', e.target.checked)}
-                className='h-4 w-4'
-              />
+              <Input type='checkbox' checked={toBoolean(props.show, true)} onChange={(e) => updateProp(componentType, 'show', e.target.checked)} className='h-4 w-4' />
               Show Disclaimer
             </label>
             <label className='text-sm text-text-primary'>
@@ -831,9 +826,7 @@ export function ComponentPropsFields({
       const supportsMarquee = componentType === 'fifthbell' || componentType === 'fifthbell-marquee';
       const selectedWeatherCities = Array.isArray(props.weatherCities) ? props.weatherCities.filter((c: unknown): c is string => typeof c === 'string') : [];
       const selectedCitySet = new Set(selectedWeatherCities);
-      const languageRotation = Array.isArray(props.languageRotation)
-        ? props.languageRotation.filter((l: unknown): l is string => typeof l === 'string')
-        : ['en', 'es', 'en', 'it'];
+      const languageRotation = Array.isArray(props.languageRotation) ? props.languageRotation.filter((l: unknown): l is string => typeof l === 'string') : ['en', 'es', 'en', 'it'];
 
       return (
         <div className='space-y-4'>

--- a/frontend/app/components/index.ts
+++ b/frontend/app/components/index.ts
@@ -21,6 +21,7 @@ export { CronicaReiteramos } from './CronicaReiteramos';
 export { Slideshow } from './Slideshow';
 export { VideoStream } from './VideoStream';
 export { StreamWall } from './StreamWall';
+export { WebrtcGuestSource } from './WebrtcGuestSource';
 export { Scoreboard } from './Scoreboard';
 export { default as RelojLoopClock } from './RelojLoopClock';
 export { default as RelojDigitalLoopClock } from './RelojDigitalLoopClock';

--- a/frontend/app/models/components.ts
+++ b/frontend/app/models/components.ts
@@ -33,7 +33,11 @@ export const OVERLAY_COMPONENTS: ComponentMetadata[] = [
     name: 'Clock Widget',
     description: 'Live updating clock display',
     hasConfigurableSceneAttributes: true,
-    defaultProps: { showIcon: true, iconUrl: '', timezone: 'America/Argentina/Buenos_Aires' }
+    defaultProps: {
+      showIcon: true,
+      iconUrl: '',
+      timezone: 'America/Argentina/Buenos_Aires'
+    }
   },
   {
     id: 'qr-code',
@@ -84,6 +88,13 @@ export const OVERLAY_COMPONENTS: ComponentMetadata[] = [
       autoPlay: true,
       objectFit: 'cover'
     }
+  },
+  {
+    id: 'webrtc-guest',
+    name: 'WebRTC Guest Slot',
+    description: 'Reusable remote guest slot assigned from the Calls console',
+    hasConfigurableSceneAttributes: true,
+    defaultProps: { slotNumber: 1, objectFit: 'cover', showStatus: true }
   },
   {
     id: 'stream-wall',
@@ -148,7 +159,14 @@ export const OVERLAY_COMPONENTS: ComponentMetadata[] = [
     name: 'Reloj Digital',
     description: 'Broadcast-style digital clock with countdown and text/CTA sequences',
     hasConfigurableSceneAttributes: true,
-    defaultProps: { timezone: 'America/New_York', mode: 'clock', countdownDuration: 300, countdownTargetSceneId: null, countdownTransitionId: 'cut', countdownCommand: 0 }
+    defaultProps: {
+      timezone: 'America/New_York',
+      mode: 'clock',
+      countdownDuration: 300,
+      countdownTargetSceneId: null,
+      countdownTransitionId: 'cut',
+      countdownCommand: 0
+    }
   },
   {
     id: 'reloj-clone',
@@ -162,14 +180,22 @@ export const OVERLAY_COMPONENTS: ComponentMetadata[] = [
     name: 'Toni Chyron',
     description: 'Chyron with social handles and presets',
     hasConfigurableSceneAttributes: true,
-    defaultProps: { text: '', useMarquee: false, socialHandles: ['@modoitaliano.oficial', '@fifth.bell', '@hnmages'] }
+    defaultProps: {
+      text: '',
+      useMarquee: false,
+      socialHandles: ['@modoitaliano.oficial', '@fifth.bell', '@hnmages']
+    }
   },
   {
     id: 'fifthbell-chyron',
     name: 'Fifth Bell Chyron',
     description: 'Fifth Bell branded chyron',
     hasConfigurableSceneAttributes: true,
-    defaultProps: { text: '', useMarquee: false, socialHandles: ['@modoitaliano.oficial', '@fifth.bell', '@hnmages'] }
+    defaultProps: {
+      text: '',
+      useMarquee: false,
+      socialHandles: ['@modoitaliano.oficial', '@fifth.bell', '@hnmages']
+    }
   },
   {
     id: 'toni-clock',

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -11,6 +11,7 @@ export default [
       route('stingers', 'routes/stingers.tsx'),
       route('songs', 'routes/songs.tsx'),
       route('media', 'routes/media.tsx'),
+      route('calls', 'routes/calls.tsx'),
       route('scenes', 'routes/scenes.tsx'),
       route('programs', 'routes/programs.tsx'),
       route('layouts', 'routes/layouts.tsx'),
@@ -21,5 +22,7 @@ export default [
     ]),
     route('overlay', 'routes/overlay.tsx')
   ]),
+  route('guest/:invitation', 'routes/guest.tsx'),
+  route('return-router/:programId', 'routes/return-router.tsx'),
   route('program/:id', 'routes/program.tsx')
 ] satisfies RouteConfig;

--- a/frontend/app/routes/calls.tsx
+++ b/frontend/app/routes/calls.tsx
@@ -1,0 +1,464 @@
+import { Button, Card, Empty, Field, Input, PageHeader, Select, StatusBadge } from '@gaulatti/bleecker';
+import { Copy, Headphones, Link2, Mic, MicOff, RefreshCw, Send, Trash2, Video, VideoOff } from 'lucide-react';
+import { createLocalAudioTrack, Room } from 'livekit-client';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { authFetch } from '../services/api';
+import { useFeatures } from '../hooks/useFeatures';
+import { PERMISSIONS } from '../auth/permissions';
+import { useGlobalProgramId } from '../utils/globalProgram';
+import type { Route } from './+types/calls';
+
+type Command = {
+  id: string;
+  type: string;
+  status: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+};
+type Invitation = {
+  id: string;
+  programId: string;
+  displayName: string;
+  slotNumber: number;
+  returnVideo: 'program' | 'preview' | 'none';
+  returnAudioBus: string;
+  sourceGain: number;
+  sourceMuted: boolean;
+  sourceDelayMs: number;
+  expiresAt: string;
+  status: 'available' | 'active' | 'revoked' | 'expired';
+  commands?: Command[];
+};
+type Participant = {
+  invitationId: string;
+  identity: string;
+  name: string;
+  slotNumber: number;
+  connectionState: 'connected' | 'reconnecting' | 'offline';
+  returnVideo: Invitation['returnVideo'];
+  returnAudioBus: string;
+  sourceGain: number;
+  sourceMuted: boolean;
+  sourceDelayMs: number;
+  tracks: Array<{ sid: string; source: string; muted: boolean }>;
+  commands: Command[];
+};
+
+export function meta({}: Route.MetaArgs) {
+  return [{ title: 'Guest Calls - Alcántara' }];
+}
+
+async function readError(response: Response) {
+  const text = await response.text();
+  try {
+    const parsed = JSON.parse(text) as { message?: string };
+    return parsed.message || text;
+  } catch {
+    return text || `Request failed (${response.status})`;
+  }
+}
+
+export default function CallsRoute() {
+  const [programId] = useGlobalProgramId();
+  const { hasPermission } = useFeatures();
+  const canOperate = hasPermission(PERMISSIONS.webrtc.operate);
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [displayName, setDisplayName] = useState('');
+  const [expiresInHours, setExpiresInHours] = useState('24');
+  const [createdUrl, setCreatedUrl] = useState('');
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [notice, setNotice] = useState('');
+  const [busy, setBusy] = useState<string | null>(null);
+  const talkbackRef = useRef<{
+    room: Room;
+    track: Awaited<ReturnType<typeof createLocalAudioTrack>>;
+  } | null>(null);
+
+  const refresh = useCallback(async () => {
+    const [invitationResponse, participantResponse] = await Promise.all([
+      authFetch('/webrtc/invitations'),
+      authFetch(`/webrtc/rooms/${encodeURIComponent(programId)}/participants`)
+    ]);
+    if (!invitationResponse.ok) throw new Error(await readError(invitationResponse));
+    if (!participantResponse.ok) throw new Error(await readError(participantResponse));
+    const allInvitations = (await invitationResponse.json()) as Invitation[];
+    const room = (await participantResponse.json()) as {
+      participants: Participant[];
+    };
+    setInvitations(allInvitations.filter((item) => item.programId === programId));
+    setParticipants(room.participants);
+  }, [programId]);
+
+  useEffect(() => {
+    void refresh().catch((error) => setNotice(error instanceof Error ? error.message : 'Unable to load calls.'));
+    const timer = window.setInterval(() => void refresh().catch(() => undefined), 3000);
+    return () => {
+      window.clearInterval(timer);
+      const talkback = talkbackRef.current;
+      if (talkback) {
+        talkback.track.stop();
+        talkback.room.disconnect();
+      }
+    };
+  }, [refresh]);
+
+  const run = async (key: string, action: () => Promise<void>) => {
+    setBusy(key);
+    setNotice('');
+    try {
+      await action();
+      await refresh();
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'Action failed.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const createInvitation = () =>
+    run('create', async () => {
+      const response = await authFetch('/webrtc/invitations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          programId,
+          displayName,
+          expiresInHours: Number(expiresInHours)
+        })
+      });
+      if (!response.ok) throw new Error(await readError(response));
+      const created = (await response.json()) as Invitation & {
+        invitationPath: string;
+      };
+      setCreatedUrl(`${window.location.origin}${created.invitationPath}`);
+      setDisplayName('');
+      setNotice(`Guest slot ${created.slotNumber} is ready. Copy the private URL now.`);
+    });
+
+  const mutateInvitation = (id: string, action: 'replace' | 'revoke') =>
+    run(`${action}-${id}`, async () => {
+      const response = await authFetch(`/webrtc/invitations/${id}${action === 'replace' ? '/replace' : ''}`, {
+        method: action === 'replace' ? 'POST' : 'DELETE'
+      });
+      if (!response.ok) throw new Error(await readError(response));
+      if (action === 'replace') {
+        const replacement = (await response.json()) as Invitation & {
+          invitationPath: string;
+        };
+        setCreatedUrl(`${window.location.origin}${replacement.invitationPath}`);
+        setNotice(`Replacement link for slot ${replacement.slotNumber} is ready. Copy it now.`);
+      }
+    });
+
+  const updateReturn = (invitation: Invitation, field: 'returnVideo' | 'returnAudioBus' | 'sourceGain' | 'sourceMuted' | 'sourceDelayMs', value: string | number | boolean) =>
+    run(`return-${invitation.id}`, async () => {
+      const response = await authFetch(`/webrtc/invitations/${invitation.id}/return`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          returnVideo: field === 'returnVideo' ? value : invitation.returnVideo,
+          returnAudioBus: field === 'returnAudioBus' ? value : invitation.returnAudioBus,
+          sourceGain: field === 'sourceGain' ? value : invitation.sourceGain,
+          sourceMuted: field === 'sourceMuted' ? value : invitation.sourceMuted,
+          sourceDelayMs: field === 'sourceDelayMs' ? value : invitation.sourceDelayMs
+        })
+      });
+      if (!response.ok) throw new Error(await readError(response));
+    });
+
+  const command = (participant: Participant, payload: Record<string, unknown>) =>
+    run(`command-${participant.identity}`, async () => {
+      const response = await authFetch(`/webrtc/rooms/${encodeURIComponent(programId)}/participants/${encodeURIComponent(participant.identity)}/control`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) throw new Error(await readError(response));
+      if (payload.type === 'message') setDrafts((current) => ({ ...current, [participant.identity]: '' }));
+    });
+
+  const remove = (participant: Participant) =>
+    run(`remove-${participant.identity}`, async () => {
+      const response = await authFetch(`/webrtc/rooms/${encodeURIComponent(programId)}/participants/${encodeURIComponent(participant.identity)}`, { method: 'DELETE' });
+      if (!response.ok) throw new Error(await readError(response));
+    });
+
+  const startTalkback = (participant: Participant) =>
+    run(`talkback-${participant.identity}`, async () => {
+      if (talkbackRef.current) {
+        talkbackRef.current.track.stop();
+        talkbackRef.current.room.disconnect();
+        talkbackRef.current = null;
+        setNotice('Talkback stopped.');
+        return;
+      }
+      const response = await authFetch('/webrtc/operator-token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ programId })
+      });
+      if (!response.ok) throw new Error(await readError(response));
+      const credentials = (await response.json()) as {
+        serverUrl: string;
+        token: string;
+      };
+      const room = new Room();
+      await room.connect(credentials.serverUrl, credentials.token);
+      const track = await createLocalAudioTrack();
+      await room.localParticipant.publishTrack(track, {
+        name: `talkback:${participant.invitationId}`
+      });
+      talkbackRef.current = { room, track };
+      setNotice(`Private talkback is live to ${participant.name}. Select it again to stop.`);
+    });
+
+  const activeInvitations = invitations.filter((item) => item.status !== 'revoked' && item.status !== 'expired');
+  return (
+    <main className='consumer-page'>
+      <div className='consumer-page__content'>
+        <PageHeader
+          title='Guest calls'
+          description={`Six reusable remote-contributor slots for ${programId}. Guests never enter Preview or Program automatically.`}
+          actions={
+            <Button variant='secondary' onClick={() => void refresh()}>
+              <RefreshCw size={15} /> Refresh
+            </Button>
+          }
+        />
+        {notice ? (
+          <div role='status' aria-live='polite' className='mb-5 rounded-[var(--radius-ui)] border border-sea/20 bg-sea/[0.06] px-4 py-3 text-sm'>
+            {notice}
+          </div>
+        ) : null}
+        {createdUrl ? (
+          <Card variant='subtle' className='mb-6 p-5'>
+            <p className='consumer-section-label'>Private invitation, shown once</p>
+            <p className='mt-2 break-all font-mono text-xs'>{createdUrl}</p>
+            <Button className='mt-3' size='sm' onClick={() => void navigator.clipboard.writeText(createdUrl).then(() => setNotice('Private invitation copied.'))}>
+              <Copy size={14} /> Copy invitation
+            </Button>
+          </Card>
+        ) : null}
+        <div className='grid items-start gap-6 xl:grid-cols-[0.72fr_1.28fr]'>
+          <Card variant='outlined' className='p-6'>
+            <h2 className='text-xl font-medium'>Create invitation</h2>
+            <p className='mt-1 text-sm text-text-secondary'>{activeInvitations.length}/6 slots assigned</p>
+            <div className='mt-5 space-y-4'>
+              <Field label='Guest name'>
+                <Input value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder='Fictional guest' maxLength={80} />
+              </Field>
+              <Field label='Expires after'>
+                <Select
+                  value={expiresInHours}
+                  onChange={setExpiresInHours}
+                  options={[
+                    { value: '1', label: '1 hour' },
+                    { value: '6', label: '6 hours' },
+                    { value: '24', label: '24 hours (default)' },
+                    { value: '72', label: '3 days' },
+                    { value: '168', label: '7 days' }
+                  ]}
+                />
+              </Field>
+              <Button fullWidth disabled={!canOperate || !displayName.trim() || activeInvitations.length >= 6} loading={busy === 'create'} onClick={() => void createInvitation()}>
+                <Link2 size={15} /> Create private link
+              </Button>
+            </div>
+          </Card>
+          <div className='space-y-4'>
+            {participants.length === 0 ? (
+              <Empty title='No assigned guest slots' description='Create an invitation to reserve the first reusable slot.' />
+            ) : (
+              participants.map((participant) => {
+                const invitation = invitations.find((item) => item.id === participant.invitationId);
+                if (!invitation) return null;
+                const microphone = participant.tracks.find((track) => track.source.includes('microphone'));
+                const camera = participant.tracks.find((track) => track.source.includes('camera'));
+                const draft = drafts[participant.identity] || '';
+                const latest = participant.commands[0];
+                return (
+                  <Card key={participant.invitationId} variant='surface' className='p-5'>
+                    <div className='flex flex-wrap items-center gap-3'>
+                      <span className='flex h-9 w-9 items-center justify-center rounded-full bg-sea/10 font-semibold text-sea'>{participant.slotNumber}</span>
+                      <div className='min-w-0 flex-1'>
+                        <h3 className='truncate font-medium'>{participant.name}</h3>
+                        <p className='text-xs text-text-secondary'>
+                          Slot {participant.slotNumber} · expires {new Date(invitation.expiresAt).toLocaleString()}
+                        </p>
+                      </div>
+                      <StatusBadge
+                        label={participant.connectionState}
+                        variant={participant.connectionState === 'connected' ? 'live' : participant.connectionState === 'reconnecting' ? 'offline' : 'default'}
+                      />
+                    </div>
+                    <div className='mt-4 grid gap-3 sm:grid-cols-2'>
+                      <Field label='Return video'>
+                        <Select
+                          value={participant.returnVideo}
+                          disabled={!canOperate}
+                          onChange={(value) => void updateReturn(invitation, 'returnVideo', value)}
+                          options={[
+                            { value: 'program', label: 'Program' },
+                            { value: 'preview', label: 'Preview' },
+                            { value: 'none', label: 'None' }
+                          ]}
+                        />
+                      </Field>
+                      <Field label='Return audio'>
+                        <Select
+                          value={participant.returnAudioBus}
+                          disabled={!canOperate}
+                          onChange={(value) => void updateReturn(invitation, 'returnAudioBus', value)}
+                          options={[
+                            { value: 'master', label: 'Program / Master' },
+                            { value: 'monitor', label: 'Operator monitor' },
+                            ...Array.from({ length: 8 }, (_, index) => ({
+                              value: `aux-${index + 1}`,
+                              label: `Aux / IFB ${index + 1}`
+                            }))
+                          ]}
+                        />
+                      </Field>
+                    </div>
+                    <div className='mt-3 grid gap-3 sm:grid-cols-3'>
+                      <Field label='Guest level in returns'>
+                        <Select
+                          value={String(participant.sourceGain)}
+                          disabled={!canOperate}
+                          onChange={(value) => void updateReturn(invitation, 'sourceGain', Number(value))}
+                          options={[0, 0.25, 0.5, 0.75, 1].map((value) => ({
+                            value: String(value),
+                            label: `${Math.round(value * 100)}%`
+                          }))}
+                        />
+                      </Field>
+                      <Field label='Guest sync delay'>
+                        <Select
+                          value={String(participant.sourceDelayMs)}
+                          disabled={!canOperate}
+                          onChange={(value) => void updateReturn(invitation, 'sourceDelayMs', Number(value))}
+                          options={[0, 50, 100, 150, 200, 300, 500, 750, 1000, 1500, 2000].map((value) => ({
+                            value: String(value),
+                            label: `${value} ms`
+                          }))}
+                        />
+                      </Field>
+                      <Field label='Guest routing'>
+                        <Button
+                          fullWidth
+                          variant={participant.sourceMuted ? 'destructive' : 'secondary'}
+                          disabled={!canOperate}
+                          onClick={() => void updateReturn(invitation, 'sourceMuted', !participant.sourceMuted)}
+                        >
+                          {participant.sourceMuted ? <MicOff size={14} /> : <Mic size={14} />}
+                          {participant.sourceMuted ? 'Muted in returns' : 'Routed to returns'}
+                        </Button>
+                      </Field>
+                    </div>
+                    <div className='mt-4 flex flex-wrap gap-2'>
+                      <Button
+                        size='sm'
+                        variant='secondary'
+                        disabled={!canOperate || !camera || busy !== null}
+                        onClick={() =>
+                          void command(participant, {
+                            type: 'media',
+                            device: 'camera',
+                            enabled: Boolean(camera?.muted)
+                          })
+                        }
+                      >
+                        {camera?.muted ? <VideoOff size={14} /> : <Video size={14} />} {camera?.muted ? 'Request camera' : 'Mute camera'}
+                      </Button>
+                      <Button
+                        size='sm'
+                        variant='secondary'
+                        disabled={!canOperate || !microphone || busy !== null}
+                        onClick={() =>
+                          void command(participant, {
+                            type: 'media',
+                            device: 'microphone',
+                            enabled: Boolean(microphone?.muted)
+                          })
+                        }
+                      >
+                        {microphone?.muted ? <MicOff size={14} /> : <Mic size={14} />} {microphone?.muted ? 'Request mic' : 'Mute mic'}
+                      </Button>
+                      {(['standby', 'live', 'wrap'] as const).map((cue) => (
+                        <Button
+                          key={cue}
+                          size='sm'
+                          variant={cue === 'live' ? 'destructive' : 'secondary'}
+                          disabled={!canOperate || participant.connectionState !== 'connected' || busy !== null}
+                          onClick={() => void command(participant, { type: 'cue', cue })}
+                        >
+                          {cue}
+                        </Button>
+                      ))}
+                      <Button
+                        size='sm'
+                        variant='secondary'
+                        disabled={!canOperate || participant.connectionState !== 'connected' || busy !== null}
+                        onClick={() => void startTalkback(participant)}
+                      >
+                        <Headphones size={14} /> Talkback
+                      </Button>
+                    </div>
+                    <div className='mt-3 flex gap-2'>
+                      <Input
+                        aria-label={`Message ${participant.name}`}
+                        value={draft}
+                        maxLength={500}
+                        onChange={(event) =>
+                          setDrafts((current) => ({
+                            ...current,
+                            [participant.identity]: event.target.value
+                          }))
+                        }
+                        placeholder='Private studio message'
+                      />
+                      <Button
+                        size='sm'
+                        disabled={!canOperate || !draft.trim() || busy !== null}
+                        onClick={() =>
+                          void command(participant, {
+                            type: 'message',
+                            text: draft
+                          })
+                        }
+                      >
+                        <Send size={14} />
+                      </Button>
+                    </div>
+                    {latest ? (
+                      <p className='mt-3 text-xs text-text-secondary'>
+                        Latest {latest.type}: <strong>{latest.status}</strong>
+                      </p>
+                    ) : null}
+                    <div className='mt-4 flex flex-wrap gap-2 border-t border-sand/20 pt-4'>
+                      <Button size='sm' variant='secondary' disabled={!canOperate || busy !== null} onClick={() => void mutateInvitation(invitation.id, 'replace')}>
+                        <RefreshCw size={14} /> Replace link
+                      </Button>
+                      <Button
+                        size='sm'
+                        variant='secondary'
+                        disabled={!canOperate || participant.connectionState === 'offline' || busy !== null}
+                        onClick={() => void remove(participant)}
+                      >
+                        Remove session
+                      </Button>
+                      <Button size='sm' variant='destructive' disabled={!canOperate || busy !== null} onClick={() => void mutateInvitation(invitation.id, 'revoke')}>
+                        <Trash2 size={14} /> Revoke
+                      </Button>
+                    </div>
+                  </Card>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/routes/guest.tsx
+++ b/frontend/app/routes/guest.tsx
@@ -1,0 +1,491 @@
+import { Button, Field, Select, StatusBadge } from '@gaulatti/bleecker';
+import { Camera, CameraOff, CheckCircle2, Headphones, Mic, MicOff, PhoneOff, Radio, Volume2 } from 'lucide-react';
+import { ConnectionState, Room, RoomEvent, Track, type RemoteParticipant, type RemoteTrack, type RemoteTrackPublication } from 'livekit-client';
+import { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router';
+import { apiUrl } from '../utils/apiBaseUrl';
+import type { Route } from './+types/guest';
+
+type GuestStatus = 'preflight' | 'ready' | 'joining' | 'live' | 'reconnecting' | 'left' | 'ended' | 'error';
+type DirectorCommand = {
+  id: string;
+  type: 'media' | 'cue' | 'message' | 'return';
+  device?: 'camera' | 'microphone';
+  enabled?: boolean;
+  cue?: string;
+  text?: string;
+  returnVideo?: string;
+  returnAudioBus?: string;
+};
+
+export function meta({}: Route.MetaArgs) {
+  return [{ title: 'Guest Call - Alcántara' }];
+}
+
+async function responseError(response: Response) {
+  const body = await response.text();
+  try {
+    const parsed = JSON.parse(body) as { message?: string };
+    return parsed.message || body;
+  } catch {
+    return body || `Request failed (${response.status})`;
+  }
+}
+
+export default function GuestRoute() {
+  const { invitation = '' } = useParams();
+  const previewRef = useRef<HTMLVideoElement | null>(null);
+  const returnVideoRef = useRef<HTMLVideoElement | null>(null);
+  const returnAudioRef = useRef<HTMLAudioElement | null>(null);
+  const localStreamRef = useRef<MediaStream | null>(null);
+  const roomRef = useRef<Room | null>(null);
+  const sessionTokenRef = useRef('');
+  const heartbeatRef = useRef<number | null>(null);
+  const [status, setStatus] = useState<GuestStatus>('preflight');
+  const [error, setError] = useState('');
+  const [cameraEnabled, setCameraEnabled] = useState(true);
+  const [microphoneEnabled, setMicrophoneEnabled] = useState(true);
+  const [headphonesConfirmed, setHeadphonesConfirmed] = useState(false);
+  const [echoRiskAccepted, setEchoRiskAccepted] = useState(false);
+  const [speakerChecked, setSpeakerChecked] = useState(false);
+  const [cameras, setCameras] = useState<MediaDeviceInfo[]>([]);
+  const [microphones, setMicrophones] = useState<MediaDeviceInfo[]>([]);
+  const [cameraId, setCameraId] = useState('');
+  const [microphoneId, setMicrophoneId] = useState('');
+  const [network, setNetwork] = useState('Checking network…');
+  const [quality, setQuality] = useState('unknown');
+  const [returnFeed, setReturnFeed] = useState(false);
+  const [displayName, setDisplayName] = useState('Guest');
+  const [programId, setProgramId] = useState('');
+  const [returnVideo, setReturnVideo] = useState('program');
+  const [returnAudioBus, setReturnAudioBus] = useState('master');
+  const [notice, setNotice] = useState<DirectorCommand | null>(null);
+
+  const stopHeartbeat = () => {
+    if (heartbeatRef.current !== null) window.clearInterval(heartbeatRef.current);
+    heartbeatRef.current = null;
+  };
+
+  const heartbeat = async () => {
+    if (!sessionTokenRef.current) return;
+    const response = await fetch(apiUrl('/webrtc/session/heartbeat'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionToken: sessionTokenRef.current,
+        telemetry: {
+          connectionState: roomRef.current?.state ?? 'disconnected',
+          quality,
+          returnFeedHealth: returnFeed ? 'healthy' : 'missing',
+          cameraEnabled,
+          microphoneEnabled
+        }
+      })
+    });
+    if (response.status === 401 || response.status === 403) {
+      stopHeartbeat();
+      roomRef.current?.disconnect();
+      setStatus('ended');
+      setError('The studio ended or revoked this guest session.');
+    }
+  };
+
+  const acknowledge = async (command: DirectorCommand, commandStatus: 'accepted' | 'rejected' | 'read' | 'acknowledged') => {
+    if (!sessionTokenRef.current) return;
+    await fetch(apiUrl(`/webrtc/commands/${encodeURIComponent(command.id)}/ack`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionToken: sessionTokenRef.current,
+        status: commandStatus
+      })
+    });
+    if (commandStatus !== 'rejected') setNotice(null);
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    const prepare = async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { width: { ideal: 1280 }, height: { ideal: 720 } },
+          audio: {
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true
+          }
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+        localStreamRef.current = stream;
+        if (previewRef.current) previewRef.current.srcObject = stream;
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const cameraDevices = devices.filter((device) => device.kind === 'videoinput');
+        const microphoneDevices = devices.filter((device) => device.kind === 'audioinput');
+        setCameras(cameraDevices);
+        setMicrophones(microphoneDevices);
+        setCameraId(stream.getVideoTracks()[0]?.getSettings().deviceId || cameraDevices[0]?.deviceId || '');
+        setMicrophoneId(stream.getAudioTracks()[0]?.getSettings().deviceId || microphoneDevices[0]?.deviceId || '');
+        const connection = (
+          navigator as Navigator & {
+            connection?: {
+              effectiveType?: string;
+              downlink?: number;
+              rtt?: number;
+            };
+          }
+        ).connection;
+        setNetwork(connection ? `${connection.effectiveType || 'network'} · ${connection.downlink || '?'} Mbps · ${connection.rtt || '?'} ms RTT` : 'Browser network check ready');
+        setStatus('ready');
+      } catch (reason) {
+        setError(reason instanceof Error ? `Camera or microphone permission failed: ${reason.message}` : 'Camera or microphone permission failed.');
+        setStatus('error');
+      }
+    };
+    void prepare();
+    return () => {
+      cancelled = true;
+      stopHeartbeat();
+      localStreamRef.current?.getTracks().forEach((track) => track.stop());
+      roomRef.current?.disconnect();
+    };
+  }, []);
+
+  const switchDevice = async (kind: 'videoinput' | 'audioinput', id: string) => {
+    if (kind === 'videoinput') setCameraId(id);
+    else setMicrophoneId(id);
+    if (roomRef.current?.state === ConnectionState.Connected) {
+      await roomRef.current.switchActiveDevice(kind, id);
+      return;
+    }
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: kind === 'videoinput' ? { deviceId: { exact: id } } : cameraId ? { deviceId: { exact: cameraId } } : true,
+      audio: kind === 'audioinput' ? { deviceId: { exact: id }, echoCancellation: true } : microphoneId ? { deviceId: { exact: microphoneId }, echoCancellation: true } : true
+    });
+    localStreamRef.current?.getTracks().forEach((track) => track.stop());
+    localStreamRef.current = stream;
+    stream.getVideoTracks().forEach((track) => {
+      track.enabled = cameraEnabled;
+    });
+    stream.getAudioTracks().forEach((track) => {
+      track.enabled = microphoneEnabled;
+    });
+    if (previewRef.current) previewRef.current.srcObject = stream;
+  };
+
+  const playSpeakerTest = async () => {
+    const context = new AudioContext();
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    oscillator.frequency.value = 523.25;
+    gain.gain.value = 0.08;
+    oscillator.connect(gain).connect(context.destination);
+    oscillator.start();
+    oscillator.stop(context.currentTime + 0.35);
+    oscillator.addEventListener('ended', () => void context.close());
+    setSpeakerChecked(true);
+  };
+
+  const join = async () => {
+    if (!speakerChecked || (!headphonesConfirmed && !echoRiskAccepted)) return;
+    setStatus('joining');
+    setError('');
+    try {
+      const storageKey = `alcantara-guest-session:${invitation.split('.')[0] || 'unknown'}`;
+      const previousSession = window.sessionStorage.getItem(storageKey);
+      const response = await fetch(apiUrl('/webrtc/join'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ invitation, sessionToken: previousSession })
+      });
+      if (!response.ok) throw new Error(await responseError(response));
+      const credentials = (await response.json()) as {
+        serverUrl: string;
+        token: string;
+        sessionToken: string;
+        displayName: string;
+        programId: string;
+        participantIdentity: string;
+        returnVideo: string;
+        returnAudioBus: string;
+      };
+      window.sessionStorage.setItem(storageKey, credentials.sessionToken);
+      sessionTokenRef.current = credentials.sessionToken;
+      setDisplayName(credentials.displayName);
+      setProgramId(credentials.programId);
+      setReturnVideo(credentials.returnVideo);
+      setReturnAudioBus(credentials.returnAudioBus);
+      localStreamRef.current?.getTracks().forEach((track) => track.stop());
+      localStreamRef.current = null;
+
+      const room = new Room({
+        adaptiveStream: true,
+        dynacast: true,
+        disconnectOnPageLeave: true
+      });
+      roomRef.current = room;
+      const wantedParticipant = (participant: RemoteParticipant) =>
+        participant.identity === `program-feed-${credentials.programId}` ||
+        participant.identity === `preview-feed-${credentials.programId}` ||
+        participant.identity.startsWith('return-router-');
+      const wantedTrack = (publication: RemoteTrackPublication, participant: RemoteParticipant) => {
+        if (!wantedParticipant(participant)) return false;
+        if (publication.kind === Track.Kind.Video) {
+          return credentials.returnVideo !== 'none' && participant.identity === `${credentials.returnVideo}-feed-${credentials.programId}`;
+        }
+        return publication.trackName === `mixminus:${credentials.participantIdentity}:${credentials.returnAudioBus}`;
+      };
+      const subscribe = (publication: RemoteTrackPublication, participant: RemoteParticipant) => {
+        void publication.setSubscribed(wantedTrack(publication, participant));
+      };
+      const attach = (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => {
+        if (!wantedTrack(publication, participant)) return;
+        if (track.kind === Track.Kind.Video && returnVideoRef.current) track.attach(returnVideoRef.current);
+        if (track.kind === Track.Kind.Audio && returnAudioRef.current) {
+          track.attach(returnAudioRef.current);
+          void returnAudioRef.current.play();
+        }
+        setReturnFeed(true);
+      };
+      room.on(RoomEvent.TrackPublished, subscribe);
+      room.on(RoomEvent.TrackSubscribed, attach);
+      room.on(RoomEvent.TrackUnsubscribed, (track) => {
+        track.detach();
+        setReturnFeed(false);
+      });
+      room.on(RoomEvent.ConnectionStateChanged, (state) => {
+        if (state === ConnectionState.Reconnecting) setStatus('reconnecting');
+        if (state === ConnectionState.Connected) setStatus('live');
+        if (state === ConnectionState.Disconnected && status !== 'left') setStatus('ended');
+      });
+      room.on(RoomEvent.ConnectionQualityChanged, (next, participant) => {
+        if (participant.isLocal) setQuality(String(next).toLowerCase());
+      });
+      room.on(RoomEvent.DataReceived, (payload, _participant, _kind, topic) => {
+        if (topic !== 'alcantara-director') return;
+        try {
+          const command = JSON.parse(new TextDecoder().decode(payload)) as DirectorCommand;
+          if (!command.id) return;
+          if (command.type === 'media' && command.enabled === false) {
+            const operation = command.device === 'camera' ? room.localParticipant.setCameraEnabled(false) : room.localParticipant.setMicrophoneEnabled(false);
+            void operation.then(() => {
+              if (command.device === 'camera') setCameraEnabled(false);
+              else setMicrophoneEnabled(false);
+              void acknowledge(command, 'accepted');
+            });
+          } else if (command.type === 'media' && command.enabled === true) {
+            setNotice(command);
+          } else if (command.type === 'return') {
+            if (command.returnVideo) setReturnVideo(command.returnVideo);
+            if (command.returnAudioBus) setReturnAudioBus(command.returnAudioBus);
+          } else {
+            setNotice(command);
+            if (command.type === 'message') void acknowledge(command, 'read');
+          }
+        } catch {
+          // Ignore malformed room data.
+        }
+      });
+      await room.connect(credentials.serverUrl, credentials.token, {
+        autoSubscribe: false
+      });
+      room.remoteParticipants.forEach((participant) => participant.trackPublications.forEach((publication) => subscribe(publication, participant)));
+      await room.localParticipant.setCameraEnabled(cameraEnabled, cameraId ? { deviceId: cameraId } : undefined);
+      await room.localParticipant.setMicrophoneEnabled(microphoneEnabled, microphoneId ? { deviceId: microphoneId } : undefined);
+      const cameraPublication = room.localParticipant.getTrackPublication(Track.Source.Camera);
+      if (cameraPublication?.videoTrack && previewRef.current) cameraPublication.videoTrack.attach(previewRef.current);
+      setStatus('live');
+      stopHeartbeat();
+      heartbeatRef.current = window.setInterval(() => void heartbeat(), 20_000);
+      void heartbeat();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : 'Unable to join the studio.');
+      setStatus('error');
+    }
+  };
+
+  const respondToEnable = async (accepted: boolean) => {
+    if (!notice || notice.type !== 'media' || !notice.device) return;
+    if (accepted && roomRef.current) {
+      if (notice.device === 'camera') {
+        await roomRef.current.localParticipant.setCameraEnabled(true);
+        setCameraEnabled(true);
+      } else {
+        await roomRef.current.localParticipant.setMicrophoneEnabled(true);
+        setMicrophoneEnabled(true);
+      }
+    }
+    await acknowledge(notice, accepted ? 'accepted' : 'rejected');
+    setNotice(null);
+  };
+
+  const toggleMedia = async (device: 'camera' | 'microphone') => {
+    const next = device === 'camera' ? !cameraEnabled : !microphoneEnabled;
+    if (device === 'camera') setCameraEnabled(next);
+    else setMicrophoneEnabled(next);
+    if (roomRef.current?.state === ConnectionState.Connected) {
+      if (device === 'camera') await roomRef.current.localParticipant.setCameraEnabled(next);
+      else await roomRef.current.localParticipant.setMicrophoneEnabled(next);
+    } else {
+      const tracks = device === 'camera' ? localStreamRef.current?.getVideoTracks() : localStreamRef.current?.getAudioTracks();
+      tracks?.forEach((track) => {
+        track.enabled = next;
+      });
+    }
+  };
+
+  const leave = () => {
+    stopHeartbeat();
+    roomRef.current?.disconnect();
+    setStatus('left');
+  };
+
+  const readyToJoin = status === 'ready' && speakerChecked && (headphonesConfirmed || echoRiskAccepted);
+  return (
+    <main className='min-h-screen bg-zinc-950 px-4 py-8 text-white'>
+      <div className='mx-auto max-w-5xl'>
+        <header className='mb-7 flex items-center gap-4'>
+          <span className='flex h-11 w-11 items-center justify-center rounded-xl bg-sky-400/10 text-sky-300'>
+            <Radio size={20} />
+          </span>
+          <div>
+            <p className='text-xs font-semibold uppercase tracking-widest text-amber-300'>Remote contribution</p>
+            <h1 className='mt-1 text-2xl font-semibold'>Alcántara guest call</h1>
+            <p className='mt-1 text-sm text-white/50'>
+              {status === 'live' ? `${displayName} · ${programId} · ${returnVideo} video · ${returnAudioBus} mix-minus` : 'Complete every preflight check, then join explicitly.'}
+            </p>
+          </div>
+          <StatusBadge className='ml-auto' label={status} variant={status === 'live' ? 'live' : status === 'reconnecting' ? 'offline' : 'default'} />
+        </header>
+        <div className='relative aspect-video overflow-hidden rounded-2xl border border-white/10 bg-black'>
+          {status === 'live' || status === 'reconnecting' ? <video ref={returnVideoRef} autoPlay playsInline className='h-full w-full object-contain' /> : null}
+          <audio ref={returnAudioRef} autoPlay playsInline />
+          <video
+            ref={previewRef}
+            autoPlay
+            playsInline
+            muted
+            className={
+              status === 'live' || status === 'reconnecting'
+                ? 'absolute bottom-4 right-4 aspect-video w-1/4 rounded-lg border-2 border-white/40 bg-black object-cover'
+                : 'h-full w-full object-cover'
+            }
+          />
+          {(status === 'live' || status === 'reconnecting') && !returnFeed ? (
+            <div className='absolute inset-0 flex items-center justify-center bg-zinc-950/80 text-center'>
+              <div>
+                <Radio className='mx-auto animate-pulse text-sky-300' />
+                <p className='mt-3 font-semibold'>Waiting for selected return feed</p>
+                <p className='mt-1 text-xs text-white/50'>
+                  {returnVideo} video · {returnAudioBus} N-1 audio
+                </p>
+              </div>
+            </div>
+          ) : null}
+          {status === 'ended' || status === 'left' ? (
+            <div className='absolute inset-0 flex items-center justify-center bg-zinc-950/95 text-xl'>
+              {status === 'left' ? 'You left the studio.' : 'The studio session ended.'}
+            </div>
+          ) : null}
+          {notice ? (
+            <div className='absolute inset-x-4 bottom-5 z-20 mx-auto max-w-xl rounded-xl border border-amber-300/50 bg-zinc-950/95 p-5 text-center shadow-2xl'>
+              <strong className={notice.type === 'cue' ? 'text-xl uppercase tracking-widest text-amber-300' : ''}>
+                {notice.type === 'cue' ? notice.cue : notice.type === 'message' ? notice.text : `Studio requests your ${notice.device}.`}
+              </strong>
+              <div className='mt-4 flex justify-center gap-2'>
+                {notice.type === 'media' ? (
+                  <>
+                    <Button onClick={() => void respondToEnable(true)}>Accept</Button>
+                    <Button variant='secondary' onClick={() => void respondToEnable(false)}>
+                      Decline
+                    </Button>
+                  </>
+                ) : (
+                  <Button onClick={() => void acknowledge(notice, 'acknowledged')}>
+                    <CheckCircle2 size={15} /> Acknowledge
+                  </Button>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </div>
+        {error ? (
+          <div role='alert' className='mt-4 rounded-xl border border-red-400/30 bg-red-400/10 p-4 text-sm text-red-200'>
+            {error}
+          </div>
+        ) : null}
+        <div className='mt-6 flex flex-wrap items-center justify-center gap-3'>
+          <Button variant='secondary' onClick={() => void toggleMedia('camera')}>
+            {cameraEnabled ? <Camera size={18} /> : <CameraOff size={18} />} {cameraEnabled ? 'Camera on' : 'Camera off'}
+          </Button>
+          <Button variant='secondary' onClick={() => void toggleMedia('microphone')}>
+            {microphoneEnabled ? <Mic size={18} /> : <MicOff size={18} />} {microphoneEnabled ? 'Mic on' : 'Mic off'}
+          </Button>
+          {status === 'ready' || status === 'error' ? (
+            <Button disabled={!readyToJoin} onClick={() => void join()}>
+              <Radio size={18} /> Join studio
+            </Button>
+          ) : null}
+          {status === 'joining' ? <Button loading>Joining</Button> : null}
+          {status === 'live' || status === 'reconnecting' ? (
+            <Button variant='destructive' onClick={leave}>
+              <PhoneOff size={18} /> Leave
+            </Button>
+          ) : null}
+        </div>
+        {status === 'ready' || status === 'error' ? (
+          <div className='mx-auto mt-8 grid max-w-3xl gap-5 rounded-2xl border border-white/10 bg-white/[0.04] p-6 sm:grid-cols-2'>
+            <Field label='Camera' className='[&_label]:text-white/70'>
+              <Select
+                value={cameraId}
+                onChange={(value) => void switchDevice('videoinput', value)}
+                options={cameras.map((device, index) => ({
+                  value: device.deviceId,
+                  label: device.label || `Camera ${index + 1}`
+                }))}
+              />
+            </Field>
+            <Field label='Microphone' className='[&_label]:text-white/70'>
+              <Select
+                value={microphoneId}
+                onChange={(value) => void switchDevice('audioinput', value)}
+                options={microphones.map((device, index) => ({
+                  value: device.deviceId,
+                  label: device.label || `Microphone ${index + 1}`
+                }))}
+              />
+            </Field>
+            <button type='button' onClick={() => void playSpeakerTest()} className='flex items-center gap-3 rounded-xl border border-white/10 p-4 text-left hover:bg-white/[0.05]'>
+              <Volume2 className={speakerChecked ? 'text-emerald-300' : 'text-sky-300'} />
+              <span>
+                <strong className='block'>Speaker test</strong>
+                <small className='text-white/50'>{speakerChecked ? 'Completed' : 'Play test tone'}</small>
+              </span>
+            </button>
+            <div className='rounded-xl border border-white/10 p-4'>
+              <strong className='block'>Network</strong>
+              <small className='text-white/50'>{network}</small>
+            </div>
+            <label className='flex items-center gap-3 rounded-xl border border-white/10 p-4'>
+              <input type='checkbox' checked={headphonesConfirmed} onChange={(event) => setHeadphonesConfirmed(event.target.checked)} />
+              <Headphones className='text-sky-300' />
+              <span>
+                <strong className='block'>I am wearing headphones</strong>
+                <small className='text-white/50'>Required to prevent echo.</small>
+              </span>
+            </label>
+            <label className='flex items-center gap-3 rounded-xl border border-amber-300/20 p-4'>
+              <input type='checkbox' checked={echoRiskAccepted} onChange={(event) => setEchoRiskAccepted(event.target.checked)} />
+              <span>
+                <strong className='block text-amber-200'>Operator accepted speaker risk</strong>
+                <small className='text-white/50'>Use only when headphones are impossible.</small>
+              </span>
+            </label>
+          </div>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/routes/layout.tsx
+++ b/frontend/app/routes/layout.tsx
@@ -24,6 +24,7 @@ import {
   List,
   LogOut,
   Music,
+  PhoneCall,
   Radio,
   RefreshCw,
   SlidersHorizontal,
@@ -271,7 +272,17 @@ export default function Layout() {
     return uniqueProgramIds.filter(Boolean).map((programIdValue) => {
       const program = programMap.get(programIdValue);
       const type = program?.type ?? 'tv';
-      const icon = type === 'radio' ? <Radio size={14} /> : type === 'both' ? <><Tv size={14} /><Radio size={14} /></> : <Tv size={14} />;
+      const icon =
+        type === 'radio' ? (
+          <Radio size={14} />
+        ) : type === 'both' ? (
+          <>
+            <Tv size={14} />
+            <Radio size={14} />
+          </>
+        ) : (
+          <Tv size={14} />
+        );
       return {
         label: programIdValue,
         value: programIdValue,
@@ -286,6 +297,7 @@ export default function Layout() {
     { href: '/instants', label: 'Instants' },
     { href: '/songs', label: 'Songs' },
     { href: '/media', label: 'Media' },
+    { href: '/calls', label: 'Guest Calls' },
     { href: '/scenes', label: 'Scenes' },
     { href: '/programs', label: 'Programs' },
     { href: '/preview', label: 'Preview' },
@@ -301,6 +313,7 @@ export default function Layout() {
         { href: '/instants', label: 'Instants' },
         { href: '/songs', label: 'Songs' },
         { href: '/media', label: 'Media' },
+        { href: '/calls', label: 'Guest Calls' },
         { href: '/scenes', label: 'Scenes' },
         { href: '/programs', label: 'Programs' }
       ].filter((item) => hasPermission(routePermission(item.href)))
@@ -438,6 +451,14 @@ export default function Layout() {
         onSelect: () => navigate('/media')
       },
       {
+        id: 'nav-calls',
+        title: 'Go to Guest Calls',
+        description: 'Invite and direct remote contributors',
+        group: 'Navigation',
+        icon: <PhoneCall size={16} />,
+        onSelect: () => navigate('/calls')
+      },
+      {
         id: 'nav-programs',
         title: 'Go to Programs',
         description: 'Manage create/edit/delete for programs',
@@ -525,9 +546,7 @@ export default function Layout() {
       {
         id: 'open-broadcast-time-override',
         title: 'Set Global Broadcast Time Override',
-        description: broadcastSettings?.timeOverrideEnabled
-          ? `Active from ${broadcastSettings.timeOverrideStartTime || '--:--'}`
-          : 'Disabled (clocks use live timezone time)',
+        description: broadcastSettings?.timeOverrideEnabled ? `Active from ${broadcastSettings.timeOverrideStartTime || '--:--'}` : 'Disabled (clocks use live timezone time)',
         group: 'Broadcast',
         icon: <Clock3 size={16} />,
         keywords: ['clock', 'time override', 'broadcast time', 'global'],
@@ -582,7 +601,10 @@ export default function Layout() {
         const activateRes = await fetch(apiUrl(`/program/${encodeURIComponent(selectedProgramId)}/activate`), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sceneId: scene.id, transitionId: selectedTransition.id })
+          body: JSON.stringify({
+            sceneId: scene.id,
+            transitionId: selectedTransition.id
+          })
         });
         if (!activateRes.ok) {
           throw new Error(`Failed to activate scene (${activateRes.status})`);
@@ -739,9 +761,7 @@ export default function Layout() {
             Applies to all programs and scenes for clock widgets.
             <br />
             {broadcastSettings?.timeOverrideEnabled
-              ? `Active from ${broadcastSettings.timeOverrideStartTime || '--:--'} (started ${new Date(
-                  broadcastSettings.timeOverrideStartedAt || Date.now()
-                ).toLocaleString()})`
+              ? `Active from ${broadcastSettings.timeOverrideStartTime || '--:--'} (started ${new Date(broadcastSettings.timeOverrideStartedAt || Date.now()).toLocaleString()})`
               : 'Disabled (clocks use live timezone time).'}
           </p>
 

--- a/frontend/app/routes/program.tsx
+++ b/frontend/app/routes/program.tsx
@@ -25,6 +25,7 @@ import {
   CronicaReiteramos,
   Slideshow,
   VideoStream,
+  WebrtcGuestSource,
   StreamWall,
   Scoreboard
 } from '../components';
@@ -40,7 +41,7 @@ import {
   getProgramAudioBusSnapshot,
   setProgramAudioBusMasterVolume,
   stopProgramAudioBus,
-  subscribeProgramAudioBus,
+  subscribeProgramAudioBus
 } from '../utils/programAudioBus';
 import { faderToGain } from '../utils/audioTaper';
 import { normalizeProgramSongSequence, resolveProgramSongLeaf, type ProgramSongSequence, type ProgramSongSequenceItem } from '../utils/programSequence';
@@ -642,7 +643,7 @@ function sceneIncludesVideoStream(scene: Scene | null | undefined): boolean {
     .split(',')
     .map((componentType) => componentType.trim())
     .filter(Boolean)
-    .includes('video-stream');
+    .some((componentType) => componentType === 'video-stream' || componentType === 'webrtc-guest');
 }
 
 function normalizeSceneInstantNumericId(value: unknown): number | null {
@@ -669,11 +670,18 @@ export default function Program() {
   const [searchParams] = useSearchParams();
   const programId = id ?? 'main';
   const confidenceMode = searchParams.get('confidence');
+  const rendererMode = searchParams.get('renderer') === '1';
 
-  return <SceneProgram programId={programId} confidenceMode={confidenceMode === 'preview' ? 'preview' : confidenceMode === 'program' ? 'program' : null} />;
+  return (
+    <SceneProgram
+      programId={programId}
+      confidenceMode={confidenceMode === 'preview' ? 'preview' : confidenceMode === 'program' ? 'program' : null}
+      suppressGuestAudio={rendererMode}
+    />
+  );
 }
 
-function SceneProgram({ programId, confidenceMode }: { programId: string; confidenceMode: 'preview' | 'program' | null }) {
+function SceneProgram({ programId, confidenceMode, suppressGuestAudio }: { programId: string; confidenceMode: 'preview' | 'program' | null; suppressGuestAudio: boolean }) {
   const [state, setState] = useState<ProgramState | null>(null);
   const [audioBusSettings, setAudioBusSettings] = useState<ProgramAudioBusSettings | null>(null);
   const [broadcastSettings, setBroadcastSettings] = useState<BroadcastSettings | null>(null);
@@ -801,10 +809,7 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
     return () => window.cancelAnimationFrame(animationFrame);
   }, [confidenceMode, state?.fadeToBlack]);
   const resolvedManualSong = useMemo(
-    () =>
-      normalizedSongSequence?.mode === 'manual'
-        ? resolveProgramSongLeaf({ sequence: normalizedSongSequence })
-        : null,
+    () => (normalizedSongSequence?.mode === 'manual' ? resolveProgramSongLeaf({ sequence: normalizedSongSequence }) : null),
     [normalizedSongSequence]
   );
   const activeSlideshowMediaGroupId = useMemo(() => {
@@ -865,7 +870,13 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
 
     try {
       const attachFromStream = (): boolean => {
-        const stream = audio.captureStream?.() || (audio as HTMLAudioElement & { mozCaptureStream?: () => MediaStream }).mozCaptureStream?.();
+        const stream =
+          audio.captureStream?.() ||
+          (
+            audio as HTMLAudioElement & {
+              mozCaptureStream?: () => MediaStream;
+            }
+          ).mozCaptureStream?.();
         if (!stream) {
           return false;
         }
@@ -938,7 +949,10 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
     }
   }, []);
 
-  const readInstantSignalSnapshot = useCallback((): { rms: number; peak: number } => {
+  const readInstantSignalSnapshot = useCallback((): {
+    rms: number;
+    peak: number;
+  } => {
     let rmsPeak = 0;
     let peak = 0;
     for (const [audio, runtime] of activeInstantAudiosRef.current) {
@@ -974,7 +988,10 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
     };
   }, []);
 
-  const readSceneInstantSignalSnapshot = useCallback((): { rms: number; peak: number } => {
+  const readSceneInstantSignalSnapshot = useCallback((): {
+    rms: number;
+    peak: number;
+  } => {
     const current = activeSceneInstantAudioRef.current;
     if (!current) {
       return { rms: 0, peak: 0 };
@@ -1299,8 +1316,7 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
 
   const shouldApplyProgramUpdatePayload = useCallback((payload: unknown, topicOverride?: ProgramUpdateTopic): boolean => {
     const topic =
-      topicOverride ??
-      (payload && typeof payload === 'object' && !Array.isArray(payload) ? resolveProgramUpdateTopicFromType((payload as Record<string, unknown>).type) : null);
+      topicOverride ?? (payload && typeof payload === 'object' && !Array.isArray(payload) ? resolveProgramUpdateTopicFromType((payload as Record<string, unknown>).type) : null);
     if (!topic) {
       return true;
     }
@@ -1481,13 +1497,7 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
           return;
         }
         const playback = event.playback;
-        if (
-          playback &&
-          playback.isPlaying &&
-          playback.instant &&
-          typeof playback.instant.audioUrl === 'string' &&
-          playback.instant.audioUrl.trim().length > 0
-        ) {
+        if (playback && playback.isPlaying && playback.instant && typeof playback.instant.audioUrl === 'string' && playback.instant.audioUrl.trim().length > 0) {
           const sceneId = normalizeSceneInstantNumericId(playback.sceneId);
           const instantId = normalizeSceneInstantNumericId(playback.instant.id);
           const timestamp = normalizeSceneInstantTimestamp(playback.startedAt) || normalizeSceneInstantTimestamp(playback.updatedAt);
@@ -1538,7 +1548,7 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
                 audioUrl,
                 durationMs: typeof playback.durationMs === 'number' ? playback.durationMs : undefined,
                 artist: typeof playback.artist === 'string' ? playback.artist : undefined,
-                title: typeof playback.title === 'string' ? playback.title : undefined,
+                title: typeof playback.title === 'string' ? playback.title : undefined
               });
             }
           }
@@ -1705,9 +1715,7 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
         .then((playback) => {
           if (!cancelled) {
             const sceneInstantVersion =
-              playback && typeof playback === 'object' && !Array.isArray(playback)
-                ? normalizeUpdateVersion((playback as Record<string, unknown>).version)
-                : null;
+              playback && typeof playback === 'object' && !Array.isArray(playback) ? normalizeUpdateVersion((playback as Record<string, unknown>).version) : null;
             handleProgramEventRef.current({
               type: 'scene_instant_state',
               programId,
@@ -1771,9 +1779,7 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
         .then((playback) => {
           if (!cancelled) {
             const sceneInstantVersion =
-              playback && typeof playback === 'object' && !Array.isArray(playback)
-                ? normalizeUpdateVersion((playback as Record<string, unknown>).version)
-                : null;
+              playback && typeof playback === 'object' && !Array.isArray(playback) ? normalizeUpdateVersion((playback as Record<string, unknown>).version) : null;
             handleProgramEventRef.current({
               type: 'scene_instant_state',
               programId,
@@ -2095,11 +2101,7 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
     const hasProgramPodcastPlayerComponent = components.includes('modoitaliano-podcast-player');
     const shouldRenderProgramRow =
       hasProgramClockComponent &&
-      (hasProgramChyronComponent ||
-        hasProgramDisclaimerComponent ||
-        hasCronicaChyronComponent ||
-        hasProgramBracketComponent ||
-        hasProgramPodcastPlayerComponent);
+      (hasProgramChyronComponent || hasProgramDisclaimerComponent || hasCronicaChyronComponent || hasProgramBracketComponent || hasProgramPodcastPlayerComponent);
     const modoItalianoChyronProps = metadata['modoitaliano-chyron'] || {};
     const modoItalianoDisclaimerProps = metadata['modoitaliano-disclaimer'] || {};
     const toBoolean = (value: unknown, fallback: boolean): boolean => {
@@ -2168,13 +2170,29 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
             switch (componentType) {
               case 'ticker':
                 return (
-                  <div key={componentType} style={{ position: 'absolute', bottom: 0, left: 0, right: 0 }}>
+                  <div
+                    key={componentType}
+                    style={{
+                      position: 'absolute',
+                      bottom: 0,
+                      left: 0,
+                      right: 0
+                    }}
+                  >
                     <Ticker hashtag={props.hashtag || '#Default'} url={props.url || 'website.com'} />
                   </div>
                 );
               case 'chyron':
                 return (
-                  <div key={componentType} style={{ position: 'absolute', bottom: '120px', left: 0, right: 0 }}>
+                  <div
+                    key={componentType}
+                    style={{
+                      position: 'absolute',
+                      bottom: '120px',
+                      left: 0,
+                      right: 0
+                    }}
+                  >
                     <ChyronHolder text={props.text || 'Chyron'} show={true} />
                   </div>
                 );
@@ -2221,6 +2239,18 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
                     maxStreams={typeof props.maxStreams === 'number' ? props.maxStreams : 4}
                     title={typeof props.title === 'string' ? props.title : ''}
                     suspended={outputGain <= 0.0001}
+                  />
+                );
+              case 'webrtc-guest':
+                return (
+                  <WebrtcGuestSource
+                    key={componentType}
+                    programId={programId}
+                    slotNumber={props.slotNumber}
+                    objectFit={props.objectFit}
+                    showStatus={props.showStatus}
+                    suppressAudio={suppressGuestAudio}
+                    channelGain={options?.forceStreamMuted ? 0 : resolvedStreamMasterVolume}
                   />
                 );
               case 'scoreboard':
@@ -2272,11 +2302,7 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
                     text={typeof fifthBellChyronProps.text === 'string' ? fifthBellChyronProps.text : ''}
                     show={true}
                     useMarquee={typeof fifthBellChyronProps.useMarquee === 'boolean' ? fifthBellChyronProps.useMarquee : undefined}
-                    contentMode={
-                      fifthBellChyronProps.contentMode === 'text' || fifthBellChyronProps.contentMode === 'sequence'
-                        ? fifthBellChyronProps.contentMode
-                        : undefined
-                    }
+                    contentMode={fifthBellChyronProps.contentMode === 'text' || fifthBellChyronProps.contentMode === 'sequence' ? fifthBellChyronProps.contentMode : undefined}
                     sequence={fifthBellChyronProps.sequence}
                     socialHandles={fifthBellChyronProps.socialHandles}
                   />
@@ -2299,12 +2325,8 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
                     key={componentType}
                     timeOverride={globalTimeOverride}
                     cities={Array.isArray(fifthBellClockProps.worldClockCities) ? fifthBellClockProps.worldClockCities : undefined}
-                    rotationIntervalMs={
-                      typeof fifthBellClockProps.worldClockRotateIntervalMs === 'number' ? fifthBellClockProps.worldClockRotateIntervalMs : undefined
-                    }
-                    transitionDurationMs={
-                      typeof fifthBellClockProps.worldClockTransitionMs === 'number' ? fifthBellClockProps.worldClockTransitionMs : undefined
-                    }
+                    rotationIntervalMs={typeof fifthBellClockProps.worldClockRotateIntervalMs === 'number' ? fifthBellClockProps.worldClockRotateIntervalMs : undefined}
+                    transitionDurationMs={typeof fifthBellClockProps.worldClockTransitionMs === 'number' ? fifthBellClockProps.worldClockTransitionMs : undefined}
                     shuffleCities={typeof fifthBellClockProps.worldClockShuffle === 'boolean' ? fifthBellClockProps.worldClockShuffle : undefined}
                     widthPx={typeof fifthBellClockProps.worldClockWidthPx === 'number' ? fifthBellClockProps.worldClockWidthPx : undefined}
                     showWorldClocks={typeof fifthBellClockProps.showWorldClocks === 'boolean' ? fifthBellClockProps.showWorldClocks : undefined}
@@ -2424,7 +2446,16 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
               default:
                 console.warn('Unknown component type:', componentType);
                 return (
-                  <div key={componentType} style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', color: 'white' }}>
+                  <div
+                    key={componentType}
+                    style={{
+                      position: 'absolute',
+                      top: '50%',
+                      left: '50%',
+                      transform: 'translate(-50%, -50%)',
+                      color: 'white'
+                    }}
+                  >
                     Unknown component: {componentType}
                   </div>
                 );
@@ -2450,9 +2481,7 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
                   text={modoItalianoDisclaimerProps.text || ''}
                   show
                   align={
-                    modoItalianoDisclaimerProps.align === 'left' ||
-                    modoItalianoDisclaimerProps.align === 'center' ||
-                    modoItalianoDisclaimerProps.align === 'right'
+                    modoItalianoDisclaimerProps.align === 'left' || modoItalianoDisclaimerProps.align === 'center' || modoItalianoDisclaimerProps.align === 'right'
                       ? modoItalianoDisclaimerProps.align
                       : 'right'
                   }
@@ -2499,7 +2528,10 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
           <div
             className='pointer-events-none absolute inset-0 z-[2000] bg-black'
             data-confidence-fade-to-black={state?.fadeToBlack ? 'active' : 'inactive'}
-            style={{ opacity: state?.fadeToBlack ? 1 : 0, transition: shouldAnimateFadeToBlack ? 'opacity 1000ms linear' : 'none' }}
+            style={{
+              opacity: state?.fadeToBlack ? 1 : 0,
+              transition: shouldAnimateFadeToBlack ? 'opacity 1000ms linear' : 'none'
+            }}
           />
         ) : null}
       </div>
@@ -2516,7 +2548,10 @@ function SceneProgram({ programId, confidenceMode }: { programId: string; confid
       <div
         className='pointer-events-none absolute inset-0 z-[2000] bg-black'
         data-fade-to-black={state?.fadeToBlack ? 'active' : 'inactive'}
-        style={{ opacity: state?.fadeToBlack ? 1 : 0, transition: shouldAnimateFadeToBlack ? 'opacity 1000ms linear' : 'none' }}
+        style={{
+          opacity: state?.fadeToBlack ? 1 : 0,
+          transition: shouldAnimateFadeToBlack ? 'opacity 1000ms linear' : 'none'
+        }}
       />
     </div>
   );

--- a/frontend/app/routes/return-router.tsx
+++ b/frontend/app/routes/return-router.tsx
@@ -1,0 +1,211 @@
+import { LocalAudioTrack, ConnectionState, Room, RoomEvent, Track, type RemoteParticipant, type RemoteTrack, type RemoteTrackPublication } from 'livekit-client';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+import { apiUrl } from '../utils/apiBaseUrl';
+import type { Route } from './+types/return-router';
+
+type RouteState = {
+  participantIdentity: string;
+  slotNumber: number;
+  returnVideo: 'program' | 'preview' | 'none';
+  returnAudioBus: string;
+  sourceGain: number;
+  sourceMuted: boolean;
+  sourceDelayMs: number;
+};
+
+type InputTrack = {
+  key: string;
+  participantIdentity: string;
+  trackName: string;
+  source: MediaStreamAudioSourceNode;
+};
+
+type PublishedMix = {
+  track: LocalAudioTrack;
+  destination: MediaStreamAudioDestinationNode;
+};
+
+export function meta({}: Route.MetaArgs) {
+  return [{ title: 'Return Router - Alcántara' }];
+}
+
+function readRendererKey() {
+  const fragment = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+  const key = fragment.get('key') || window.sessionStorage.getItem('alcantara-renderer-key') || '';
+  if (key) window.sessionStorage.setItem('alcantara-renderer-key', key);
+  window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`);
+  return key;
+}
+
+export default function ReturnRouterRoute() {
+  const { programId = 'main' } = useParams();
+  const [status, setStatus] = useState('Starting isolated return router…');
+  const [mixCount, setMixCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const rendererKey = readRendererKey();
+    const room = new Room({ adaptiveStream: false, dynacast: false });
+    const context = new AudioContext({ latencyHint: 'interactive' });
+    const inputs = new Map<string, InputTrack>();
+    const mixes = new Map<string, PublishedMix>();
+    let routes: RouteState[] = [];
+    let rebuildTimer = 0;
+    let stateTimer = 0;
+
+    const unpublishMixes = async () => {
+      const pending = Array.from(mixes.values()).map(async (mix) => {
+        await room.localParticipant.unpublishTrack(mix.track);
+        mix.track.stop();
+        mix.destination.disconnect();
+      });
+      mixes.clear();
+      await Promise.all(pending);
+    };
+
+    const rebuild = async () => {
+      if (cancelled || room.state !== ConnectionState.Connected) return;
+      await unpublishMixes();
+      inputs.forEach((input) => input.source.disconnect());
+      const connectedGuests = new Set(
+        Array.from(room.remoteParticipants.values())
+          .filter((participant) => participant.identity.startsWith('guest-'))
+          .map((participant) => participant.identity)
+      );
+      for (const route of routes.filter((item) => connectedGuests.has(item.participantIdentity))) {
+        const destination = context.createMediaStreamDestination();
+        for (const input of inputs.values()) {
+          const isOwnGuest = input.participantIdentity === route.participantIdentity;
+          const isOtherGuest = input.participantIdentity.startsWith('guest-') && !isOwnGuest;
+          const isSelectedBus =
+            input.participantIdentity === `${route.returnAudioBus}-feed-${programId}` ||
+            (route.returnAudioBus === 'master' && input.participantIdentity === `program-feed-${programId}`);
+          const isTargetedTalkback =
+            input.participantIdentity.startsWith('operator-') &&
+            (input.trackName === `talkback:${route.participantIdentity.replace(/^guest-/, '')}` || input.trackName === 'talkback:all');
+          if (isSelectedBus || isTargetedTalkback) {
+            input.source.connect(destination);
+          } else if (isOtherGuest) {
+            const sourceRoute = routes.find((candidate) => candidate.participantIdentity === input.participantIdentity);
+            if (sourceRoute?.sourceMuted) continue;
+            const gain = context.createGain();
+            gain.gain.value = sourceRoute?.sourceGain ?? 1;
+            const delay = context.createDelay(2);
+            delay.delayTime.value = (sourceRoute?.sourceDelayMs ?? 0) / 1000;
+            input.source.connect(gain).connect(delay).connect(destination);
+          }
+        }
+        const mediaTrack = destination.stream.getAudioTracks()[0];
+        const localTrack = new LocalAudioTrack(mediaTrack);
+        await room.localParticipant.publishTrack(localTrack, {
+          name: `mixminus:${route.participantIdentity}:${route.returnAudioBus}`,
+          source: Track.Source.Microphone
+        });
+        mixes.set(route.participantIdentity, {
+          track: localTrack,
+          destination
+        });
+      }
+      if (!cancelled) {
+        setMixCount(mixes.size);
+        setStatus(`${mixes.size} synchronized N-1 return mix${mixes.size === 1 ? '' : 'es'} active`);
+      }
+    };
+
+    const scheduleRebuild = () => {
+      window.clearTimeout(rebuildTimer);
+      rebuildTimer = window.setTimeout(() => void rebuild().catch((error) => setStatus(error instanceof Error ? error.message : 'Mix rebuild failed.')), 100);
+    };
+
+    const addTrack = (track: RemoteTrack, publication: RemoteTrackPublication, participant: RemoteParticipant) => {
+      if (track.kind !== Track.Kind.Audio || !track.mediaStreamTrack) return;
+      const key = publication.trackSid;
+      const source = context.createMediaStreamSource(new MediaStream([track.mediaStreamTrack]));
+      inputs.set(key, {
+        key,
+        participantIdentity: participant.identity,
+        trackName: publication.trackName,
+        source
+      });
+      scheduleRebuild();
+    };
+
+    const removeTrack = (_track: RemoteTrack, publication: RemoteTrackPublication) => {
+      const input = inputs.get(publication.trackSid);
+      input?.source.disconnect();
+      inputs.delete(publication.trackSid);
+      scheduleRebuild();
+    };
+
+    const loadRoutes = async () => {
+      const response = await fetch(apiUrl('/webrtc/renderer-state'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Renderer-Key': rendererKey
+        },
+        body: JSON.stringify({ programId })
+      });
+      if (!response.ok) throw new Error(`Return routing state failed (${response.status}).`);
+      const payload = (await response.json()) as { routes: RouteState[] };
+      const changed = JSON.stringify(routes) !== JSON.stringify(payload.routes);
+      routes = payload.routes;
+      if (changed) scheduleRebuild();
+    };
+
+    const start = async () => {
+      if (!rendererKey) throw new Error('Renderer bootstrap key is required in the URL fragment.');
+      const response = await fetch(apiUrl('/webrtc/renderer-token'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Renderer-Key': rendererKey
+        },
+        body: JSON.stringify({ programId })
+      });
+      if (!response.ok) throw new Error(`Renderer authorization failed (${response.status}).`);
+      const credentials = (await response.json()) as {
+        serverUrl: string;
+        token: string;
+      };
+      room.on(RoomEvent.TrackSubscribed, addTrack);
+      room.on(RoomEvent.TrackUnsubscribed, removeTrack);
+      room.on(RoomEvent.ParticipantConnected, scheduleRebuild);
+      room.on(RoomEvent.ParticipantDisconnected, scheduleRebuild);
+      room.on(RoomEvent.Reconnecting, () => setStatus('Reconnecting return router…'));
+      room.on(RoomEvent.Reconnected, scheduleRebuild);
+      await room.connect(credentials.serverUrl, credentials.token, {
+        autoSubscribe: true
+      });
+      await context.resume();
+      await loadRoutes();
+      stateTimer = window.setInterval(() => void loadRoutes().catch((error) => setStatus(error instanceof Error ? error.message : 'Route refresh failed.')), 3000);
+      scheduleRebuild();
+    };
+
+    void start().catch((error) => setStatus(error instanceof Error ? error.message : 'Return router failed.'));
+    return () => {
+      cancelled = true;
+      window.clearTimeout(rebuildTimer);
+      window.clearInterval(stateTimer);
+      void unpublishMixes();
+      inputs.forEach((input) => input.source.disconnect());
+      room.disconnect();
+      void context.close();
+    };
+  }, [programId]);
+
+  return (
+    <main className='flex min-h-screen items-center justify-center bg-zinc-950 p-8 text-white'>
+      <div className='max-w-xl text-center'>
+        <div className={`mx-auto h-4 w-4 rounded-full ${mixCount ? 'bg-emerald-400' : 'animate-pulse bg-amber-300'}`} />
+        <h1 className='mt-5 text-2xl font-semibold'>Alcántara return router</h1>
+        <p className='mt-3 text-white/60'>{status}</p>
+        <p className='mt-6 text-xs text-white/35'>
+          This machine-only page produces a distinct Program/Monitor/Aux N-1 mix for every connected guest. Keep it isolated with the Alana renderer.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "fast-average-color": "^9.5.0",
     "hls.js": "^1.6.15",
     "isbot": "^5.1.31",
+    "livekit-client": "2.21.0",
     "lucide-react": "^0.563.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/infra/compose.production.yml
+++ b/infra/compose.production.yml
@@ -1,0 +1,38 @@
+name: alcantara-media
+
+services:
+  redis:
+    image: redis:7.4-alpine
+    container_name: alcantara-livekit-redis
+    command: ['redis-server', '--save', '60', '1', '--appendonly', 'yes']
+    volumes:
+      - /services/alcantara/livekit-redis:/data
+    restart: always
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  livekit:
+    image: livekit/livekit-server:v1.13.4
+    container_name: alcantara-livekit
+    command: ['--config', '/etc/livekit.yaml']
+    volumes:
+      - /services/alcantara/livekit.yaml:/etc/livekit.yaml:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    ports:
+      - '7880:7880/tcp'
+      - '7881:7881/tcp'
+      - '3478:3478/udp'
+      - '443:443/tcp'
+      - '30000-40000:30000-40000/udp'
+      - '50000-60000:50000-60000/udp'
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: always
+
+networks:
+  default:
+    name: alcantara

--- a/infra/livekit.dev.yaml
+++ b/infra/livekit.dev.yaml
@@ -1,0 +1,11 @@
+port: 7880
+log_level: info
+rtc:
+  tcp_port: 7881
+  udp_port: 7882
+  use_external_ip: false
+room:
+  empty_timeout: 300
+  departure_timeout: 60
+keys:
+  devkey: devsecret-devsecret-devsecret-devsecret

--- a/infra/livekit.production.example.yaml
+++ b/infra/livekit.production.example.yaml
@@ -1,0 +1,19 @@
+# Render this template from deployment secrets. Never commit real values.
+port: 7880
+rtc:
+  tcp_port: 7881
+  port_range_start: 50000
+  port_range_end: 60000
+  use_external_ip: true
+redis:
+  address: redis.internal:6379
+turn:
+  enabled: true
+  domain: turn.example.invalid
+  tls_port: 443
+  udp_port: 3478
+  relay_range_start: 30000
+  relay_range_end: 40000
+  ttl_seconds: 300
+keys:
+  replace-api-key: replace-api-secret

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
+      livekit-server-sdk:
+        specifier: 2.17.0
+        version: 2.17.0
       music-metadata:
         specifier: ^11.12.3
         version: 11.12.3
@@ -174,6 +177,9 @@ importers:
       isbot:
         specifier: ^5.1.31
         version: 5.1.34
+      livekit-client:
+        specifier: 2.21.0
+        version: 2.21.0(@types/dom-mediacapture-record@1.0.22)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
@@ -710,6 +716,9 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@bufbuild/protobuf@1.10.1':
+    resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
 
   '@chevrotain/cst-dts-gen@10.5.0':
     resolution: {integrity: sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==}
@@ -1365,6 +1374,12 @@ packages:
     resolution: {integrity: sha512-Fj0j8RnBpo43tVZUVoNK6BV/9AtDUM5S7DF3LB4qTYg1LMSZqi3yeCneUTLJD6XomQJlZzbI4mst89yspVSAnA==}
     cpu: [x64]
     os: [win32]
+
+  '@livekit/mutex@1.1.1':
+    resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
+
+  '@livekit/protocol@1.50.4':
+    resolution: {integrity: sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -2927,6 +2942,9 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/dom-mediacapture-record@1.0.22':
+    resolution: {integrity: sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -4647,6 +4665,12 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
+  jose@6.2.9:
+    resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
+
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -4809,6 +4833,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  livekit-client@2.21.0:
+    resolution: {integrity: sha512-RBUhPkV/sl1nzl8lokVlK5uATPwn0AlsudCBZXissw/kDl9yz8ac4pNJ43iPpMVoHOeBYH/BZ3vUC1adqa/zFQ==}
+    peerDependencies:
+      '@types/dom-mediacapture-record': ^1
+
+  livekit-server-sdk@2.17.0:
+    resolution: {integrity: sha512-GWNEQrUD13UwZNrmosyTVFPgeBvSU2lFKGxdA4DaUI5F4sMb1cGeep/PPEE9vvRNELJYpxWS0ImS4gQmovKUDA==}
+    engines: {node: '>=18'}
+
   load-esm@1.0.3:
     resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
     engines: {node: '>=13.2.0'}
@@ -4864,6 +4897,10 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -5629,6 +5666,13 @@ packages:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
+  sdp-transform@2.15.0:
+    resolution: {integrity: sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==}
+    hasBin: true
+
+  sdp@3.2.2:
+    resolution: {integrity: sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -5996,6 +6040,9 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typed-emitter@2.1.0:
+    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
+
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
@@ -6205,6 +6252,10 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  webrtc-adapter@9.0.6:
+    resolution: {integrity: sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==}
+    engines: {node: '>=6.0.0', npm: '>=3.10.0'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -7300,6 +7351,8 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@bufbuild/protobuf@1.10.1': {}
+
   '@chevrotain/cst-dts-gen@10.5.0':
     dependencies:
       '@chevrotain/gast': 10.5.0
@@ -8038,6 +8091,12 @@ snapshots:
 
   '@libsql/win32-x64-msvc@0.5.22':
     optional: true
+
+  '@livekit/mutex@1.1.1': {}
+
+  '@livekit/protocol@1.50.4':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
 
   '@lukeed/csprng@1.1.0': {}
 
@@ -9686,6 +9745,8 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/dom-mediacapture-record@1.0.22': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -11714,6 +11775,10 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@5.10.0: {}
+
+  jose@6.2.9: {}
+
   js-base64@3.7.8: {}
 
   js-cookie@3.0.5: {}
@@ -11864,6 +11929,25 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  livekit-client@2.21.0(@types/dom-mediacapture-record@1.0.22):
+    dependencies:
+      '@livekit/mutex': 1.1.1
+      '@livekit/protocol': 1.50.4
+      '@types/dom-mediacapture-record': 1.0.22
+      events: 3.3.0
+      jose: 6.2.9
+      loglevel: 1.9.2
+      sdp-transform: 2.15.0
+      tslib: 2.8.1
+      typed-emitter: 2.1.0
+      webrtc-adapter: 9.0.6
+
+  livekit-server-sdk@2.17.0:
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
+      '@livekit/protocol': 1.50.4
+      jose: 5.10.0
+
   load-esm@1.0.3: {}
 
   loader-runner@4.3.1: {}
@@ -11904,6 +11988,8 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  loglevel@1.9.2: {}
 
   long@5.3.2: {}
 
@@ -12646,6 +12732,10 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
+  sdp-transform@2.15.0: {}
+
+  sdp@3.2.2: {}
+
   secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
@@ -13022,6 +13112,10 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typed-emitter@2.1.0:
+    optionalDependencies:
+      rxjs: 7.8.2
+
   typedarray@0.0.6: {}
 
   typescript-compare@0.0.2:
@@ -13253,6 +13347,10 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  webrtc-adapter@9.0.6:
+    dependencies:
+      sdp: 3.2.2
 
   whatwg-url@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- add persisted, permission-gated invitation and session management for six stable remote-guest slots, including reconnect leases, immediate mute, consent-based enable commands, cues, messages, acknowledgements, and targeted talkback
- add self-hosted LiveKit configuration and production deployment contracts with short-lived scoped credentials, a machine-only renderer boundary, Redis-backed production signaling, TLS/TURN configuration, and committed database migrations
- add the operator guest-call console, guest preflight/call experience, reusable scene sources, and a return router that publishes a distinct selected-bus N-1 mix for each guest with per-source gain, mute, and delay

## Validation

- backend: 7 test suites and 25 tests passed
- backend: production build and scoped ESLint passed
- frontend: production SPA build passed
- frontend typecheck: the same 21 pre-existing G-86 base errors remain; G-85 introduces no new error category or affected file
- local and production Compose configurations render successfully
- fresh-volume local stack: PostgreSQL, Pompeii, LiveKit 1.13.4, backend, and frontend all reached healthy/running state
- API smoke: six slots accepted; seventh and concurrent joins rejected; heartbeat, revoke, scoped JWT, and acknowledgement persistence verified
- browser UAT with fake media: six simultaneous guests connected, six distinct N-1 mixes became active, cue acknowledgement persisted, and the guest reconnect flow completed within the 60-second lease

## UAT boundary

- this PR is ready for review and UAT; it does not deploy production
- production UAT should still exercise six physical/external devices, restrictive-network TURN fallback, the deployed Cognito/Pompeii permission path, and Alana's Program/Preview publication on the production renderer

Closes G-85
## Summary by Sourcery

Ship a secure six-guest WebRTC contribution workflow with operator controls, guest experiences, isolated return mixes, and self-hosted media infrastructure.

New Features:
- Add a permission-gated operator console for managing six reusable guest invitations, sessions, returns, controls, cues, messages, acknowledgements, and talkback.
- Add a guest preflight and call experience with device selection, consent-based controls, reconnect leases, and selected return feeds.
- Add reusable WebRTC guest scene sources and isolated per-guest N-1 return routing for Program, Preview, monitor, and auxiliary buses.

Enhancements:
- Secure guest access with persisted invitation hashes, short-lived scoped LiveKit credentials, session leases, and a machine-authenticated renderer boundary.
- Persist guest invitations, commands, and events through PostgreSQL migrations and expose the WebRTC control API.
- Add self-hosted LiveKit and Redis infrastructure with local Compose support and production deployment contracts including TLS, TURN, and media networking.
- Document local operation, production configuration, and renderer deployment requirements.

Build:
- Add LiveKit server and client dependencies and integrate the local media service into Compose.

CI:
- Deploy the production LiveKit Compose definition when backend or infrastructure changes are merged.

Deployment:
- Add production LiveKit and Redis deployment configuration with persistent signaling storage, TLS/TURN settings, and scoped runtime secrets.

Documentation:
- Document the six-guest workflow, return routing, local testing, and production operational requirements.

Tests:
- Add backend coverage for invitation lifecycle, session security, concurrent joins, revocation, LiveKit credentials, and renderer authentication.