### PR TITLE
fix(auth): isolate transitional renderer boundary (G-118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,41 @@ the committed local credentials outside Compose.
   - Full Screen
   - Corner Bug
 
+#### Transitional renderer boundary (G-118)
+
+The Alana-owned Program renderer remains a trusted machine-runtime client while
+machine authentication is extracted in G-119. Alcantara exposes only the
+following renderer HTTP surface without an operator bearer token:
+
+| Direction  | Route                                                             | Renderer purpose                |
+| ---------- | ----------------------------------------------------------------- | ------------------------------- |
+| Read       | `GET /program/broadcast-settings`                                 | Audio and timing bootstrap      |
+| Read       | `GET /program/:programId/state` and legacy `GET /program/state`   | Active scene and Program state  |
+| Read       | `GET /program/:programId/audio-bus`                               | Audio-bus bootstrap             |
+| Read/write | `GET`/`POST /program/:programId/audio-meter`                      | Meter snapshot and telemetry    |
+| Read       | `GET /program/:programId/scene-instant`                           | Scene-instant playback restore  |
+| Read/write | `GET`/`POST /program/:programId/song-playback`                    | Song playback state             |
+| Read       | `GET /program/audio-proxy`                                        | Same-origin renderer audio      |
+| Read       | `GET /program/:programId/media-groups`                            | Program media-group assignments |
+| Read       | `GET /program/:programId/stingers`                                | Program stinger preload         |
+| Read       | `SSE /program/:programId/events` and legacy `SSE /program/events` | Program event stream            |
+| Read       | `GET /media-groups/:id`                                           | Active slideshow media          |
+| Read       | `GET /charts/sanremo-realtime`                                    | Renderer chart data             |
+
+The renderer WebSocket connects to
+`/program/ws?programId=<id>&role=program`. It may send only
+`audio_meter_update`, `song_playback_update`, and `song_ended`. The role never
+receives operator snapshots or operator event broadcasts, and all other inbound
+message types are rejected. Operator REST and realtime access continues through
+Cognito plus Pompeii permissions; `role=control` also requires a protected,
+single-use realtime ticket.
+
+This is an explicitly transitional trust boundary: the renderer role is
+self-declared and its two telemetry/playback writes are unauthenticated. Keep
+the renderer URL and runtime network exposure limited to the deployed broadcast
+environment until G-119 replaces this with machine authentication. Public
+guest/WebRTC endpoints are separate from this boundary and are unchanged.
+
 ### Control Page (`/control`)
 
 - Scene selection and activation

--- a/backend/package.json
+++ b/backend/package.json
@@ -54,6 +54,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
+    "@types/ws": "8.18.1",
     "dotenv": "^17.2.4",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/backend/src/auth/renderer-boundary.spec.ts
+++ b/backend/src/auth/renderer-boundary.spec.ts
@@ -1,0 +1,96 @@
+import 'reflect-metadata';
+import { IS_PUBLIC_KEY } from './public.decorator';
+import {
+  IS_RENDERER_PUBLIC_KEY,
+  RENDERER_HTTP_BOUNDARY,
+  RENDERER_REALTIME_INBOUND_TYPES,
+  isRendererRealtimeInboundType,
+} from './renderer-boundary';
+import { ChartsController } from '../charts/charts.controller';
+import { MediaGroupsController } from '../media-groups/media-groups.controller';
+import { ProgramController } from '../program/program.controller';
+
+describe('transitional renderer boundary', () => {
+  const controllerCapabilities = [
+    [ProgramController.prototype, 'getBroadcastSettings'],
+    [ProgramController.prototype, 'getStateById'],
+    [ProgramController.prototype, 'getProgramAudioBusById'],
+    [ProgramController.prototype, 'getProgramAudioMeterById'],
+    [ProgramController.prototype, 'updateProgramAudioMeterById'],
+    [ProgramController.prototype, 'getProgramSceneInstantById'],
+    [ProgramController.prototype, 'getProgramSongPlaybackById'],
+    [ProgramController.prototype, 'updateProgramSongPlaybackById'],
+    [ProgramController.prototype, 'proxyAudio'],
+    [ProgramController.prototype, 'getState'],
+    [ProgramController.prototype, 'listProgramMediaGroups'],
+    [ProgramController.prototype, 'listProgramStingers'],
+    [ProgramController.prototype, 'eventsById'],
+    [ProgramController.prototype, 'events'],
+    [MediaGroupsController.prototype, 'findOne'],
+    [ChartsController.prototype, 'getSanremoRealtime'],
+  ] as const;
+
+  const getMethodMetadata = <T>(
+    metadataKey: string,
+    controller: object,
+    method: string,
+  ): T | undefined => {
+    const handler = Object.getOwnPropertyDescriptor(controller, method)
+      ?.value as object | undefined;
+    if (!handler) {
+      throw new Error(`Missing controller method: ${method}`);
+    }
+    return Reflect.getMetadata(metadataKey, handler) as T | undefined;
+  };
+
+  it('enumerates every renderer HTTP capability exactly once', () => {
+    const declared = RENDERER_HTTP_BOUNDARY.map(({ capability }) => capability);
+    const decorated = controllerCapabilities.map(([controller, method]) =>
+      getMethodMetadata<string>(IS_RENDERER_PUBLIC_KEY, controller, method),
+    );
+
+    expect(new Set(declared).size).toBe(16);
+    expect(decorated.sort()).toEqual([...declared].sort());
+    for (const [controller, method] of controllerCapabilities) {
+      expect(
+        getMethodMetadata<boolean>(IS_PUBLIC_KEY, controller, method),
+      ).toBe(true);
+    }
+  });
+
+  it('does not expose representative operator actions as renderer public', () => {
+    for (const method of [
+      'updateBroadcastSettings',
+      'activateSceneById',
+      'updateProgramAudioBusById',
+      'goFlightById',
+    ] as const) {
+      expect(
+        getMethodMetadata<string>(
+          IS_RENDERER_PUBLIC_KEY,
+          ProgramController.prototype,
+          method,
+        ),
+      ).toBeUndefined();
+      expect(
+        getMethodMetadata<boolean>(
+          IS_PUBLIC_KEY,
+          ProgramController.prototype,
+          method,
+        ),
+      ).toBeUndefined();
+    }
+  });
+
+  it('allows only renderer telemetry, playback, and song completion messages', () => {
+    expect(RENDERER_REALTIME_INBOUND_TYPES).toEqual([
+      'audio_meter_update',
+      'song_playback_update',
+      'song_ended',
+    ]);
+    expect(isRendererRealtimeInboundType('audio_meter_update')).toBe(true);
+    expect(isRendererRealtimeInboundType('scene_activate')).toBe(false);
+    expect(isRendererRealtimeInboundType('program_state_update')).toBe(false);
+    expect(isRendererRealtimeInboundType(undefined)).toBe(false);
+  });
+});

--- a/backend/src/auth/renderer-boundary.spec.ts
+++ b/backend/src/auth/renderer-boundary.spec.ts
@@ -49,7 +49,7 @@ describe('transitional renderer boundary', () => {
       getMethodMetadata<string>(IS_RENDERER_PUBLIC_KEY, controller, method),
     );
 
-    expect(new Set(declared).size).toBe(16);
+    expect(new Set(declared).size).toBe(controllerCapabilities.length);
     expect(decorated.sort()).toEqual([...declared].sort());
     for (const [controller, method] of controllerCapabilities) {
       expect(

--- a/backend/src/auth/renderer-boundary.ts
+++ b/backend/src/auth/renderer-boundary.ts
@@ -1,0 +1,131 @@
+import { applyDecorators, SetMetadata } from '@nestjs/common';
+import { Public } from './public.decorator';
+
+export const IS_RENDERER_PUBLIC_KEY = 'isRendererPublic';
+
+export const RENDERER_HTTP_BOUNDARY = [
+  {
+    capability: 'broadcast-settings-read',
+    method: 'GET',
+    path: '/program/broadcast-settings',
+    purpose: 'Bootstrap and poll renderer-owned audio and timing behavior.',
+  },
+  {
+    capability: 'program-state-read',
+    method: 'GET',
+    path: '/program/:programId/state',
+    purpose: 'Bootstrap and reconcile the active scene and program state.',
+  },
+  {
+    capability: 'legacy-program-state-read',
+    method: 'GET',
+    path: '/program/state',
+    purpose: 'Retain the deployed default-program renderer bootstrap.',
+  },
+  {
+    capability: 'audio-bus-read',
+    method: 'GET',
+    path: '/program/:programId/audio-bus',
+    purpose: 'Bootstrap and reconcile the renderer audio bus.',
+  },
+  {
+    capability: 'audio-meter-read',
+    method: 'GET',
+    path: '/program/:programId/audio-meter',
+    purpose: 'Read the latest renderer meter snapshot.',
+  },
+  {
+    capability: 'audio-meter-write',
+    method: 'POST',
+    path: '/program/:programId/audio-meter',
+    purpose: 'Publish bounded renderer meter telemetry.',
+  },
+  {
+    capability: 'scene-instant-read',
+    method: 'GET',
+    path: '/program/:programId/scene-instant',
+    purpose: 'Restore renderer-owned scene-instant playback.',
+  },
+  {
+    capability: 'song-playback-read',
+    method: 'GET',
+    path: '/program/:programId/song-playback',
+    purpose: 'Restore renderer-owned song playback.',
+  },
+  {
+    capability: 'song-playback-write',
+    method: 'POST',
+    path: '/program/:programId/song-playback',
+    purpose: 'Publish renderer playback position and completion state.',
+  },
+  {
+    capability: 'audio-proxy-read',
+    method: 'GET',
+    path: '/program/audio-proxy',
+    purpose:
+      'Retain the deployed same-origin audio proxy used by the renderer.',
+  },
+  {
+    capability: 'program-media-groups-read',
+    method: 'GET',
+    path: '/program/:programId/media-groups',
+    purpose: 'Read media groups assigned to the rendered program.',
+  },
+  {
+    capability: 'program-stingers-read',
+    method: 'GET',
+    path: '/program/:programId/stingers',
+    purpose: 'Preload stingers assigned to the rendered program.',
+  },
+  {
+    capability: 'program-events-read',
+    method: 'SSE',
+    path: '/program/:programId/events',
+    purpose: 'Consume the scoped program event stream.',
+  },
+  {
+    capability: 'legacy-program-events-read',
+    method: 'SSE',
+    path: '/program/events',
+    purpose: 'Retain the deployed default-program event stream.',
+  },
+  {
+    capability: 'media-group-read',
+    method: 'GET',
+    path: '/media-groups/:id',
+    purpose: 'Resolve the active slideshow media group.',
+  },
+  {
+    capability: 'sanremo-realtime-read',
+    method: 'GET',
+    path: '/charts/sanremo-realtime',
+    purpose: 'Resolve the public chart data used by the current renderer.',
+  },
+] as const;
+
+export type RendererHttpCapability =
+  (typeof RENDERER_HTTP_BOUNDARY)[number]['capability'];
+
+export const RENDERER_REALTIME_INBOUND_TYPES = [
+  'audio_meter_update',
+  'song_playback_update',
+  'song_ended',
+] as const;
+export type RendererRealtimeInboundType =
+  (typeof RENDERER_REALTIME_INBOUND_TYPES)[number];
+
+export function isRendererRealtimeInboundType(
+  value: unknown,
+): value is RendererRealtimeInboundType {
+  return (
+    typeof value === 'string' &&
+    (RENDERER_REALTIME_INBOUND_TYPES as readonly string[]).includes(value)
+  );
+}
+
+export function RendererPublic(capability: RendererHttpCapability) {
+  return applyDecorators(
+    Public(),
+    SetMetadata(IS_RENDERER_PUBLIC_KEY, capability),
+  );
+}

--- a/backend/src/charts/charts.controller.ts
+++ b/backend/src/charts/charts.controller.ts
@@ -1,13 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { CachedChartsResponse, ChartsService } from './charts.service';
-import { Public } from '../auth/public.decorator';
+import { RendererPublic } from '../auth/renderer-boundary';
 
 @Controller('charts')
-@Public()
 export class ChartsController {
   constructor(private readonly chartsService: ChartsService) {}
 
   @Get('sanremo-realtime')
+  @RendererPublic('sanremo-realtime-read')
   async getSanremoRealtime(): Promise<CachedChartsResponse> {
     return this.chartsService.getSanremoRealtime();
   }

--- a/backend/src/media-groups/media-groups.controller.ts
+++ b/backend/src/media-groups/media-groups.controller.ts
@@ -10,8 +10,8 @@ import {
 } from '@nestjs/common';
 import { MediaGroupsService } from './media-groups.service';
 import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
-import { Public } from '../auth/public.decorator';
 import { RequirePermission } from '../auth/require-permission.decorator';
+import { RendererPublic } from '../auth/renderer-boundary';
 
 @Controller('media-groups')
 @RequirePermission(ALCANTARA_PERMISSIONS.media.read)
@@ -36,7 +36,7 @@ export class MediaGroupsController {
   }
 
   @Get(':id')
-  @Public()
+  @RendererPublic('media-group-read')
   async findOne(@Param('id') id: string) {
     return this.mediaGroupsService.findOne(Number(id));
   }

--- a/backend/src/program/program.controller.ts
+++ b/backend/src/program/program.controller.ts
@@ -14,8 +14,8 @@ import { Observable } from 'rxjs';
 import { ProgramService } from './program.service';
 import { FlightService } from './flight.service';
 import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
-import { Public } from '../auth/public.decorator';
 import { RequirePermission } from '../auth/require-permission.decorator';
+import { RendererPublic } from '../auth/renderer-boundary';
 
 @Controller('program')
 @RequirePermission(ALCANTARA_PERMISSIONS.program.read)
@@ -56,7 +56,7 @@ export class ProgramController {
   }
 
   @Get('broadcast-settings')
-  @Public()
+  @RendererPublic('broadcast-settings-read')
   async getBroadcastSettings() {
     // The service currently exposes a legacy loosely typed settings payload.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -92,25 +92,25 @@ export class ProgramController {
   }
 
   @Get(':programId/state')
-  @Public()
+  @RendererPublic('program-state-read')
   async getStateById(@Param('programId') programId: string) {
     return this.programService.getState(programId);
   }
 
   @Get(':programId/audio-bus')
-  @Public()
+  @RendererPublic('audio-bus-read')
   async getProgramAudioBusById(@Param('programId') programId: string) {
     return this.programService.getProgramAudioBus(programId);
   }
 
   @Get(':programId/audio-meter')
-  @Public()
+  @RendererPublic('audio-meter-read')
   async getProgramAudioMeterById(@Param('programId') programId: string) {
     return this.programService.getProgramAudioMeter(programId);
   }
 
   @Post(':programId/audio-meter')
-  @Public()
+  @RendererPublic('audio-meter-write')
   async updateProgramAudioMeterById(
     @Param('programId') programId: string,
     @Body()
@@ -125,7 +125,7 @@ export class ProgramController {
   }
 
   @Get(':programId/scene-instant')
-  @Public()
+  @RendererPublic('scene-instant-read')
   async getProgramSceneInstantById(@Param('programId') programId: string) {
     return this.programService.getProgramSceneInstantPlayback(programId);
   }
@@ -158,13 +158,13 @@ export class ProgramController {
   }
 
   @Get(':programId/song-playback')
-  @Public()
+  @RendererPublic('song-playback-read')
   async getProgramSongPlaybackById(@Param('programId') programId: string) {
     return this.programService.getProgramSongPlayback(programId);
   }
 
   @Post(':programId/song-playback')
-  @Public()
+  @RendererPublic('song-playback-write')
   async updateProgramSongPlaybackById(
     @Param('programId') programId: string,
     @Body()
@@ -181,7 +181,7 @@ export class ProgramController {
   }
 
   @Get('audio-proxy')
-  @Public()
+  @RendererPublic('audio-proxy-read')
   async proxyAudio(@Query('url') url: string): Promise<StreamableFile> {
     const proxied = await this.programService.proxyAudio(url);
     return new StreamableFile(proxied.buffer, {
@@ -191,7 +191,7 @@ export class ProgramController {
   }
 
   @Get('state')
-  @Public()
+  @RendererPublic('legacy-program-state-read')
   async getState() {
     return this.programService.getState();
   }
@@ -218,7 +218,7 @@ export class ProgramController {
   }
 
   @Get(':programId/media-groups')
-  @Public()
+  @RendererPublic('program-media-groups-read')
   async listProgramMediaGroups(@Param('programId') programId: string) {
     return this.programService.listProgramMediaGroups(programId);
   }
@@ -248,7 +248,7 @@ export class ProgramController {
   }
 
   @Get(':programId/stingers')
-  @Public()
+  @RendererPublic('program-stingers-read')
   async listProgramStingers(@Param('programId') programId: string) {
     return this.programService.listProgramStingers(programId);
   }
@@ -456,7 +456,7 @@ export class ProgramController {
   }
 
   @Sse(':programId/events')
-  @Public()
+  @RendererPublic('program-events-read')
   eventsById(
     @Param('programId') programId: string,
   ): Observable<{ data: string }> {
@@ -464,7 +464,7 @@ export class ProgramController {
   }
 
   @Sse('events')
-  @Public()
+  @RendererPublic('legacy-program-events-read')
   events(): Observable<{ data: string }> {
     return this.programService.getEventStream();
   }

--- a/backend/src/program/program.realtime.service.spec.ts
+++ b/backend/src/program/program.realtime.service.spec.ts
@@ -1,0 +1,167 @@
+import { createServer, Server } from 'http';
+import { WebSocket } from 'ws';
+import type { RawData } from 'ws';
+import { RealtimeTicketService } from '../auth/realtime-ticket.service';
+import { ProgramRealtimeService } from './program.realtime.service';
+
+describe('ProgramRealtimeService renderer isolation', () => {
+  const programService = {
+    addEventListener: jest.fn(() => jest.fn()),
+    getState: jest.fn().mockResolvedValue({ version: 1 }),
+    getProgramAudioBus: jest.fn().mockResolvedValue({ version: 1 }),
+    getBroadcastSettings: jest.fn().mockResolvedValue({ version: 1 }),
+    getProgramAudioMeter: jest.fn().mockResolvedValue({ version: 1 }),
+    getProgramSongPlayback: jest.fn().mockResolvedValue({ version: 1 }),
+    getProgramSceneInstantPlayback: jest.fn().mockResolvedValue({ version: 1 }),
+    updateProgramAudioMeter: jest.fn(),
+    updateProgramSongPlayback: jest.fn(),
+  };
+  const flightService = {
+    handleSongEnded: jest.fn(),
+  };
+  let service: ProgramRealtimeService;
+
+  const rendererClient = {
+    socket: { readyState: WebSocket.OPEN },
+    programId: 'main',
+    role: 'program',
+  };
+
+  const decodeMessage = (data: RawData): string =>
+    Array.isArray(data)
+      ? Buffer.concat(data).toString('utf8')
+      : data instanceof ArrayBuffer
+        ? Buffer.from(data).toString('utf8')
+        : Buffer.from(data).toString('utf8');
+
+  const getMessageType = (message: string): string => {
+    const parsed = JSON.parse(message) as unknown;
+    if (!parsed || typeof parsed !== 'object' || !('type' in parsed)) {
+      throw new Error('Expected a typed realtime message');
+    }
+    return String(parsed.type);
+  };
+
+  const send = async (payload: Record<string, unknown>) => {
+    const subject = service as unknown as {
+      handleMessage(client: unknown, data: Buffer): Promise<void>;
+    };
+    await subject.handleMessage(
+      rendererClient,
+      Buffer.from(JSON.stringify(payload)),
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ProgramRealtimeService(
+      programService as never,
+      flightService as never,
+      new RealtimeTicketService(),
+    );
+  });
+
+  it('keeps a renderer role out of operator snapshots even when given a valid ticket', async () => {
+    const tickets = new RealtimeTicketService();
+    const issued = tickets.issue('main');
+    const isolatedService = new ProgramRealtimeService(
+      programService as never,
+      flightService as never,
+      tickets,
+    );
+    const server: Server = createServer();
+    isolatedService.attachToServer(server);
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected an ephemeral TCP address');
+    }
+
+    const renderer = new WebSocket(
+      `ws://127.0.0.1:${address.port}/program/ws?programId=main&role=program&ticket=${issued.ticket}`,
+    );
+    const rendererMessages: string[] = [];
+    renderer.on('message', (data) =>
+      rendererMessages.push(decodeMessage(data)),
+    );
+    await new Promise<void>((resolve, reject) => {
+      renderer.once('open', resolve);
+      renderer.once('error', reject);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(rendererMessages).toEqual([]);
+    renderer.close();
+
+    const control = new WebSocket(
+      `ws://127.0.0.1:${address.port}/program/ws?programId=main&role=control&ticket=${issued.ticket}`,
+    );
+    const controlMessages: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      control.on('message', (data) => {
+        controlMessages.push(decodeMessage(data));
+        if (controlMessages.length === 6) {
+          resolve();
+        }
+      });
+      control.once('error', reject);
+    });
+
+    expect(controlMessages.map(getMessageType)).toEqual(
+      expect.arrayContaining([
+        'program_state_snapshot',
+        'audio_bus_snapshot',
+        'broadcast_settings_snapshot',
+        'audio_meter_update',
+        'song_playback_update',
+        'scene_instant_state',
+      ]),
+    );
+
+    control.close();
+    isolatedService.onModuleDestroy();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+  });
+
+  it('accepts only renderer-owned telemetry, playback, and song completion', async () => {
+    const levels = { main: { vu: -12 } };
+    const playback = { token: 'song-7', progress: 0.4 };
+
+    await send({ type: 'audio_meter_update', levels });
+    await send({ type: 'song_playback_update', playback });
+    await send({ type: 'song_ended' });
+
+    expect(programService.updateProgramAudioMeter).toHaveBeenCalledWith(
+      levels,
+      'main',
+    );
+    expect(programService.updateProgramSongPlayback).toHaveBeenCalledWith(
+      playback,
+      'main',
+    );
+    expect(flightService.handleSongEnded).toHaveBeenCalledWith('main');
+  });
+
+  it.each([
+    'program_state_update',
+    'scene_activate',
+    'audio_bus_update',
+    'flight_go',
+  ])(
+    'rejects renderer attempts to invoke operator message %s',
+    async (type) => {
+      await send({ type, sceneId: 7, enabled: true });
+
+      expect(programService.updateProgramAudioMeter).not.toHaveBeenCalled();
+      expect(programService.updateProgramSongPlayback).not.toHaveBeenCalled();
+      expect(flightService.handleSongEnded).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/backend/src/program/program.realtime.service.ts
+++ b/backend/src/program/program.realtime.service.ts
@@ -454,7 +454,7 @@ export class ProgramRealtimeService implements OnModuleDestroy {
       !isRendererRealtimeInboundType(payload.type)
     ) {
       this.logger.warn(
-        `Rejected renderer realtime message type: ${String(payload.type)}`,
+        `Rejected renderer realtime message: role=${client.role} programId=${client.programId} type=${String(payload.type)}`,
       );
       return;
     }

--- a/backend/src/program/program.realtime.service.ts
+++ b/backend/src/program/program.realtime.service.ts
@@ -6,6 +6,7 @@ import type { RawData } from 'ws';
 import { ProgramService } from './program.service';
 import { FlightService } from './flight.service';
 import { RealtimeTicketService } from '../auth/realtime-ticket.service';
+import { isRendererRealtimeInboundType } from '../auth/renderer-boundary';
 
 type ProgramRealtimeRole = 'program' | 'control' | 'unknown';
 
@@ -448,6 +449,16 @@ export class ProgramRealtimeService implements OnModuleDestroy {
       return;
     }
 
+    if (
+      client.role === 'program' &&
+      !isRendererRealtimeInboundType(payload.type)
+    ) {
+      this.logger.warn(
+        `Rejected renderer realtime message type: ${String(payload.type)}`,
+      );
+      return;
+    }
+
     if (payload.type === 'audio_meter_update') {
       if (client.role !== 'program') {
         return;
@@ -516,6 +527,10 @@ export class ProgramRealtimeService implements OnModuleDestroy {
 
     if (Array.isArray(rawData)) {
       return Buffer.concat(rawData).toString('utf8');
+    }
+
+    if (rawData instanceof ArrayBuffer) {
+      return Buffer.from(rawData).toString('utf8');
     }
 
     return Buffer.from(rawData).toString('utf8');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.3
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
       dotenv:
         specifier: ^17.2.4
         version: 17.2.4


### PR DESCRIPTION
## Summary

- enumerate the complete transitional Alana renderer HTTP boundary with explicit route metadata
- limit renderer realtime input to meter telemetry, playback state, and song completion
- keep operator snapshots, events, REST actions, and realtime tickets behind Cognito plus Pompeii
- document the temporary self-declared renderer trust model and its G-119 replacement boundary
- add regression coverage for public-route enumeration, operator-action exclusion, message rejection, and ticket non-elevation

## Validation

- `pnpm test --runInBand` — 34 tests pass
- focused ESLint for the new boundary and realtime regression suites
- backend production build
- frontend production build
- fresh Compose stack with Alcantara, Pompeii, PostgreSQL, LiveKit, backend, and frontend healthy
- browser UAT: `/program/main?renderer=1` loads without auth redirect or console errors
- browser UAT: protected operator switcher loads through TEST AUTH with Preview/Program controls
- runtime endpoint probes: renderer reads succeed; unauthenticated operator ticket and action requests return 401

## Known base limitation

The stacked frontend typecheck still reports the same 21 pre-existing errors from the G-85 base. G-118 changes no frontend TypeScript and introduces no additional typecheck errors.

## Stack

This PR targets the G-85 branch so each Linear ticket remains one atomic PR. Merge after #8.

Closes G-118
## Summary by Sourcery

Isolate the transitional renderer HTTP and realtime boundary while keeping operator capabilities protected by authentication and permissions.

Bug Fixes:
- Prevent renderer WebSocket clients from invoking operator actions or receiving operator snapshots and broadcasts.
- Reject unauthorised renderer realtime message types while preserving telemetry, playback, and song-completion updates.

Enhancements:
- Define and annotate the complete transitional renderer HTTP boundary, separating renderer capabilities from protected operator access.
- Document the temporary self-declared renderer trust model and the planned machine-authenticated replacement boundary.

Build:
- Add WebSocket type definitions to the backend dependencies.

Documentation:
- Document the renderer HTTP and realtime boundary, protected operator routes, and transitional deployment constraints.

Tests:
- Add regression coverage for renderer route enumeration, operator-action exclusion, realtime message filtering, and role isolation.