### PR TITLE
docs(agents): require repository wiki maintenance

### DIFF
--- a/.agents/skills/ai-agentic-update/SKILL.md
+++ b/.agents/skills/ai-agentic-update/SKILL.md
@@ -21,11 +21,16 @@ root first and execute the script from there. After a successful update, reread
 the root `AGENTS.md` and any applicable updated skills before continuing.
 
 The helper fetches the central repository, hydrates the current repository from
-the fetched default-branch snapshot, and verifies the result. It preserves
-instructions outside the managed markers and differently named local skills.
+the fetched default-branch snapshot, and verifies the result. It also verifies
+the repository's separate `./wiki` checkout, clones the wiki when its derived
+remote exists, and validates an existing checkout's origin. It preserves
+instructions outside the managed markers, differently named local skills,
+uncommitted wiki work, and unrelated product changes.
 
-Do not replace this command with hand-written copying. Do not commit, push,
-deploy, reset, rebase, or discard worktree changes as part of the refresh.
+Do not replace this command with hand-written copying. After it completes,
+inspect the relevant wiki pages before planning code changes. Do not commit,
+push, deploy, reset, rebase, or discard product or wiki worktree changes as part
+of the refresh.
 
 If the updater fails or cannot verify the central source, stop before making
 other repository mutations and report the exact failure. Do not silently work

--- a/.agents/skills/ai-agentic-update/scripts/update
+++ b/.agents/skills/ai-agentic-update/scripts/update
@@ -12,6 +12,81 @@ usage() {
   printf '%s\n' 'Usage: update [--repository PATH] [--reference-repository PATH] [--no-fetch]'
 }
 
+wiki_remote_from_origin() {
+  local origin_url="$1"
+  if [[ "${origin_url}" == *.git ]]; then
+    printf '%s.wiki.git\n' "${origin_url%.git}"
+  else
+    printf '%s.wiki.git\n' "${origin_url}"
+  fi
+}
+
+ensure_wiki_checkout() {
+  local repository="$1"
+  local wiki_directory="${repository}/wiki"
+  local origin_url=''
+  local wiki_remote=''
+  local existing_remote=''
+  local exclude_file=''
+  local wiki_branch=''
+
+  origin_url="$(git -C "${repository}" remote get-url origin 2>/dev/null || true)"
+  if [[ -z "${origin_url}" ]]; then
+    printf 'wiki-unavailable\trepository=%s\treason=no-origin\n' "${repository}"
+    return 0
+  fi
+  wiki_remote="$(wiki_remote_from_origin "${origin_url}")"
+
+  exclude_file="$(git -C "${repository}" rev-parse --path-format=absolute --git-path info/exclude)"
+  mkdir -p "$(dirname "${exclude_file}")"
+  touch "${exclude_file}"
+  if ! grep -Fqx '/wiki/' "${exclude_file}"; then
+    printf '\n/wiki/\n' >> "${exclude_file}"
+  fi
+
+  if [[ -e "${wiki_directory}" && ! -d "${wiki_directory}/.git" ]]; then
+    printf 'error: ./wiki exists but is not a Git checkout: %s\n' "${wiki_directory}" >&2
+    return 1
+  fi
+
+  if [[ ! -d "${wiki_directory}/.git" ]]; then
+    if GIT_TERMINAL_PROMPT=0 git clone --quiet "${wiki_remote}" "${wiki_directory}" 2>/dev/null; then
+      printf 'wiki-cloned\trepository=%s\tremote=%s\n' "${repository}" "${wiki_remote}"
+      return 0
+    fi
+    rm -rf "${wiki_directory}"
+    printf 'wiki-unavailable\trepository=%s\tremote=%s\treason=remote-not-found-or-inaccessible\n' \
+      "${repository}" "${wiki_remote}"
+    return 0
+  fi
+
+  existing_remote="$(git -C "${wiki_directory}" remote get-url origin 2>/dev/null || true)"
+  if [[ "${existing_remote}" != "${wiki_remote}" ]]; then
+    printf 'error: ./wiki origin mismatch: expected %s, found %s\n' \
+      "${wiki_remote}" "${existing_remote:-no-origin}" >&2
+    return 1
+  fi
+
+  if ! GIT_TERMINAL_PROMPT=0 git -C "${wiki_directory}" fetch --quiet origin --prune 2>/dev/null; then
+    printf 'wiki-unavailable\trepository=%s\tremote=%s\treason=fetch-failed\n' \
+      "${repository}" "${wiki_remote}"
+    return 0
+  fi
+
+  if [[ -n "$(git -C "${wiki_directory}" status --porcelain)" ]]; then
+    printf 'wiki-current\trepository=%s\tstate=dirty-preserved\n' "${repository}"
+    return 0
+  fi
+
+  wiki_branch="$(git -C "${wiki_directory}" branch --show-current)"
+  if [[ -n "${wiki_branch}" ]] && git -C "${wiki_directory}" show-ref --verify --quiet "refs/remotes/origin/${wiki_branch}"; then
+    if git -C "${wiki_directory}" merge-base --is-ancestor HEAD "refs/remotes/origin/${wiki_branch}"; then
+      git -C "${wiki_directory}" merge --ff-only --quiet "refs/remotes/origin/${wiki_branch}"
+    fi
+  fi
+  printf 'wiki-current\trepository=%s\tremote=%s\n' "${repository}" "${wiki_remote}"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repository)
@@ -94,6 +169,7 @@ reference_common="$(git -C "${REFERENCE_REPOSITORY}" rev-parse --path-format=abs
 
 if [[ "${target_common}" == "${reference_common}" ]]; then
   if [[ "${FETCH}" != 'true' ]]; then
+    ensure_wiki_checkout "${TARGET_REPOSITORY}"
     printf 'agentic-current\trepository=%s\tmode=working-tree\n' "${TARGET_REPOSITORY}"
     exit 0
   fi
@@ -102,6 +178,7 @@ if [[ "${target_common}" == "${reference_common}" ]]; then
   local_commit="$(git -C "${REFERENCE_REPOSITORY}" rev-parse HEAD)"
   remote_commit="$(git -C "${REFERENCE_REPOSITORY}" rev-parse "${remote_ref}")"
   if [[ "${local_commit}" == "${remote_commit}" ]]; then
+    ensure_wiki_checkout "${TARGET_REPOSITORY}"
     printf 'agentic-current\trepository=%s\tcommit=%s\n' "${TARGET_REPOSITORY}" "${remote_commit}"
     exit 0
   fi
@@ -119,6 +196,7 @@ if [[ "${target_common}" == "${reference_common}" ]]; then
     exit 1
   fi
   git -C "${REFERENCE_REPOSITORY}" merge --ff-only --quiet "${remote_ref}"
+  ensure_wiki_checkout "${TARGET_REPOSITORY}"
   printf 'agentic-updated\trepository=%s\tcommit=%s\n' "${TARGET_REPOSITORY}" "${remote_commit}"
   exit 0
 fi
@@ -154,5 +232,6 @@ fi
 
 "${update_source}/scripts/sync" --write --repository "${TARGET_REPOSITORY}"
 "${update_source}/scripts/sync" --check --repository "${TARGET_REPOSITORY}"
+ensure_wiki_checkout "${TARGET_REPOSITORY}"
 
 printf 'agentic-updated\trepository=%s\tcommit=%s\n' "${TARGET_REPOSITORY}" "${central_commit}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,14 +13,43 @@ weaken or contradict these rules.
   root.
 - The updater must fetch the central `agentic-coding` standard and, when a newer
   version exists, refresh only the managed rules and centrally owned skills in
-  the current repository. Reread the updated root `AGENTS.md` and any applicable
-  skills before continuing.
+  the current repository. It must also verify the repository wiki checkout at
+  `./wiki`, clone the repository's wiki there when the remote wiki exists, and
+  validate that an existing checkout points to the expected wiki remote. Reread
+  the updated root `AGENTS.md`, any applicable skills, and the relevant wiki
+  pages before continuing.
 - Do not silently skip or weaken the freshness check. If the central source
   cannot be verified or the update fails, stop before other repository mutations
   and report the exact failure.
 - The freshness update must preserve repository-local instructions, local-only
-  skills, and unrelated worktree changes. It must not commit, push, deploy,
-  reset, rebase, or discard changes.
+  skills, wiki changes, and unrelated worktree changes. It must not commit,
+  push, deploy, reset, rebase, or discard changes.
+
+## Repository wiki and documentation
+
+- Every managed repository's GitHub wiki must be available as a separate Git
+  checkout at `./wiki`. The startup updater derives the wiki URL from the
+  repository's `origin`, clones it when available, and excludes `./wiki` from
+  the parent repository through local Git metadata. Never treat the wiki as
+  ordinary untracked parent-repository content.
+- Before planning or changing code, inspect the relevant wiki pages alongside
+  the code and repository documentation. Do not rely on a stale architectural,
+  operational, API, configuration, deployment, or user-workflow assumption when
+  the wiki can establish the intended contract.
+- Documentation is part of every implementation, fix, refactor, migration, and
+  configuration change. Update the relevant wiki pages in the same task whenever
+  behavior, architecture, interfaces, setup, operations, deployment, or
+  troubleshooting guidance changes.
+- When a code change genuinely has no documentation impact, verify that the
+  relevant wiki remains accurate and state that explicitly in the handoff. Do
+  not use “no documentation impact” without checking.
+- Preserve unrelated or uncommitted wiki work. Wiki commits and pushes are
+  separate external writes: make them only when the task authorizes publishing,
+  and report code-repository and wiki-repository status separately.
+- If the repository has no `origin`, its wiki remote does not exist yet, or wiki
+  access fails, report that condition explicitly and continue using in-repository
+  documentation unless the task requires wiki publication. Do not fabricate a
+  wiki remote or silently skip documentation.
 
 ## Feature completeness
 


### PR DESCRIPTION
## Summary
- require agents to inspect and maintain repository wiki documentation
- make the startup updater validate the repository wiki checkout
- preserve missing or dirty wiki state without fabricating a remote

## Validation
- central `./scripts/test` passed
- central `./scripts/sync --check` reports 42 current repositories and zero failures
- isolated updater write/check passed
- staged diff contains only centrally managed agent paths
- wiki state: `wiki-unavailable`

Closes G-142
## Summary by Sourcery

Make repository wiki availability and maintenance part of the agent startup and development workflow.

New Features:
- Require agents to inspect relevant repository wiki documentation and keep it aligned with code and operational changes.
- Add startup handling for separate repository wiki checkouts, including cloning available wikis and validating existing wiki remotes.

Bug Fixes:
- Preserve unavailable, missing, dirty, or unrelated wiki state without fabricating remotes or discarding work.

Enhancements:
- Clarify agent guidance for wiki-aware repository work, documentation verification, and separate reporting of code and wiki status.

Documentation:
- Document repository wiki maintenance requirements and explicitly account for unavailable wiki access.