### PR TITLE
fix(backend): package authorization proto for production

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,5 +13,6 @@ RUN pnpm install --no-frozen-lockfile
 COPY . .
 RUN pnpm run prisma:generate
 RUN pnpm run build
+RUN test -f /app/dist/src/proto/authorization.proto
 
 CMD ["sh", "-c", "pnpm prisma db push && pnpm start:prod"]

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -7,6 +7,7 @@
     "assets": [
       {
         "include": "proto/*.proto",
+        "outDir": "dist/src",
         "watchAssets": true
       }
     ]


### PR DESCRIPTION
## Summary
- copy the authorization proto into the runtime `dist/src/proto` tree
- fail the production image build if the proto is missing

## Production failure
`alcantara-backend` was crash-looping because Nest copied the asset to `dist/proto` while `PompeiiService` loads `dist/src/proto/authorization.proto`.

## Verification
- `pnpm build`
- `pnpm test --runInBand` (4 suites, 13 tests)
- `docker build -f backend/Dockerfile -t alcantara:proto-path-test backend`