### PR TITLE
fix(auth): hardcode production Pompeii endpoint

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -54,15 +54,13 @@ jobs:
 
             docker run -d --name alcantara-backend \
             -p ${{ vars.HTTP_PORT }}:${{ vars.HTTP_PORT }} \
+            -e NODE_ENV=production \
             -e HTTP_PORT="${{ vars.HTTP_PORT }}" \
             -e PORT="${{ vars.HTTP_PORT }}" \
             -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
             -e ALLOWED_ORIGINS="${{ vars.FQDN }}" \
             -e AWS_REGION="${{ vars.AWS_REGION }}" \
-            -e POMPEII_GRPC_URL="${{ vars.POMPEII_GRPC_URL }}" \
-            -e POMPEII_TEAM_ID="${{ vars.POMPEII_TEAM_ID }}" \
-            -e POMPEII_GRPC_TLS="${{ vars.POMPEII_GRPC_TLS }}" \
-            -e POMPEII_GRPC_TIMEOUT_MS="${{ vars.POMPEII_GRPC_TIMEOUT_MS }}" \
+            -e POMPEII_TEAM_ID=1 \
             -e MEDIA_S3_BUCKET="${{ secrets.MEDIA_S3_BUCKET }}" \
             -e CONTAINERIZED=true \
             --restart=always \

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ This builds and starts both services (ports configurable via `.env`):
 
 Source directories are mounted so changes are reflected immediately.
 
+The backend uses the local `POMPEII_GRPC_URL` from `backend/.env` while
+developing. Production ignores endpoint overrides and always uses the
+code-owned `api.pompeii.gaulatti.com:443` TLS endpoint with Gaulatti team `1`.
+
 Rebuild images after dependency changes:
 ```bash
 docker compose up --build

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,9 +4,11 @@ ALLOWED_ORIGINS="http://localhost:5173,https://alcantara.gaulatti.com,https://al
 PORT=3000
 AWS_REGION=us-east-1
 
-# Required for Cognito JWT validation
-COGNITO_USER_POOL_ID=us-east-1_xxxxxxxxx
-COGNITO_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxx
+# Local-only Pompeii authorization endpoint and Gaulatti team scope.
+# Production always uses api.pompeii.gaulatti.com:443 with TLS.
+POMPEII_GRPC_URL=host.docker.internal:50087
+POMPEII_TEAM_ID=1
+POMPEII_GRPC_TIMEOUT_MS=2000
 
 # Optional media uploads (instants/artwork) to S3
 MEDIA_S3_BUCKET="your-bucket-name"

--- a/backend/src/auth/pompeii.service.spec.ts
+++ b/backend/src/auth/pompeii.service.spec.ts
@@ -1,12 +1,34 @@
 import { ConfigService } from '@nestjs/config';
-import { PompeiiService } from './pompeii.service';
+import {
+  PRODUCTION_POMPEII_GRPC_URL,
+  PompeiiService,
+  resolvePompeiiGrpcUrl,
+} from './pompeii.service';
 
 describe('PompeiiService production contract', () => {
+  it('uses the code-owned production endpoint regardless of an override', () => {
+    expect(resolvePompeiiGrpcUrl('production', 'untrusted:50087')).toBe(
+      PRODUCTION_POMPEII_GRPC_URL,
+    );
+    expect(PRODUCTION_POMPEII_GRPC_URL).toBe(
+      'api.pompeii.gaulatti.com:443',
+    );
+  });
+
+  it('requires an explicit non-production endpoint', () => {
+    expect(resolvePompeiiGrpcUrl('development', 'localhost:50087')).toBe(
+      'localhost:50087',
+    );
+    expect(() => resolvePompeiiGrpcUrl('development', undefined)).toThrow(
+      'POMPEII_GRPC_URL is required outside production',
+    );
+  });
+
   it('requires an explicit positive team in production', () => {
     const config = new ConfigService({
       NODE_ENV: 'production',
       POMPEII_TEAM_ID: '0',
-      POMPEII_GRPC_URL: 'localhost:50087',
+      POMPEII_GRPC_URL: 'untrusted:50087',
     });
 
     expect(() => new PompeiiService(config)).toThrow(
@@ -19,10 +41,13 @@ describe('PompeiiService production contract', () => {
       new ConfigService({
         NODE_ENV: 'production',
         POMPEII_TEAM_ID: '42',
-        POMPEII_GRPC_URL: '127.0.0.1:1',
-        POMPEII_GRPC_TIMEOUT_MS: '25',
       }),
     );
+    jest.spyOn(service, 'checkConnection').mockResolvedValue({
+      target: PRODUCTION_POMPEII_GRPC_URL,
+      ready: false,
+      error: 'unavailable',
+    });
 
     try {
       await expect(service.onModuleInit()).rejects.toThrow(

--- a/backend/src/auth/pompeii.service.ts
+++ b/backend/src/auth/pompeii.service.ts
@@ -57,6 +57,23 @@ type AuthorizationClientConstructor = new (
   channelCredentials: ChannelCredentials,
 ) => AuthorizationClient;
 
+export const PRODUCTION_POMPEII_GRPC_URL = 'api.pompeii.gaulatti.com:443';
+
+export function resolvePompeiiGrpcUrl(
+  nodeEnv: string | undefined,
+  localEndpoint: string | undefined,
+): string {
+  if (nodeEnv === 'production') {
+    return PRODUCTION_POMPEII_GRPC_URL;
+  }
+
+  const endpoint = localEndpoint?.trim();
+  if (!endpoint) {
+    throw new Error('POMPEII_GRPC_URL is required outside production');
+  }
+  return endpoint;
+}
+
 @Injectable()
 export class PompeiiService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(PompeiiService.name);
@@ -67,8 +84,11 @@ export class PompeiiService implements OnModuleInit, OnModuleDestroy {
   readonly teamId: number;
 
   constructor(config: ConfigService) {
-    this.grpcUrl =
-      config.get<string>('POMPEII_GRPC_URL')?.trim() || 'localhost:50087';
+    this.isProduction = config.get<string>('NODE_ENV') === 'production';
+    this.grpcUrl = resolvePompeiiGrpcUrl(
+      config.get<string>('NODE_ENV'),
+      config.get<string>('POMPEII_GRPC_URL'),
+    );
     this.timeoutMs = this.positiveInteger(
       config.get<string>('POMPEII_GRPC_TIMEOUT_MS'),
       2_000,
@@ -77,7 +97,6 @@ export class PompeiiService implements OnModuleInit, OnModuleDestroy {
       config.get<string>('POMPEII_TEAM_ID'),
       0,
     );
-    this.isProduction = config.get<string>('NODE_ENV') === 'production';
     if (this.isProduction && this.teamId === 0) {
       throw new Error(
         'POMPEII_TEAM_ID must be an explicit positive integer in production',
@@ -99,7 +118,8 @@ export class PompeiiService implements OnModuleInit, OnModuleDestroy {
         };
       };
     };
-    const useTls = config.get<string>('POMPEII_GRPC_TLS') === 'true';
+    const useTls =
+      this.isProduction || config.get<string>('POMPEII_GRPC_TLS') === 'true';
     this.client = new loaded.pompeii.authorization.v1.AuthorizationService(
       this.grpcUrl,
       useTls ? credentials.createSsl() : credentials.createInsecure(),


### PR DESCRIPTION
## Summary
- force the code-owned Pompeii production endpoint and TLS
- keep local endpoints explicit for Compose and tests
- remove obsolete deployment-variable injection and document the contract

## Verification
- pnpm test --runInBand
- pnpm build

## Summary by Sourcery

Enforce a trusted production Pompeii connection while keeping development and test endpoints explicitly configurable.

Bug Fixes:
- Ensure production Pompeii authentication always uses the trusted code-owned TLS endpoint instead of deployment-provided overrides.

Enhancements:
- Require explicit local Pompeii endpoints outside production and document the production and development endpoint contract.

Deployment:
- Simplify backend deployment configuration by removing production Pompeii endpoint, TLS, and timeout injection while explicitly setting production mode and team ID.

Documentation:
- Document the distinct local and production Pompeii endpoint behavior.

Tests:
- Add coverage for production endpoint enforcement and required non-production endpoint configuration.