### PR TITLE
fix(auth): authenticate frontend API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Source directories are mounted so changes are reflected immediately.
 The backend uses the local `POMPEII_GRPC_URL` from `backend/.env` while
 developing. Production ignores endpoint overrides and always uses the
 code-owned `api.pompeii.gaulatti.com:443` TLS endpoint with Gaulatti team `1`.
+The browser attaches its current Cognito ID token to every request targeting
+Alcantara's configured API origin; requests to external media and data sources
+remain unchanged.
 
 Rebuild images after dependency changes:
 ```bash

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -6,8 +6,11 @@ import 'aws-amplify/auth/enable-oauth-listener';
 import type { Route } from './+types/root';
 import './app.css';
 import './services/auth';
+import { installAuthenticatedFetch } from './services/authenticatedFetch';
 import AuthListener from './components/common/AuthListener';
 import { getStore } from './state';
+
+installAuthenticatedFetch();
 
 export const links: Route.LinksFunction = () => [
   { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },

--- a/frontend/app/services/authenticatedFetch.ts
+++ b/frontend/app/services/authenticatedFetch.ts
@@ -1,0 +1,40 @@
+import { fetchAuthSession } from 'aws-amplify/auth';
+import { getApiBaseUrl } from '../utils/apiBaseUrl';
+
+const nativeFetch = globalThis.fetch.bind(globalThis);
+let installed = false;
+
+const isBackendRequest = (input: RequestInfo | URL): boolean => {
+  const requestUrl = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  const backendUrl = new URL(getApiBaseUrl());
+  const targetUrl = new URL(requestUrl, window.location.origin);
+  const backendPath = backendUrl.pathname.replace(/\/$/, '');
+
+  return (
+    targetUrl.origin === backendUrl.origin &&
+    (!backendPath || targetUrl.pathname === backendPath || targetUrl.pathname.startsWith(`${backendPath}/`))
+  );
+};
+
+const authenticatedBackendFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const requestHeaders = input instanceof Request ? input.headers : undefined;
+  const headers = new Headers(init?.headers ?? requestHeaders);
+
+  try {
+    const session = await fetchAuthSession();
+    const token = session.tokens?.idToken?.toString();
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+  } catch {
+    // Preserve the backend's normal unauthenticated response when no session exists.
+  }
+
+  return nativeFetch(input, { ...init, headers });
+};
+
+export const installAuthenticatedFetch = (): void => {
+  if (typeof window === 'undefined' || installed) return;
+
+  installed = true;
+  globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) =>
+    isBackendRequest(input) ? authenticatedBackendFetch(input, init) : nativeFetch(input, init);
+};


### PR DESCRIPTION
## Summary
- attach the current Cognito ID token to every request targeting the configured Alcantara API origin
- leave external media and data requests unchanged
- install the authenticated transport once at browser startup

## Verification
- VITE_API_BASE_URL=https://api.alcantara.gaulatti.com pnpm build
- production browser verification pending deployment

## Known baseline
- pnpm typecheck remains blocked by existing unrelated TypeScript errors in the current main branch

## Summary by Sourcery

Authenticate frontend requests to the configured Alcantara API while preserving existing behavior for external and unauthenticated requests.

Bug Fixes:
- Authenticate browser requests to the configured Alcantara API by attaching the current Cognito ID token.

Enhancements:
- Preserve unauthenticated behavior when no session is available and leave requests to external media and data sources unchanged.

Documentation:
- Document frontend API request authentication and the unchanged handling of external requests.