### PR TITLE
fix(media): expose add-to-group action

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ code-owned `api.pompeii.gaulatti.com:443` TLS endpoint with Gaulatti team `1`.
 The browser attaches its current Cognito ID token to every request targeting
 Alcantara's configured API origin; requests to external media and data sources
 remain unchanged.
+To populate a slideshow, select its media group on the Media Groups tab, switch
+to Media Library, and use each image's add-to-group action. The selected group
+and its ordered membership remain active across the tab switch.
 
 Rebuild images after dependency changes:
 ```bash

--- a/frontend/app/routes/media.tsx
+++ b/frontend/app/routes/media.tsx
@@ -538,6 +538,7 @@ export default function MediaRoute() {
 
     const updated = (await res.json()) as MediaGroup;
     setMediaGroups((prev) => prev.map((group) => (group.id === updated.id ? updated : group)));
+    setSelectedGroup(updated);
   };
 
   const addMediaToSelectedGroup = async (mediaId: number) => {
@@ -700,6 +701,18 @@ export default function MediaRoute() {
                               <h3 className='truncate text-sm font-semibold text-white drop-shadow-sm'>{item.name}</h3>
                             </div>
                             <div className='absolute right-2 top-2 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100'>
+                              {selectedGroup && !selectedGroup.items.some((groupItem) => groupItem.mediaId === item.id) ? (
+                                <IconButton
+                                  onClick={() => {
+                                    void addMediaToSelectedGroup(item.id);
+                                  }}
+                                  className='bg-white/80 text-sea backdrop-blur-sm hover:bg-white dark:bg-dark-sand/80 dark:hover:bg-dark-sand'
+                                  title={`Add ${item.name} to ${selectedGroup.name}`}
+                                  aria-label={`Add ${item.name} to ${selectedGroup.name}`}
+                                >
+                                  <Plus size={14} />
+                                </IconButton>
+                              ) : null}
                               <IconButton
                                 onClick={() => openEditMediaModal(item)}
                                 className='bg-white/80 text-sea backdrop-blur-sm hover:bg-white dark:bg-dark-sand/80 dark:hover:bg-dark-sand'


### PR DESCRIPTION
## Summary
- expose the existing add-media operation for the selected slideshow group
- refresh selected group membership after every persisted addition
- document the group-to-library workflow

## Verification
- VITE_API_BASE_URL=https://api.alcantara.gaulatti.com pnpm build
- production browser verification pending deployment

## Summary by Sourcery

Enable adding media to the selected slideshow group directly from the media library while preserving group context across navigation.

New Features:
- Expose an add-to-group action for media items when a slideshow group is selected.

Bug Fixes:
- Keep the selected group and its membership synchronized after persisted media additions or updates.

Documentation:
- Document the workflow for populating slideshow groups from the media library.