### PR TITLE
fix(radio): persist shuffled playlist order

### DIFF
--- a/docs/radio-telemetry.md
+++ b/docs/radio-telemetry.md
@@ -89,6 +89,11 @@ multiplied by that bus and the main output gain. Bumper settings persist
 `bumperEnabled`, `bumperInterval`, `bumperInstantIds`, and `bumperMode`; invalid
 intervals, IDs, or modes fail visibly instead of being dropped.
 
+The playback bar's Shuffle action persists a newly randomized playlist order,
+anchors the authoritative current track at the front, and continues in autoplay
+through every remaining item once before loop behavior applies. Shuffle does
+not reset the current track's start time or change the loop setting.
+
 ## Machine credential and configuration
 
 The browser calls Alcantara only and never receives or transmits the Palazzo

--- a/frontend/app/components/PlaybackBar.tsx
+++ b/frontend/app/components/PlaybackBar.tsx
@@ -5,6 +5,7 @@ import {
   createProgramSongSequence,
   getProgramSongSequenceSelectedItemId,
   normalizeProgramSongSequence,
+  shuffleProgramSongSequence,
   type ProgramSongSequence,
 } from '../utils/programSequence';
 import type { ProgramSongPlaybackState } from '../models/broadcast';
@@ -363,13 +364,14 @@ export function PlaybackBar({
             </Button>
             <Button
               onClick={() =>
-                applySequence({
-                  ...sequence,
-                  mode: 'shuffle',
-                  startedAt: Date.now()
-                })
+                applySequence(
+                  shuffleProgramSongSequence(sequence, runtimeActiveItemId ?? sequence.activeItemId ?? null)
+                )
               }
-              className={`flex items-center gap-1 rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors ${sequence.mode === 'shuffle' ? 'bg-sea/20 text-sea' : 'text-text-secondary hover:text-text-primary'}`}
+              disabled={sequence.items.length < 2}
+              title='Shuffle playlist'
+              aria-label='Shuffle playlist'
+              className='flex items-center gap-1 rounded-md px-2.5 py-1 text-[11px] font-medium text-text-secondary transition-colors hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40'
               size='sm'
               variant='secondary'
             >

--- a/frontend/app/utils/programSequence.shuffle.test.mjs
+++ b/frontend/app/utils/programSequence.shuffle.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { shuffleProgramSongSequence } from './programSequence.ts';
+
+function sequence(ids, overrides = {}) {
+  return {
+    mode: 'shuffle',
+    items: ids.map((id) => ({ id, kind: 'preset', artist: id, title: id, coverUrl: '' })),
+    activeItemId: ids[1] ?? null,
+    loop: false,
+    startedAt: 1234,
+    ...overrides
+  };
+}
+
+test('anchors the active song and persists a no-repeat autoplay order', () => {
+  const input = sequence(['a', 'b', 'c', 'd']);
+  const output = shuffleProgramSongSequence(input, 'b', () => 0);
+
+  assert.deepEqual(output.items.map((item) => item.id), ['b', 'c', 'd', 'a']);
+  assert.equal(output.activeItemId, 'b');
+  assert.equal(output.mode, 'autoplay');
+  assert.equal(output.loop, false);
+  assert.equal(output.startedAt, 1234);
+  assert.deepEqual(new Set(output.items.map((item) => item.id)), new Set(['a', 'b', 'c', 'd']));
+});
+
+test('guarantees a visible order change when random values retain the original order', () => {
+  const input = sequence(['a', 'b', 'c'], { activeItemId: 'a' });
+  const output = shuffleProgramSongSequence(input, 'a', () => 0.999999);
+
+  assert.deepEqual(output.items.map((item) => item.id), ['a', 'c', 'b']);
+});
+
+test('does not mutate or replace a playlist that cannot be shuffled', () => {
+  const input = sequence(['a'], { activeItemId: 'a', mode: 'manual' });
+  assert.equal(shuffleProgramSongSequence(input, 'a'), input);
+});

--- a/frontend/app/utils/programSequence.ts
+++ b/frontend/app/utils/programSequence.ts
@@ -74,6 +74,38 @@ export type ProgramSongSequenceItem =
 
 export type ProgramSongSequence = BaseSequence<ProgramSongSequenceItem>;
 
+export function shuffleProgramSongSequence(
+  sequence: ProgramSongSequence,
+  activeItemId: string | null = sequence.activeItemId ?? null,
+  random: () => number = Math.random
+): ProgramSongSequence {
+  if (sequence.items.length < 2) return sequence;
+
+  const anchoredItem = activeItemId
+    ? sequence.items.find((item) => item.id === activeItemId) ?? null
+    : null;
+  const shuffledItems = anchoredItem
+    ? sequence.items.filter((item) => item.id !== anchoredItem.id)
+    : [...sequence.items];
+
+  for (let index = shuffledItems.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.min(index, Math.max(0, Math.floor(random() * (index + 1))));
+    [shuffledItems[index], shuffledItems[swapIndex]] = [shuffledItems[swapIndex], shuffledItems[index]];
+  }
+
+  const nextItems = anchoredItem ? [anchoredItem, ...shuffledItems] : shuffledItems;
+  if (!nextItems.some((item, index) => item.id !== sequence.items[index]?.id) && shuffledItems.length > 1) {
+    shuffledItems.push(shuffledItems.shift()!);
+  }
+
+  return {
+    ...sequence,
+    mode: 'autoplay',
+    items: anchoredItem ? [anchoredItem, ...shuffledItems] : shuffledItems,
+    activeItemId: anchoredItem?.id ?? sequence.activeItemId ?? null
+  };
+}
+
 export interface ProgramResolvedSongLeaf {
   id: string;
   songId?: number;


### PR DESCRIPTION
## Summary
- make Shuffle persist a visible randomized queue instead of selecting random songs with replacement
- anchor the current track and preserve autoplay/loop state
- add deterministic regression coverage and document the control behavior

## Verification
- `node --test app/utils/programSequence.shuffle.test.mjs`
- `pnpm build`
- `pnpm typecheck` *(fails on pre-existing unrelated baseline errors; no changed Shuffle file errors)*
- production Palazzo queue manually shuffled and browser-verified at 384 unique rows

## Summary by Sourcery

Persist shuffled playlist order while preserving current playback state and ensuring a complete no-repeat queue.

New Features:
- Persist a randomized playlist order from the playback bar while keeping the current track first and ensuring each remaining item plays once before loop behavior applies.

Bug Fixes:
- Preserve the current track, playback position, and loop setting when shuffling instead of restarting or selecting tracks with replacement.

Enhancements:
- Disable Shuffle for playlists with fewer than two items and expose accessible control labeling.

Documentation:
- Document the persisted shuffle behavior and its autoplay, current-track, and loop semantics.

Tests:
- Add deterministic regression coverage for active-track anchoring, no-repeat ordering, visible reordering, and non-shufflable playlists.