### PR TITLE
feat(recording): add truthful Alana controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ own microphone. Guests subscribe only to their selected video output and their
 own `mixminus:<identity>:<bus>` track. This replaces the earlier fixed 250 ms
 browser relay and keeps isolated guest tracks out of the guest UI.
 
+Authorized operators can control Alana's independent composed-Program recorder
+without treating a requested or finalizing operation as safe media. See
+[`docs/program-recording.md`](docs/program-recording.md) for the pinned Alana
+contract, state semantics, permissions, idempotency, local fixture, private
+configuration, metrics, and recovery boundary.
+
 #### Local and production operations
 
 `docker compose up --build` includes LiveKit 1.13.4 with fixed local-only
@@ -332,7 +338,8 @@ BACKEND_PORT=3000 VITE_PORT=5173 docker compose up
 ## Architecture
 
 Production places the backend on the external `broadcast-control` Docker
-network shared with Palazzo. Before stopping the live backend, deployment runs
+network shared with Palazzo and Alana. Before stopping the live backend,
+deployment runs
 a side-effect-free runtime preflight in the new image to resolve and validate
 the Palazzo credential and approved URL list. The previous container is retained
 until the replacement passes its startup check and is automatically restored if
@@ -342,7 +349,8 @@ configuration or startup defect reaches deployment.
 The replacement joins `broadcast-control` so the private
 `http://palazzo:3100` program-scoped machine API remains resolvable. Set the
 production `ALCANTARA_CONFIG_SECRET_ID` repository variable to the
-application-scoped Secrets Manager payload. During migration, deployment also
+application-scoped Secrets Manager payload, including Alana's private recording
+control URL and token. During migration, deployment also
 discovers and inherits the running Palazzo container's existing read-only
 control-token mount as a backwards-compatible credential source. Preflight fails without
 replacing the live backend when that mount is absent or ambiguous, neither
@@ -352,8 +360,9 @@ source is available, or configuration is invalid.
 
 ```
 Control Panel → REST API → Database → SSE Broadcast → Program Page
-                              ↓
-                        Program State Update
+      │                       ↓
+      └── Recording API → private Alana control → composed capture state
+                         Program State Update
 ```
 
 1. Control page sends scene activation/chyron update via REST

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,12 @@ METRICS_TOKEN_FILE=/run/secrets/alcantara-metrics-token
 PALAZZO_CONTROL_TOKEN=palazzo-local-control-token
 PALAZZO_ALLOWED_URLS=http://palazzo:3100
 
+# Backend-only Alana recording control. The URL must be an origin without a
+# path, query, credentials, or fragment. Production loads both values from the
+# application-scoped secret.
+ALANA_CONTROL_TOKEN=alana-local-control-token
+ALANA_CONTROL_URL=http://alana-recording-fixture:8080
+
 # Local-only Pompeii authorization endpoint and Gaulatti team scope.
 # Production always uses api.pompeii.gaulatti.com:443 with TLS.
 POMPEII_TEAM_ID=1
@@ -30,5 +36,6 @@ WEBRTC_SESSION_SECRET="replace-with-a-separate-random-secret"
 WEBRTC_RENDERER_KEY="replace-with-a-separate-machine-bootstrap-secret"
 
 # Production bootstrap only. The referenced JSON contains the allowlisted
-# palazzoControlToken and palazzoAllowedUrls scalar fields.
+# palazzoControlToken, palazzoAllowedUrls, alanaControlToken, and
+# alanaControlUrl scalar fields.
 # ALCANTARA_CONFIG_SECRET_ID=alcantara/production/config

--- a/backend/README.md
+++ b/backend/README.md
@@ -82,10 +82,12 @@ both non-interactive execution and repeatability.
 
 The application process also requires `ALCANTARA_CONFIG_SECRET_ID` and
 `AWS_REGION` in production. Before constructing Nest providers it loads the
-allowlisted `palazzoControlToken` and `palazzoAllowedUrls` fields from that
-Secrets Manager payload. Missing, malformed, or unavailable configuration
-fails startup; the token is never a frontend variable or Docker build argument.
-See [`../docs/radio-telemetry.md`](../docs/radio-telemetry.md).
+allowlisted `palazzoControlToken`, `palazzoAllowedUrls`, `alanaControlToken`,
+and `alanaControlUrl` fields from that Secrets Manager payload. Missing,
+malformed, or unavailable configuration fails startup; tokens are never
+frontend variables or Docker build arguments. See
+[`../docs/radio-telemetry.md`](../docs/radio-telemetry.md) and
+[`../docs/program-recording.md`](../docs/program-recording.md).
 
 The deployment workflow keeps the existing host path when the repository
 variable `ON_PREMISES` is exactly `true`. When it is false or absent, GitHub

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,6 +18,7 @@ import { MetricsController } from './metrics.controller';
 import { WebrtcModule } from './webrtc/webrtc.module';
 import { ObservabilityModule } from './observability/observability.module';
 import { OperatorPreferencesModule } from './operator-preferences/operator-preferences.module';
+import { RecordingModule } from './recording/recording.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { OperatorPreferencesModule } from './operator-preferences/operator-prefe
     RadioModule,
     WebrtcModule,
     OperatorPreferencesModule,
+    RecordingModule,
   ],
   controllers: [AppController, MetricsController],
   providers: [AppService],

--- a/backend/src/config/runtime-preflight.ts
+++ b/backend/src/config/runtime-preflight.ts
@@ -2,13 +2,13 @@ import 'dotenv/config';
 import { assertTestAuthSafety } from '../auth/test-auth.service';
 import {
   loadRuntimeSecrets,
-  validatePalazzoRuntimeConfiguration,
+  validateRuntimeConfiguration,
 } from './runtime-secrets';
 
 async function preflight(): Promise<void> {
   assertTestAuthSafety();
   await loadRuntimeSecrets();
-  validatePalazzoRuntimeConfiguration();
+  validateRuntimeConfiguration();
   process.stdout.write('Alcantara runtime preflight passed\n');
 }
 

--- a/backend/src/config/runtime-secrets.spec.ts
+++ b/backend/src/config/runtime-secrets.spec.ts
@@ -1,5 +1,6 @@
 import {
   loadRuntimeSecrets,
+  validateAlanaRuntimeConfiguration,
   validatePalazzoRuntimeConfiguration,
 } from './runtime-secrets';
 import { readFile } from 'node:fs/promises';
@@ -16,12 +17,14 @@ function productionEnvironment() {
 }
 
 describe('loadRuntimeSecrets', () => {
-  it('selects only allowlisted Palazzo scalars from the production payload', async () => {
+  it('selects only allowlisted private-service scalars from the production payload', async () => {
     const environment = productionEnvironment();
     const send = jest.fn().mockResolvedValue({
       SecretString: JSON.stringify({
         palazzoControlToken: 'fictional-production-token',
         palazzoAllowedUrls: 'http://palazzo:3100',
+        alanaControlToken: 'fictional-alana-control-token',
+        alanaControlUrl: 'http://alana:8080',
         untrustedProperty: 'must-not-enter-environment',
       }),
     });
@@ -29,6 +32,8 @@ describe('loadRuntimeSecrets', () => {
     expect(environment).toMatchObject({
       PALAZZO_CONTROL_TOKEN: 'fictional-production-token',
       PALAZZO_ALLOWED_URLS: 'http://palazzo:3100',
+      ALANA_CONTROL_TOKEN: 'fictional-alana-control-token',
+      ALANA_CONTROL_URL: 'http://alana:8080',
     });
     expect(environment).not.toHaveProperty('untrustedProperty');
   });
@@ -43,20 +48,24 @@ describe('loadRuntimeSecrets', () => {
       loadRuntimeSecrets(productionEnvironment(), {
         send: jest.fn().mockResolvedValue({ SecretString: '{}' }),
       }),
-    ).rejects.toThrow('Palazzo configuration is incomplete');
+    ).rejects.toThrow('private service configuration is incomplete');
     await expect(
       loadRuntimeSecrets({ NODE_ENV: 'production', AWS_REGION: 'us-east-1' }),
     ).rejects.toThrow(
-      'ALCANTARA_CONFIG_SECRET_ID or PALAZZO_CONTROL_TOKEN_FILE is required',
+      'ALCANTARA_CONFIG_SECRET_ID or both private control token files are required',
     );
   });
 
-  it('supports the existing Palazzo token file during production migration', async () => {
-    readFileMock.mockResolvedValue('existing-palazzo-control-token\n');
+  it('supports explicit token files for both private services during production migration', async () => {
+    readFileMock
+      .mockResolvedValueOnce('existing-palazzo-control-token\n')
+      .mockResolvedValueOnce('existing-alana-control-token\n');
     const environment = {
       NODE_ENV: 'production',
       PALAZZO_CONTROL_TOKEN_FILE: '/run/secrets/palazzo-control-token',
       PALAZZO_ALLOWED_URLS: 'http://palazzo:3100',
+      ALANA_CONTROL_TOKEN_FILE: '/run/secrets/alana-control-token',
+      ALANA_CONTROL_URL: 'http://alana:8080',
     };
 
     await loadRuntimeSecrets(environment);
@@ -67,6 +76,7 @@ describe('loadRuntimeSecrets', () => {
     );
     expect(environment).toMatchObject({
       PALAZZO_CONTROL_TOKEN: 'existing-palazzo-control-token',
+      ALANA_CONTROL_TOKEN: 'existing-alana-control-token',
     });
   });
 
@@ -96,5 +106,11 @@ describe('loadRuntimeSecrets', () => {
         PALAZZO_ALLOWED_URLS: 'http://user:password@palazzo:3100',
       }),
     ).toThrow('PALAZZO_ALLOWED_URLS contains an invalid URL');
+    expect(() =>
+      validateAlanaRuntimeConfiguration({
+        ALANA_CONTROL_TOKEN: 'fictional-alana-control-token',
+        ALANA_CONTROL_URL: 'http://alana:8080/private/path',
+      }),
+    ).toThrow('ALANA_CONTROL_URL contains an invalid URL');
   });
 });

--- a/backend/src/config/runtime-secrets.ts
+++ b/backend/src/config/runtime-secrets.ts
@@ -16,15 +16,20 @@ interface RuntimeEnvironment {
   PALAZZO_CONTROL_TOKEN?: string;
   PALAZZO_CONTROL_TOKEN_FILE?: string;
   PALAZZO_ALLOWED_URLS?: string;
+  ALANA_CONTROL_TOKEN?: string;
+  ALANA_CONTROL_TOKEN_FILE?: string;
+  ALANA_CONTROL_URL?: string;
   [key: string]: string | undefined;
 }
 
 const ALLOWED_SECRET_FIELDS = new Set([
   'palazzoControlToken',
   'palazzoAllowedUrls',
+  'alanaControlToken',
+  'alanaControlUrl',
 ]);
 
-export function isValidPalazzoControlToken(value: string): boolean {
+export function isValidPrivateControlToken(value: string): boolean {
   return (
     value.length >= 16 &&
     value.length <= 4096 &&
@@ -35,12 +40,17 @@ export function isValidPalazzoControlToken(value: string): boolean {
   );
 }
 
-export function normalizePalazzoBaseUrl(value: string): string {
+export const isValidPalazzoControlToken = isValidPrivateControlToken;
+
+export function normalizePrivateServiceUrl(
+  value: string,
+  fieldName: string,
+): string {
   let parsed: URL;
   try {
     parsed = new URL(value);
   } catch {
-    throw new Error('PALAZZO_ALLOWED_URLS contains an invalid URL');
+    throw new Error(`${fieldName} contains an invalid URL`);
   }
   if (
     !['http:', 'https:'].includes(parsed.protocol) ||
@@ -50,9 +60,13 @@ export function normalizePalazzoBaseUrl(value: string): string {
     parsed.hash ||
     (parsed.pathname !== '/' && parsed.pathname !== '')
   ) {
-    throw new Error('PALAZZO_ALLOWED_URLS contains an invalid URL');
+    throw new Error(`${fieldName} contains an invalid URL`);
   }
   return parsed.origin;
+}
+
+export function normalizePalazzoBaseUrl(value: string): string {
+  return normalizePrivateServiceUrl(value, 'PALAZZO_ALLOWED_URLS');
 }
 
 /** Validate the Palazzo machine configuration without constructing Nest. */
@@ -73,6 +87,26 @@ export function validatePalazzoRuntimeConfiguration(
   }
 }
 
+export function validateAlanaRuntimeConfiguration(
+  environment: RuntimeEnvironment = process.env,
+): void {
+  const token = environment.ALANA_CONTROL_TOKEN?.trim() ?? '';
+  if (!isValidPrivateControlToken(token)) {
+    throw new Error('ALANA_CONTROL_TOKEN is missing or invalid');
+  }
+  normalizePrivateServiceUrl(
+    environment.ALANA_CONTROL_URL?.trim() ?? '',
+    'ALANA_CONTROL_URL',
+  );
+}
+
+export function validateRuntimeConfiguration(
+  environment: RuntimeEnvironment = process.env,
+): void {
+  validatePalazzoRuntimeConfiguration(environment);
+  validateAlanaRuntimeConfiguration(environment);
+}
+
 /** Load the production Palazzo credential before Nest constructs any client. */
 export async function loadRuntimeSecrets(
   environment: RuntimeEnvironment = process.env,
@@ -82,19 +116,23 @@ export async function loadRuntimeSecrets(
   const secretId = environment.ALCANTARA_CONFIG_SECRET_ID?.trim();
   if (!secretId) {
     const tokenFile = environment.PALAZZO_CONTROL_TOKEN_FILE?.trim();
-    if (!tokenFile) {
+    const alanaTokenFile = environment.ALANA_CONTROL_TOKEN_FILE?.trim();
+    if (!tokenFile || !alanaTokenFile) {
       throw new Error(
-        'ALCANTARA_CONFIG_SECRET_ID or PALAZZO_CONTROL_TOKEN_FILE is required',
+        'ALCANTARA_CONFIG_SECRET_ID or both private control token files are required',
       );
     }
     try {
-      environment.PALAZZO_CONTROL_TOKEN = (
-        await readFile(tokenFile, 'utf8')
-      ).trim();
+      const [palazzoToken, alanaToken] = await Promise.all([
+        readFile(tokenFile, 'utf8'),
+        readFile(alanaTokenFile, 'utf8'),
+      ]);
+      environment.PALAZZO_CONTROL_TOKEN = palazzoToken.trim();
+      environment.ALANA_CONTROL_TOKEN = alanaToken.trim();
     } catch {
       throw new Error('Alcantara runtime configuration is unavailable');
     }
-    validatePalazzoRuntimeConfiguration(environment);
+    validateRuntimeConfiguration(environment);
     return;
   }
   const region = (
@@ -127,10 +165,17 @@ export async function loadRuntimeSecrets(
     }
     selected[key] = value.trim();
   }
-  if (!selected.palazzoControlToken || !selected.palazzoAllowedUrls) {
-    throw new Error('Alcantara Palazzo configuration is incomplete');
+  if (
+    !selected.palazzoControlToken ||
+    !selected.palazzoAllowedUrls ||
+    !selected.alanaControlToken ||
+    !selected.alanaControlUrl
+  ) {
+    throw new Error('Alcantara private service configuration is incomplete');
   }
   environment.PALAZZO_CONTROL_TOKEN = selected.palazzoControlToken;
   environment.PALAZZO_ALLOWED_URLS = selected.palazzoAllowedUrls;
-  validatePalazzoRuntimeConfiguration(environment);
+  environment.ALANA_CONTROL_TOKEN = selected.alanaControlToken;
+  environment.ALANA_CONTROL_URL = selected.alanaControlUrl;
+  validateRuntimeConfiguration(environment);
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -70,7 +70,12 @@ async function bootstrap() {
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Renderer-Key'],
+    allowedHeaders: [
+      'Content-Type',
+      'Authorization',
+      'Idempotency-Key',
+      'X-Renderer-Key',
+    ],
   });
 
   await app.listen(port, '0.0.0.0');

--- a/backend/src/observability/managed-metrics.service.spec.ts
+++ b/backend/src/observability/managed-metrics.service.spec.ts
@@ -10,6 +10,9 @@ describe('ManagedMetricsService program SSE metrics', () => {
     metrics.recordProgramSseSnapshot('success');
     metrics.recordProgramSseSnapshot('failure');
     metrics.recordProgramSseSnapshot('unbounded-value');
+    metrics.recordRecordingCommand('start', 'accepted');
+    metrics.recordRecordingCommand('private-action', 'private-result');
+    metrics.recordRecordingStatus('finalizing', 'success');
 
     const output = await metrics.render('');
 
@@ -24,5 +27,16 @@ describe('ManagedMetricsService program SSE metrics', () => {
       'alcantara_program_sse_snapshots_total{result="unknown"} 1',
     );
     expect(output).not.toContain('result="unbounded-value"');
+    expect(output).toContain(
+      'alcantara_recording_commands_total{action="start",result="accepted"} 1',
+    );
+    expect(output).toContain(
+      'alcantara_recording_commands_total{action="unknown",result="unknown"} 1',
+    );
+    expect(output).toContain(
+      'alcantara_recording_reconciliations_total{state="finalizing",result="success"} 1',
+    );
+    expect(output).not.toContain('private-action');
+    expect(output).not.toContain('private-result');
   });
 });

--- a/backend/src/observability/managed-metrics.service.ts
+++ b/backend/src/observability/managed-metrics.service.ts
@@ -43,6 +43,7 @@ const DEPENDENCIES = new Set([
   'postgres',
   's3',
   'livekit',
+  'alana',
   'unknown',
 ]);
 const DEPENDENCY_OPERATIONS = new Set([
@@ -82,6 +83,37 @@ const PREFERENCE_RESULTS = new Set([
   'failure',
 ]);
 const PROGRAM_SSE_SNAPSHOT_RESULTS = new Set(['success', 'failure']);
+const RECORDING_ACTIONS = new Set(['start', 'stop']);
+const RECORDING_STATES = new Set([
+  'disabled',
+  'idle',
+  'requested',
+  'active',
+  'finalizing',
+  'complete',
+  'failed',
+]);
+const RECORDING_RESULTS = new Set([
+  'success',
+  'accepted',
+  'complete',
+  'failed',
+  'disabled',
+  'already-active',
+  'not-active',
+  'pipeline-not-ready',
+  'disk-exhausted',
+  'quota-exhausted',
+  'capture-failed',
+  'restart-exhausted',
+  'manifest-corrupt',
+  'segment-corrupt',
+  'finalize-failed',
+  'final-artifact-invalid',
+  'unavailable',
+  'invalid-response',
+  'failure',
+]);
 
 function bounded(value: string, allowed: Set<string>): string {
   return allowed.has(value) ? value : 'unknown';
@@ -104,6 +136,8 @@ export class ManagedMetricsService {
   private readonly preferenceOperations: Counter<string>;
   private readonly programSseConnections: Gauge<string>;
   private readonly programSseSnapshots: Counter<string>;
+  private readonly recordingCommands: Counter<string>;
+  private readonly recordingReconciliations: Counter<string>;
 
   constructor() {
     collectDefaultMetrics({ prefix: 'alcantara_', register: this.registry });
@@ -183,6 +217,18 @@ export class ManagedMetricsService {
       labelNames: ['result'],
       registers: [this.registry],
     });
+    this.recordingCommands = new Counter({
+      name: 'alcantara_recording_commands_total',
+      help: 'Recording control commands by bounded action and result.',
+      labelNames: ['action', 'result'],
+      registers: [this.registry],
+    });
+    this.recordingReconciliations = new Counter({
+      name: 'alcantara_recording_reconciliations_total',
+      help: 'Alana recording status reconciliations by bounded state and result.',
+      labelNames: ['state', 'result'],
+      registers: [this.registry],
+    });
   }
 
   recordHttp(
@@ -248,6 +294,20 @@ export class ManagedMetricsService {
   recordProgramSseSnapshot(result: string): void {
     this.programSseSnapshots.inc({
       result: bounded(result, PROGRAM_SSE_SNAPSHOT_RESULTS),
+    });
+  }
+
+  recordRecordingCommand(action: string, result: string): void {
+    this.recordingCommands.inc({
+      action: bounded(action, RECORDING_ACTIONS),
+      result: bounded(result, RECORDING_RESULTS),
+    });
+  }
+
+  recordRecordingStatus(state: string, result: string): void {
+    this.recordingReconciliations.inc({
+      state: bounded(state, RECORDING_STATES),
+      result: bounded(result, RECORDING_RESULTS),
     });
   }
 

--- a/backend/src/recording/alana-recording.client.spec.ts
+++ b/backend/src/recording/alana-recording.client.spec.ts
@@ -1,0 +1,197 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  BadGatewayException,
+  HttpException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ManagedMetricsService } from '../observability/managed-metrics.service';
+import {
+  AlanaRecordingClient,
+  type RecordingFetch,
+} from './alana-recording.client';
+
+const TOKEN = 'alana-fictional-control-token';
+const BASE_URL = 'http://alana:8080';
+
+const status = (overrides: Record<string, unknown> = {}) => ({
+  enabled: true,
+  state: 'active',
+  requestedAt: '2026-09-06T18:00:00Z',
+  startedAt: '2026-09-06T18:00:01Z',
+  stoppedAt: null,
+  finalizedAt: null,
+  updatedAt: '2026-09-06T18:00:02Z',
+  segmentCount: 2,
+  bytes: 2000,
+  durationSeconds: 10,
+  droppedFrames: 0,
+  errors: 0,
+  restarts: 0,
+  finalizationState: 'not-requested',
+  finalBytes: 0,
+  error: null,
+  disk: {
+    freeBytes: 10_000,
+    usageBytes: 2_000,
+    quotaBytes: 20_000,
+    minimumFreeBytes: 1_000,
+  },
+  ...overrides,
+});
+
+function config(values: Record<string, string> = {}) {
+  return new ConfigService({
+    NODE_ENV: 'test',
+    ALANA_CONTROL_URL: BASE_URL,
+    ALANA_CONTROL_TOKEN: TOKEN,
+    ...values,
+  });
+}
+
+describe('AlanaRecordingClient', () => {
+  it('reads the exact program-scoped Alana status and keeps only bounded fields', async () => {
+    const transport = jest.fn<RecordingFetch>().mockResolvedValue(
+      Response.json(
+        status({
+          operationId: 'private-operation',
+          path: '/var/lib/alana/private.mp4',
+          finalSha256: 'private-artifact-hash',
+        }),
+      ),
+    );
+    const metrics = new ManagedMetricsService();
+    const client = new AlanaRecordingClient(config(), metrics, transport);
+
+    const result = await client.status('modo italiano');
+
+    expect(transport).toHaveBeenCalledWith(
+      'http://alana:8080/v1/programs/modo%20italiano/recording',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      }),
+    );
+    expect(result).toMatchObject({ state: 'active', segmentCount: 2 });
+    expect(result).not.toHaveProperty('operationId');
+    expect(result).not.toHaveProperty('path');
+    expect(result).not.toHaveProperty('finalSha256');
+    expect(await metrics.render('')).toContain(
+      'alcantara_recording_reconciliations_total{state="active",result="success"} 1',
+    );
+  });
+
+  it('forwards one bounded idempotency key with no command body', async () => {
+    const transport = jest.fn<RecordingFetch>().mockResolvedValue(
+      Response.json(
+        status({
+          state: 'requested',
+          commandResult: {
+            action: 'start',
+            status: 202,
+            result: 'accepted',
+          },
+        }),
+        { status: 202 },
+      ),
+    );
+    const metrics = new ManagedMetricsService();
+    const client = new AlanaRecordingClient(config(), metrics, transport);
+
+    const result = await client.command(
+      'modoitaliano',
+      'start',
+      'recording-start-1',
+    );
+
+    expect(result.state).toBe('requested');
+    const [url, init] = transport.mock
+      .calls[0] as unknown as Parameters<RecordingFetch>;
+    expect(url).toBe(
+      'http://alana:8080/v1/programs/modoitaliano/recording/start',
+    );
+    expect(init).not.toHaveProperty('body');
+    expect(init?.headers).toEqual({
+      Authorization: `Bearer ${TOKEN}`,
+      'Idempotency-Key': 'recording-start-1',
+    });
+    const output = await metrics.render('');
+    expect(output).toContain(
+      'alcantara_recording_commands_total{action="start",result="accepted"} 1',
+    );
+    expect(output).not.toContain(TOKEN);
+    expect(output).not.toContain('modoitaliano');
+  });
+
+  it('returns only bounded Alana rejection evidence', async () => {
+    const transport = jest.fn<RecordingFetch>().mockResolvedValue(
+      Response.json(
+        status({
+          state: 'failed',
+          error: '/private/path/provider-detail',
+          commandResult: {
+            action: 'stop',
+            status: 500,
+            result: '/private/path/provider-detail',
+          },
+        }),
+        { status: 500 },
+      ),
+    );
+    const client = new AlanaRecordingClient(
+      config(),
+      new ManagedMetricsService(),
+      transport,
+    );
+
+    let rejection: unknown;
+    try {
+      await client.command('modoitaliano', 'stop', 'recording-stop-1');
+    } catch (error) {
+      rejection = error;
+    }
+    expect(rejection).toBeInstanceOf(HttpException);
+    const response = (rejection as HttpException).getResponse();
+    expect(response).toMatchObject({ reason: 'unknown' });
+  });
+
+  it('fails closed on unavailable or malformed Alana responses', async () => {
+    const unavailable = new AlanaRecordingClient(
+      config(),
+      new ManagedMetricsService(),
+      jest
+        .fn<RecordingFetch>()
+        .mockRejectedValue(new Error('private provider detail')),
+    );
+    const malformed = new AlanaRecordingClient(
+      config(),
+      new ManagedMetricsService(),
+      jest
+        .fn<RecordingFetch>()
+        .mockResolvedValue(Response.json({ state: 'active' })),
+    );
+
+    await expect(unavailable.status('modoitaliano')).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
+    await expect(malformed.status('modoitaliano')).rejects.toBeInstanceOf(
+      BadGatewayException,
+    );
+  });
+
+  it('rejects credentials and non-origin targets before making a request', () => {
+    expect(
+      () =>
+        new AlanaRecordingClient(
+          config({ ALANA_CONTROL_TOKEN: 'short' }),
+          new ManagedMetricsService(),
+        ),
+    ).toThrow('ALANA_CONTROL_TOKEN is missing or invalid');
+    expect(
+      () =>
+        new AlanaRecordingClient(
+          config({ ALANA_CONTROL_URL: 'http://user:secret@alana:8080/path' }),
+          new ManagedMetricsService(),
+        ),
+    ).toThrow('ALANA_CONTROL_URL contains an invalid URL');
+  });
+});

--- a/backend/src/recording/alana-recording.client.ts
+++ b/backend/src/recording/alana-recording.client.ts
@@ -1,0 +1,179 @@
+import {
+  BadGatewayException,
+  HttpException,
+  Inject,
+  Injectable,
+  Logger,
+  Optional,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ManagedMetricsService } from '../observability/managed-metrics.service';
+import {
+  normalizeRecordingStatus,
+  type RecordingStatus,
+} from './recording.contract';
+import {
+  isValidPrivateControlToken,
+  normalizePrivateServiceUrl,
+} from '../config/runtime-secrets';
+
+export const ALANA_RECORDING_FETCH = Symbol('ALANA_RECORDING_FETCH');
+
+export type RecordingFetch = (
+  input: string,
+  init?: RequestInit,
+) => Promise<Response>;
+type RecordingAction = 'start' | 'stop';
+
+@Injectable()
+export class AlanaRecordingClient {
+  private readonly logger = new Logger(AlanaRecordingClient.name);
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+  private readonly transport: RecordingFetch;
+
+  constructor(
+    config: ConfigService,
+    private readonly metrics: ManagedMetricsService,
+    @Optional()
+    @Inject(ALANA_RECORDING_FETCH)
+    transport?: RecordingFetch,
+  ) {
+    const isTest = config.get<string>('NODE_ENV') === 'test';
+    this.baseUrl = normalizePrivateServiceUrl(
+      config.get<string>('ALANA_CONTROL_URL') ??
+        (isTest ? 'http://alana.test:8080' : ''),
+      'ALANA_CONTROL_URL',
+    );
+    this.token =
+      config.get<string>('ALANA_CONTROL_TOKEN')?.trim() ??
+      (isTest ? 'alana-test-control-token' : '');
+    if (!isValidPrivateControlToken(this.token)) {
+      throw new Error('ALANA_CONTROL_TOKEN is missing or invalid');
+    }
+    this.timeoutMs = 5_000;
+    this.transport =
+      transport ?? ((input, init) => globalThis.fetch(input, init));
+  }
+
+  async status(programId: string): Promise<RecordingStatus> {
+    return this.request(programId, 'status');
+  }
+
+  async command(
+    programId: string,
+    action: RecordingAction,
+    idempotencyKey: string,
+  ): Promise<RecordingStatus> {
+    return this.request(programId, action, idempotencyKey);
+  }
+
+  private async request(
+    programId: string,
+    operation: 'status' | RecordingAction,
+    idempotencyKey?: string,
+  ): Promise<RecordingStatus> {
+    const started = process.hrtime.bigint();
+    const isStatus = operation === 'status';
+    const url = `${this.baseUrl}/v1/programs/${encodeURIComponent(programId)}/recording${isStatus ? '' : `/${operation}`}`;
+    let response: Response;
+    try {
+      response = await this.transport(url, {
+        method: isStatus ? 'GET' : 'POST',
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
+        },
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch {
+      this.recordDependency(
+        isStatus ? 'read' : 'write',
+        'unavailable',
+        started,
+      );
+      if (!isStatus) this.recordAudit(operation, 'unavailable', 503);
+      throw new ServiceUnavailableException({
+        error: 'ALANA_RECORDING_UNAVAILABLE',
+      });
+    }
+
+    let status: RecordingStatus;
+    try {
+      status = normalizeRecordingStatus(await response.json());
+    } catch {
+      this.recordDependency(
+        isStatus ? 'read' : 'write',
+        'invalid-response',
+        started,
+      );
+      if (!isStatus) this.recordAudit(operation, 'invalid-response', 502);
+      throw new BadGatewayException({
+        error: 'ALANA_RECORDING_INVALID_RESPONSE',
+      });
+    }
+
+    const result = response.ok ? 'success' : 'http-error';
+    this.recordDependency(isStatus ? 'read' : 'write', result, started);
+    this.metrics.recordRecordingStatus(
+      status.state,
+      response.ok ? 'success' : 'failure',
+    );
+
+    if (!response.ok) {
+      const boundedReason =
+        status.commandResult?.result ?? status.error ?? 'unknown';
+      if (!isStatus) {
+        this.metrics.recordRecordingCommand(operation, boundedReason);
+        this.recordAudit(operation, boundedReason, response.status);
+      }
+      throw new HttpException(
+        {
+          error: 'RECORDING_COMMAND_REJECTED',
+          reason: boundedReason,
+          recording: status,
+        },
+        response.status >= 400 && response.status <= 599
+          ? response.status
+          : 502,
+      );
+    }
+
+    if (!isStatus) {
+      const boundedResult = status.commandResult?.result ?? 'success';
+      this.metrics.recordRecordingCommand(operation, boundedResult);
+      this.recordAudit(operation, boundedResult, response.status);
+    }
+    return status;
+  }
+
+  private recordDependency(
+    operation: 'read' | 'write',
+    result: string,
+    started: bigint,
+  ): void {
+    this.metrics.recordDependency(
+      'alana',
+      operation,
+      result,
+      Number(process.hrtime.bigint() - started) / 1_000_000_000,
+    );
+  }
+
+  private recordAudit(
+    action: RecordingAction,
+    result: string,
+    status: number,
+  ): void {
+    this.logger.log(
+      JSON.stringify({
+        event: 'recording-command',
+        action,
+        result,
+        status,
+      }),
+    );
+  }
+}

--- a/backend/src/recording/recording.contract.ts
+++ b/backend/src/recording/recording.contract.ts
@@ -1,0 +1,180 @@
+export const RECORDING_STATES = [
+  'disabled',
+  'idle',
+  'requested',
+  'active',
+  'finalizing',
+  'complete',
+  'failed',
+] as const;
+
+export type RecordingState = (typeof RECORDING_STATES)[number];
+
+export const RECORDING_FAILURE_REASONS = [
+  'disk-exhausted',
+  'quota-exhausted',
+  'capture-failed',
+  'restart-exhausted',
+  'manifest-corrupt',
+  'segment-corrupt',
+  'finalize-failed',
+  'final-artifact-invalid',
+] as const;
+
+export type RecordingFailureReason =
+  | (typeof RECORDING_FAILURE_REASONS)[number]
+  | 'unknown';
+
+export type RecordingStatus = {
+  enabled: boolean;
+  state: RecordingState;
+  requestedAt: string | null;
+  startedAt: string | null;
+  stoppedAt: string | null;
+  finalizedAt: string | null;
+  updatedAt: string | null;
+  segmentCount: number;
+  bytes: number;
+  durationSeconds: number;
+  droppedFrames: number;
+  errors: number;
+  restarts: number;
+  finalizationState: 'not-requested' | 'pending' | 'verified' | 'failed';
+  finalBytes: number;
+  error: RecordingFailureReason | null;
+  disk: {
+    freeBytes: number;
+    usageBytes: number;
+    quotaBytes: number;
+    minimumFreeBytes: number;
+  } | null;
+  commandResult?: {
+    action: 'start' | 'stop';
+    status: number;
+    result: string;
+    duplicate: boolean;
+  };
+};
+
+const stateSet = new Set<string>(RECORDING_STATES);
+const failureSet = new Set<string>(RECORDING_FAILURE_REASONS);
+const finalizationSet = new Set([
+  'not-requested',
+  'pending',
+  'verified',
+  'failed',
+]);
+const commandResults = new Set([
+  'accepted',
+  'complete',
+  'failed',
+  'disabled',
+  'already-active',
+  'not-active',
+  'pipeline-not-ready',
+  ...RECORDING_FAILURE_REASONS,
+]);
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('invalid recording response');
+  }
+  return value as Record<string, unknown>;
+}
+
+function nonNegativeNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : 0;
+}
+
+function nullableTimestamp(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length > 40) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? value : null;
+}
+
+function normalizeDisk(value: unknown): RecordingStatus['disk'] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const candidate = value as Record<string, unknown>;
+  return {
+    freeBytes: nonNegativeNumber(candidate.freeBytes),
+    usageBytes: nonNegativeNumber(candidate.usageBytes),
+    quotaBytes: nonNegativeNumber(candidate.quotaBytes),
+    minimumFreeBytes: nonNegativeNumber(candidate.minimumFreeBytes),
+  };
+}
+
+export function normalizeRecordingStatus(value: unknown): RecordingStatus {
+  const candidate = record(value);
+  if (
+    typeof candidate.enabled !== 'boolean' ||
+    typeof candidate.state !== 'string' ||
+    !stateSet.has(candidate.state)
+  ) {
+    throw new Error('invalid recording response');
+  }
+  const finalizationState =
+    typeof candidate.finalizationState === 'string' &&
+    finalizationSet.has(candidate.finalizationState)
+      ? (candidate.finalizationState as RecordingStatus['finalizationState'])
+      : 'not-requested';
+  const error =
+    typeof candidate.error === 'string'
+      ? failureSet.has(candidate.error)
+        ? (candidate.error as RecordingFailureReason)
+        : 'unknown'
+      : null;
+  const status: RecordingStatus = {
+    enabled: candidate.enabled,
+    state: candidate.state as RecordingState,
+    requestedAt: nullableTimestamp(candidate.requestedAt),
+    startedAt: nullableTimestamp(candidate.startedAt),
+    stoppedAt: nullableTimestamp(candidate.stoppedAt),
+    finalizedAt: nullableTimestamp(candidate.finalizedAt),
+    updatedAt: nullableTimestamp(candidate.updatedAt),
+    segmentCount: nonNegativeNumber(candidate.segmentCount),
+    bytes: nonNegativeNumber(candidate.bytes),
+    durationSeconds: nonNegativeNumber(candidate.durationSeconds),
+    droppedFrames: nonNegativeNumber(candidate.droppedFrames),
+    errors: nonNegativeNumber(candidate.errors),
+    restarts: nonNegativeNumber(candidate.restarts),
+    finalizationState,
+    finalBytes: nonNegativeNumber(candidate.finalBytes),
+    error,
+    disk: normalizeDisk(candidate.disk),
+  };
+  if (
+    (status.enabled === false && status.state !== 'disabled') ||
+    (status.state === 'disabled' && status.enabled !== false) ||
+    (status.state === 'complete' &&
+      (status.finalizationState !== 'verified' ||
+        status.finalBytes <= 0 ||
+        status.finalizedAt === null))
+  ) {
+    throw new Error('invalid recording response');
+  }
+  if (
+    candidate.commandResult &&
+    typeof candidate.commandResult === 'object' &&
+    !Array.isArray(candidate.commandResult)
+  ) {
+    const command = candidate.commandResult as Record<string, unknown>;
+    if (
+      (command.action === 'start' || command.action === 'stop') &&
+      typeof command.status === 'number'
+    ) {
+      status.commandResult = {
+        action: command.action,
+        status: command.status,
+        result:
+          typeof command.result === 'string' &&
+          commandResults.has(command.result)
+            ? command.result
+            : 'unknown',
+        duplicate: command.duplicate === true,
+      };
+    }
+  }
+  return status;
+}

--- a/backend/src/recording/recording.controller.spec.ts
+++ b/backend/src/recording/recording.controller.spec.ts
@@ -1,0 +1,69 @@
+import { BadRequestException } from '@nestjs/common';
+import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
+import { REQUIRED_PERMISSION_KEY } from '../auth/require-permission.decorator';
+import type { AlanaRecordingClient } from './alana-recording.client';
+import { RecordingController } from './recording.controller';
+
+function controllerMethod(name: 'start' | 'stop'): object {
+  const value: unknown = Object.getOwnPropertyDescriptor(
+    RecordingController.prototype,
+    name,
+  )?.value;
+  if (typeof value !== 'function') throw new Error(`Missing ${name} handler`);
+  return value;
+}
+
+describe('RecordingController', () => {
+  const status = jest.fn<AlanaRecordingClient['status']>();
+  const command = jest.fn<AlanaRecordingClient['command']>();
+  const recording = {
+    status,
+    command,
+  } as unknown as AlanaRecordingClient;
+  const controller = new RecordingController(recording);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('requires read access for status and operate access for mutations', () => {
+    expect(
+      Reflect.getMetadata(REQUIRED_PERMISSION_KEY, RecordingController),
+    ).toBe(ALCANTARA_PERMISSIONS.program.read);
+    expect(
+      Reflect.getMetadata(REQUIRED_PERMISSION_KEY, controllerMethod('start')),
+    ).toBe(ALCANTARA_PERMISSIONS.program.operate);
+    expect(
+      Reflect.getMetadata(REQUIRED_PERMISSION_KEY, controllerMethod('stop')),
+    ).toBe(ALCANTARA_PERMISSIONS.program.operate);
+  });
+
+  it('passes the exact caller key through for replay-safe commands', () => {
+    void controller.start('modoitaliano', 'recording-start-1');
+    void controller.stop('modoitaliano', 'recording-stop-1');
+
+    expect(command).toHaveBeenNthCalledWith(
+      1,
+      'modoitaliano',
+      'start',
+      'recording-start-1',
+    );
+    expect(command).toHaveBeenNthCalledWith(
+      2,
+      'modoitaliano',
+      'stop',
+      'recording-stop-1',
+    );
+  });
+
+  it('rejects missing, malformed, or oversized identifiers before Alana', () => {
+    expect(() => void controller.start('modoitaliano', undefined)).toThrow(
+      BadRequestException,
+    );
+    expect(
+      () => void controller.stop('modo/italiano', 'recording-stop-1'),
+    ).toThrow(BadRequestException);
+    expect(
+      () => void controller.start('modoitaliano', 'contains spaces'),
+    ).toThrow(BadRequestException);
+    expect(command).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/recording/recording.controller.ts
+++ b/backend/src/recording/recording.controller.ts
@@ -1,0 +1,84 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Header,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
+import { RequirePermission } from '../auth/require-permission.decorator';
+import { AlanaRecordingClient } from './alana-recording.client';
+
+const COMMAND_KEY = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/;
+
+@Controller('program/:programId/recording')
+@RequirePermission(ALCANTARA_PERMISSIONS.program.read)
+export class RecordingController {
+  constructor(private readonly recording: AlanaRecordingClient) {}
+
+  @Get()
+  @Header('Cache-Control', 'no-store')
+  status(@Param('programId') programId: string) {
+    return this.recording.status(normalizeProgramId(programId));
+  }
+
+  @Post('start')
+  @Header('Cache-Control', 'no-store')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @RequirePermission(ALCANTARA_PERMISSIONS.program.operate)
+  start(
+    @Param('programId') programId: string,
+    @Headers('idempotency-key') idempotencyKey?: string,
+  ) {
+    return this.recording.command(
+      normalizeProgramId(programId),
+      'start',
+      normalizeCommandKey(idempotencyKey),
+    );
+  }
+
+  @Post('stop')
+  @Header('Cache-Control', 'no-store')
+  @HttpCode(HttpStatus.OK)
+  @RequirePermission(ALCANTARA_PERMISSIONS.program.operate)
+  stop(
+    @Param('programId') programId: string,
+    @Headers('idempotency-key') idempotencyKey?: string,
+  ) {
+    return this.recording.command(
+      normalizeProgramId(programId),
+      'stop',
+      normalizeCommandKey(idempotencyKey),
+    );
+  }
+}
+
+function normalizeProgramId(value: string): string {
+  const normalized = value.trim();
+  if (
+    !normalized ||
+    normalized.length > 200 ||
+    normalized.includes('/') ||
+    [...normalized].some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 0x1f || code === 0x7f;
+    })
+  ) {
+    throw new BadRequestException({ error: 'INVALID_PROGRAM_ID' });
+  }
+  return normalized;
+}
+
+function normalizeCommandKey(value?: string): string {
+  const normalized = value?.trim() ?? '';
+  if (!COMMAND_KEY.test(normalized)) {
+    throw new BadRequestException({
+      error: 'A_BOUNDED_IDEMPOTENCY_KEY_IS_REQUIRED',
+    });
+  }
+  return normalized;
+}

--- a/backend/src/recording/recording.module.ts
+++ b/backend/src/recording/recording.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { AlanaRecordingClient } from './alana-recording.client';
+import { RecordingController } from './recording.controller';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [RecordingController],
+  providers: [AlanaRecordingClient],
+  exports: [AlanaRecordingClient],
+})
+export class RecordingModule {}

--- a/backend/test/fixtures/alana-recording-server.mjs
+++ b/backend/test/fixtures/alana-recording-server.mjs
@@ -1,0 +1,177 @@
+import { createServer } from 'node:http';
+import { URL } from 'node:url';
+
+const port = Number(process.env.PORT ?? '8080');
+const programId = process.env.PROGRAM_ID ?? 'modoitaliano';
+const token = process.env.ALANA_CONTROL_TOKEN ?? '';
+const basePath = `/v1/programs/${encodeURIComponent(programId)}/recording`;
+const commands = new Map();
+
+const timestamp = () => new Date().toISOString();
+const disk = {
+  freeBytes: 8_000_000_000,
+  usageBytes: 24_000_000,
+  quotaBytes: 50_000_000_000,
+  minimumFreeBytes: 1_000_000_000,
+};
+let state = {
+  enabled: true,
+  state: 'idle',
+  requestedAt: null,
+  startedAt: null,
+  stoppedAt: null,
+  finalizedAt: null,
+  updatedAt: timestamp(),
+  segmentCount: 0,
+  bytes: 0,
+  durationSeconds: 0,
+  droppedFrames: 0,
+  errors: 0,
+  restarts: 0,
+  finalizationState: 'not-requested',
+  finalBytes: 0,
+  error: null,
+  disk,
+};
+
+function send(response, status, payload) {
+  response.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+  });
+  response.end(`${JSON.stringify(payload)}\n`);
+}
+
+function command(response, action, key) {
+  const prior = commands.get(key);
+  if (prior) {
+    if (prior.action !== action) {
+      send(response, 409, {
+        ...state,
+        commandResult: {
+          action,
+          status: 409,
+          result: 'failed',
+          duplicate: true,
+        },
+      });
+      return;
+    }
+    send(response, prior.status, {
+      ...state,
+      commandResult: { ...prior, duplicate: true },
+    });
+    return;
+  }
+
+  if (action === 'start') {
+    if (['requested', 'active', 'finalizing'].includes(state.state)) {
+      const result = { action, status: 409, result: 'already-active' };
+      commands.set(key, result);
+      send(response, 409, {
+        ...state,
+        commandResult: { ...result, duplicate: false },
+      });
+      return;
+    }
+    state = {
+      ...state,
+      state: 'requested',
+      requestedAt: timestamp(),
+      startedAt: null,
+      stoppedAt: null,
+      finalizedAt: null,
+      updatedAt: timestamp(),
+      segmentCount: 0,
+      bytes: 0,
+      durationSeconds: 0,
+      finalizationState: 'not-requested',
+      finalBytes: 0,
+      error: null,
+    };
+    const result = { action, status: 202, result: 'accepted' };
+    commands.set(key, result);
+    send(response, 202, {
+      ...state,
+      commandResult: { ...result, duplicate: false },
+    });
+    setTimeout(() => {
+      if (state.state !== 'requested') return;
+      state = {
+        ...state,
+        state: 'active',
+        startedAt: timestamp(),
+        updatedAt: timestamp(),
+        segmentCount: 1,
+        bytes: 1_250_000,
+        durationSeconds: 5,
+      };
+    }, 250);
+    return;
+  }
+
+  if (!['requested', 'active'].includes(state.state)) {
+    const result = { action, status: 409, result: 'not-active' };
+    commands.set(key, result);
+    send(response, 409, {
+      ...state,
+      commandResult: { ...result, duplicate: false },
+    });
+    return;
+  }
+  state = {
+    ...state,
+    state: 'finalizing',
+    stoppedAt: timestamp(),
+    updatedAt: timestamp(),
+    finalizationState: 'pending',
+  };
+  const result = { action, status: 200, result: 'complete' };
+  commands.set(key, result);
+  setTimeout(() => {
+    if (state.state !== 'finalizing') return;
+    state = {
+      ...state,
+      state: 'complete',
+      finalizedAt: timestamp(),
+      updatedAt: timestamp(),
+      finalizationState: 'verified',
+      finalBytes: Math.max(state.bytes, 1_250_000),
+    };
+    send(response, 200, {
+      ...state,
+      commandResult: { ...result, duplicate: false },
+    });
+  }, 250);
+}
+
+createServer((request, response) => {
+  const path = new URL(request.url ?? '/', 'http://fixture').pathname;
+  if (request.method === 'GET' && path === '/health') {
+    send(response, 200, { status: 'ok' });
+    return;
+  }
+  if (request.headers.authorization !== `Bearer ${token}`) {
+    send(response, 401, { error: 'unauthorized' });
+    return;
+  }
+  if (request.method === 'GET' && path === basePath) {
+    send(response, 200, state);
+    return;
+  }
+  if (
+    request.method === 'POST' &&
+    (path === `${basePath}/start` || path === `${basePath}/stop`)
+  ) {
+    const key = String(request.headers['idempotency-key'] ?? '');
+    if (!key || key.length > 200) {
+      send(response, 400, { error: 'idempotency-key-required' });
+      return;
+    }
+    command(response, path.endsWith('/start') ? 'start' : 'stop', key);
+    return;
+  }
+  send(response, 404, { error: 'not-found' });
+}).listen(port, '0.0.0.0', () => {
+  process.stdout.write('Alana recording fixture ready\n');
+});

--- a/backend/test/metrics.e2e-spec.ts
+++ b/backend/test/metrics.e2e-spec.ts
@@ -50,6 +50,8 @@ describe('private Prometheus scrape boundary (e2e)', () => {
     );
     metrics.recordJob('charts-refresh', 'failure');
     metrics.recordPreference('write', 'conflict');
+    metrics.recordRecordingCommand('start', 'accepted');
+    metrics.recordRecordingStatus('active', 'success');
     const radioMetrics = app.get(RadioMetricsService);
     radioMetrics.recordMachineRequest('song-play', 'deduplicated');
     radioMetrics.recordMachineRequest('event-connect', 'unauthorized');
@@ -94,6 +96,12 @@ describe('private Prometheus scrape boundary (e2e)', () => {
     expect(body).toContain('alcantara_http_requests_total');
     expect(body).toContain('alcantara_dependency_operations_total');
     expect(body).toContain('alcantara_jobs_total');
+    expect(body).toContain(
+      'alcantara_recording_commands_total{action="start",result="accepted"} 1',
+    );
+    expect(body).toContain(
+      'alcantara_recording_reconciliations_total{state="active",result="success"} 1',
+    );
     expect(body).toContain('alcantara_palazzo_sse_connections');
     expect(body).toContain(
       'alcantara_operator_preference_operations_total{action="write",result="conflict"} 1',

--- a/backend/test/recording.e2e-spec.ts
+++ b/backend/test/recording.e2e-spec.ts
@@ -1,0 +1,153 @@
+import { ConfigModule } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { PompeiiAuthorizationGuard } from '../src/auth/pompeii-authorization.guard';
+import { ALCANTARA_PERMISSIONS } from '../src/auth/permissions';
+import { PompeiiService } from '../src/auth/pompeii.service';
+import { AlanaRecordingClient } from '../src/recording/alana-recording.client';
+import { RecordingController } from '../src/recording/recording.controller';
+
+const recordingStatus = {
+  enabled: true,
+  state: 'idle' as const,
+  requestedAt: null,
+  startedAt: null,
+  stoppedAt: null,
+  finalizedAt: null,
+  updatedAt: '2026-09-06T18:00:00Z',
+  segmentCount: 0,
+  bytes: 0,
+  durationSeconds: 0,
+  droppedFrames: 0,
+  errors: 0,
+  restarts: 0,
+  finalizationState: 'not-requested' as const,
+  finalBytes: 0,
+  error: null,
+  disk: null,
+};
+
+describe('recording authorization and idempotency boundary (e2e)', () => {
+  let app: NestFastifyApplication;
+  let origin: string;
+  const status = jest.fn().mockResolvedValue(recordingStatus);
+  const command = jest.fn().mockResolvedValue({
+    ...recordingStatus,
+    state: 'requested',
+    commandResult: {
+      action: 'start',
+      status: 202,
+      result: 'accepted',
+      duplicate: false,
+    },
+  });
+  const authorize = jest.fn((token: string, permission: string) => ({
+    authenticated: true,
+    allowed: token === 'Bearer operator-token',
+    reason:
+      token === 'Bearer operator-token' ? 'ALLOW_TEST' : 'DENY_PERMISSION',
+    subject: 'operator-subject',
+    effectivePermissions: [permission],
+    roles: ['operator'],
+  }));
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ isGlobal: true })],
+      controllers: [RecordingController],
+      providers: [
+        {
+          provide: AlanaRecordingClient,
+          useValue: { status, command },
+        },
+        {
+          provide: PompeiiService,
+          useValue: { authorize, teamId: 1 },
+        },
+        PompeiiAuthorizationGuard,
+        {
+          provide: APP_GUARD,
+          useExisting: PompeiiAuthorizationGuard,
+        },
+      ],
+    }).compile();
+    app = module.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
+    await app.listen(0, '127.0.0.1');
+    origin = await app.getUrl();
+  });
+
+  afterAll(async () => app.close());
+
+  it('denies status without authentication and operation without permission', async () => {
+    expect(
+      (await fetch(`${origin}/program/modoitaliano/recording`)).status,
+    ).toBe(401);
+    expect(
+      (
+        await fetch(`${origin}/program/modoitaliano/recording/start`, {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer viewer-token',
+            'Idempotency-Key': 'recording-start-1',
+          },
+        })
+      ).status,
+    ).toBe(403);
+    expect(command).not.toHaveBeenCalled();
+  });
+
+  it('uses read and operate catalog permissions and preserves replay keys', async () => {
+    const headers = { Authorization: 'Bearer operator-token' };
+    expect(
+      (await fetch(`${origin}/program/modoitaliano/recording`, { headers }))
+        .status,
+    ).toBe(200);
+    const commandHeaders = {
+      ...headers,
+      'Idempotency-Key': 'recording-start-1',
+    };
+    expect(
+      (
+        await fetch(`${origin}/program/modoitaliano/recording/start`, {
+          method: 'POST',
+          headers: commandHeaders,
+        })
+      ).status,
+    ).toBe(202);
+    expect(
+      (
+        await fetch(`${origin}/program/modoitaliano/recording/start`, {
+          method: 'POST',
+          headers: commandHeaders,
+        })
+      ).status,
+    ).toBe(202);
+
+    expect(authorize).toHaveBeenCalledWith(
+      'Bearer operator-token',
+      ALCANTARA_PERMISSIONS.program.read,
+    );
+    expect(authorize).toHaveBeenCalledWith(
+      'Bearer operator-token',
+      ALCANTARA_PERMISSIONS.program.operate,
+    );
+    expect(command).toHaveBeenNthCalledWith(
+      1,
+      'modoitaliano',
+      'start',
+      'recording-start-1',
+    );
+    expect(command).toHaveBeenNthCalledWith(
+      2,
+      'modoitaliano',
+      'start',
+      'recording-start-1',
+    );
+  });
+});

--- a/compose.yml
+++ b/compose.yml
@@ -33,6 +33,27 @@ services:
       timeout: 5s
       retries: 20
       start_period: 10s
+  alana-recording-fixture:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    command: ["node", "test/fixtures/alana-recording-server.mjs"]
+    environment:
+      PORT: "8080"
+      PROGRAM_ID: modoitaliano
+      ALANA_CONTROL_TOKEN: alana-local-control-token
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:8080/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
   backend:
     build:
       context: ./backend
@@ -64,6 +85,8 @@ services:
       METRICS_TOKEN_FILE: /run/secrets/alcantara-metrics-token
       PALAZZO_CONTROL_TOKEN: palazzo-local-control-token
       PALAZZO_ALLOWED_URLS: http://palazzo:3100
+      ALANA_CONTROL_TOKEN: alana-local-control-token
+      ALANA_CONTROL_URL: http://alana-recording-fixture:8080
     volumes:
       - ./backend/src:/app/src
       - ./backend/prisma:/app/prisma
@@ -87,6 +110,8 @@ services:
       postgres:
         condition: service_healthy
       livekit:
+        condition: service_healthy
+      alana-recording-fixture:
         condition: service_healthy
     healthcheck:
       test:

--- a/docs/program-recording.md
+++ b/docs/program-recording.md
@@ -1,0 +1,107 @@
+# Program recording control
+
+Alcantara is the authenticated operator control plane for Alana's composed
+Program recording. It does not capture, store, verify, serve, or delete media.
+The consumed contract is the Alana recorder landed by
+[`gaulatti/alana#16`](https://github.com/gaulatti/alana/pull/16), merge commit
+`fcc1ec29a4239631d7fb146b2d9ea905103aa0f2`.
+
+## Truthful state
+
+The control panel shows only the bounded state returned by Alana:
+
+- `disabled`: the Alana runtime has no recording control.
+- `idle`: recording is enabled and no operation is active.
+- `requested`: Start was accepted but capture is not yet confirmed.
+- `active`: Alana confirmed capture. This is the only state that displays
+  `REC`.
+- `finalizing`: capture stopped, but the manifest and final artifact are not
+  yet verified. Media is not safe to claim or publish.
+- `complete`: Alana verified the manifest and final artifact.
+- `failed`: recording failed. Alcantara keeps the independent broadcast
+  controls usable and reports only Alana's bounded failure reason; it does not
+  claim that a broadcast was live.
+
+Duration, bytes, segment count, restart count, finalization state, and the disk
+reserve are Alana-owned observations. Alcantara does not infer them or construct
+paths to an artifact. A disk warning appears when remaining space approaches
+Alana's configured reserve or retained bytes approach its quota.
+
+## API and authorization
+
+Alcantara exposes these authenticated routes:
+
+| Method | Route                                  | Permission                  | Behavior                                     |
+| ------ | -------------------------------------- | --------------------------- | -------------------------------------------- |
+| `GET`  | `/program/{programId}/recording`       | `alcantara:program:read`    | Reconcile current Alana state                |
+| `POST` | `/program/{programId}/recording/start` | `alcantara:program:operate` | Request independent capture                  |
+| `POST` | `/program/{programId}/recording/stop`  | `alcantara:program:operate` | Stop capture and begin verified finalization |
+
+Start and Stop require a bounded `Idempotency-Key`. Alcantara passes that exact
+key to Alana and sends no command body. The browser disables a command while it
+is in flight and retains the key after an ambiguous server failure so an
+operator retry cannot repeat the side effect. Alana remains the durable
+idempotency authority.
+
+Stop requires an explicit browser confirmation. The landed Alana API has no
+discard command, so Alcantara does not invent one. Artifact retention or
+operator cleanup remains an Alana storage operation after capture is inactive;
+it must not be represented as a recording Stop.
+
+The browser reconciles on initial load, every 2.5 seconds, window focus,
+visibility return, and network return. Browser state is never authoritative
+after a reload or reconnect.
+
+## Private service configuration
+
+`ALANA_CONTROL_URL` must be a private HTTP(S) origin without credentials, path,
+query, or fragment. `ALANA_CONTROL_TOKEN` is backend-only. Production loads the
+allowlisted `alanaControlUrl` and `alanaControlToken` scalars from the same
+application-scoped Secrets Manager payload as the Palazzo values before Nest
+constructs the adapter. Missing, malformed, or unavailable configuration fails
+the preflight without replacing the running backend.
+
+During a bounded migration, production can instead supply both
+`PALAZZO_CONTROL_TOKEN_FILE` and `ALANA_CONTROL_TOKEN_FILE`, plus their approved
+service URLs. No token or Alana address is exposed to the frontend.
+
+Local Compose starts a committed, private `alana-recording-fixture` service for
+the fictional `modoitaliano` program. It implements the landed status,
+Start/Stop, finalization, authorization, and idempotency shapes so the complete
+browser-to-backend path is testable without AWS, production media, an Alana
+checkout, or a real recorder. It never produces media and is not a deployment
+substitute.
+
+## Audit and metrics
+
+Recording commands emit a structured log containing only the closed event,
+action, result, and HTTP status. Program IDs, paths, tokens, artifact hashes,
+provider bodies, and free-form errors are excluded.
+
+The private authenticated Prometheus endpoint adds:
+
+- `alcantara_recording_commands_total{action,result}` for bounded Start/Stop
+  outcomes.
+- `alcantara_recording_reconciliations_total{state,result}` for bounded Alana
+  state reads.
+- existing `alcantara_dependency_operations_total` and
+  `alcantara_dependency_duration_seconds` with `dependency="alana"` and
+  `operation="read"|"write"`.
+
+These metrics show control-plane behavior only. Alana remains authoritative for
+capture health, disk, segments, final artifact verification, and its recorder
+metrics.
+
+## Rollout and recovery
+
+Before deployment, add the two Alana fields to the Alcantara production secret
+and verify that the selected Alana runtime is on the shared private network and
+has recording enabled. Exercise a bounded Start, observe `requested -> active`,
+confirm Stop, observe `finalizing -> complete`, and verify the artifact directly
+through Alana's documented operator boundary.
+
+On an Alana outage or malformed response, Alcantara shows recording control as
+unavailable and does not change the broadcast lifecycle. Recover Alana first;
+the next scheduled or focus/reconnect reconciliation restores the authoritative
+state. A `failed` recording must not stop, disable, or visually downgrade the
+separate Program live controls.

--- a/frontend/app/components/RecordingPanel.test.tsx
+++ b/frontend/app/components/RecordingPanel.test.tsx
@@ -1,0 +1,249 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RecordingState, RecordingStatus } from "../models/broadcast";
+import { RecordingPanel, RecordingStatusView } from "./RecordingPanel";
+import {
+  fetchRecordingStatus,
+  newRecordingCommandKey,
+  RecordingApiError,
+  sendRecordingCommand,
+} from "../services/recording";
+
+vi.mock("../services/recording", async () => {
+  class TestRecordingApiError extends Error {
+    constructor(
+      readonly status: number,
+      message: string,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    fetchRecordingStatus: vi.fn(),
+    sendRecordingCommand: vi.fn(),
+    newRecordingCommandKey: vi.fn(() => "recording-command-1"),
+    RecordingApiError: TestRecordingApiError,
+  };
+});
+
+afterEach(() => cleanup());
+
+const baseStatus = (state: RecordingState = "idle"): RecordingStatus => ({
+  enabled: state !== "disabled",
+  state,
+  requestedAt: "2026-09-06T18:00:00Z",
+  startedAt: state === "idle" ? null : "2026-09-06T18:00:01Z",
+  stoppedAt: null,
+  finalizedAt: null,
+  updatedAt: "2026-09-06T18:00:02Z",
+  segmentCount: state === "idle" ? 0 : 2,
+  bytes: state === "idle" ? 0 : 2_000_000,
+  durationSeconds: state === "idle" ? 0 : 10,
+  droppedFrames: 0,
+  errors: state === "failed" ? 1 : 0,
+  restarts: 0,
+  finalizationState:
+    state === "complete"
+      ? "verified"
+      : state === "finalizing"
+        ? "pending"
+        : state === "failed"
+          ? "failed"
+          : "not-requested",
+  finalBytes: state === "complete" ? 1_900_000 : 0,
+  error: state === "failed" ? "capture-failed" : null,
+  disk: {
+    freeBytes: 8_000_000_000,
+    usageBytes: 2_000_000,
+    quotaBytes: 50_000_000_000,
+    minimumFreeBytes: 1_000_000_000,
+  },
+});
+
+describe("RecordingStatusView", () => {
+  it.each([
+    ["requested", "Start requested"],
+    ["active", "Recording active"],
+    ["finalizing", "Finalizing — media is not safe yet"],
+    ["complete", "Complete — final artifact verified"],
+    ["failed", "Recording failed — broadcast controls remain available"],
+  ] as const)("renders the %s lifecycle distinctly", (state, label) => {
+    render(
+      <RecordingStatusView
+        status={baseStatus(state)}
+        busy={null}
+        message=""
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(label);
+    if (state === "active") {
+      expect(screen.getByText("REC")).toBeInTheDocument();
+    } else {
+      expect(screen.queryByText("REC")).toBeNull();
+    }
+  });
+
+  it("surfaces the Alana disk reserve without exposing a path", () => {
+    const status = baseStatus("failed");
+    status.error = "disk-exhausted";
+    status.disk = {
+      freeBytes: 900_000_000,
+      usageBytes: 49_000_000_000,
+      quotaBytes: 50_000_000_000,
+      minimumFreeBytes: 1_000_000_000,
+    };
+    render(
+      <RecordingStatusView
+        status={status}
+        busy={null}
+        message=""
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Disk warning")).toBeInTheDocument();
+    expect(
+      screen.getByText("Insufficient free disk space"),
+    ).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("/var/lib");
+  });
+});
+
+describe("RecordingPanel", () => {
+  beforeEach(() => {
+    vi.mocked(fetchRecordingStatus).mockResolvedValue(baseStatus("idle"));
+    vi.mocked(sendRecordingCommand).mockResolvedValue(baseStatus("requested"));
+    vi.mocked(newRecordingCommandKey).mockReturnValue("recording-command-1");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("reconciles actual state on load and browser reconnect", async () => {
+    render(<RecordingPanel programId="modoitaliano" />);
+    await screen.findByText("Ready to record");
+    window.dispatchEvent(new Event("online"));
+    await waitFor(() => expect(fetchRecordingStatus).toHaveBeenCalledTimes(2));
+    expect(fetchRecordingStatus).toHaveBeenCalledWith("modoitaliano");
+  });
+
+  it("prevents duplicate submissions and sends one caller-stable command key", async () => {
+    let resolveCommand: ((status: RecordingStatus) => void) | undefined;
+    vi.mocked(sendRecordingCommand).mockReturnValue(
+      new Promise((resolve) => {
+        resolveCommand = resolve;
+      }),
+    );
+    render(<RecordingPanel programId="modoitaliano" />);
+    const button = await screen.findByRole("button", {
+      name: "Start recording",
+    });
+    fireEvent.click(button);
+    expect(screen.getByRole("button", { name: "Requesting…" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Requesting…" }));
+    expect(sendRecordingCommand).toHaveBeenCalledTimes(1);
+    expect(sendRecordingCommand).toHaveBeenCalledWith(
+      "modoitaliano",
+      "start",
+      "recording-command-1",
+    );
+    resolveCommand?.(baseStatus("requested"));
+    await screen.findByText("Start requested");
+  });
+
+  it("requires confirmation before stop and preserves active state on cancel", async () => {
+    vi.mocked(fetchRecordingStatus).mockResolvedValue(baseStatus("active"));
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(<RecordingPanel programId="modoitaliano" />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Stop and finalize" }),
+    );
+    expect(confirm).toHaveBeenCalledWith(
+      expect.stringContaining("media is not complete until Alana verifies"),
+    );
+    expect(sendRecordingCommand).not.toHaveBeenCalled();
+    expect(screen.getByText("REC")).toBeInTheDocument();
+  });
+
+  it("reuses the key after an ambiguous upstream failure and explains permission denial", async () => {
+    vi.mocked(sendRecordingCommand)
+      .mockRejectedValueOnce(
+        new RecordingApiError(
+          503,
+          "Recording control is temporarily unavailable.",
+        ),
+      )
+      .mockRejectedValueOnce(
+        new RecordingApiError(
+          403,
+          "You do not have permission to operate recording.",
+        ),
+      );
+    render(<RecordingPanel programId="modoitaliano" />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Start recording" }),
+    );
+    await screen.findByText("Recording control is temporarily unavailable.");
+    fireEvent.click(screen.getByRole("button", { name: "Start recording" }));
+    await screen.findByText("You do not have permission to operate recording.");
+    expect(sendRecordingCommand).toHaveBeenNthCalledWith(
+      1,
+      "modoitaliano",
+      "start",
+      "recording-command-1",
+    );
+    expect(sendRecordingCommand).toHaveBeenNthCalledWith(
+      2,
+      "modoitaliano",
+      "start",
+      "recording-command-1",
+    );
+  });
+
+  it("reuses the key after an ambiguous browser transport failure", async () => {
+    vi.mocked(newRecordingCommandKey)
+      .mockReturnValueOnce("recording-command-transport-1")
+      .mockReturnValueOnce("recording-command-transport-2");
+    vi.mocked(sendRecordingCommand)
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockRejectedValueOnce(
+        new RecordingApiError(
+          403,
+          "You do not have permission to operate recording.",
+        ),
+      );
+    render(<RecordingPanel programId="modoitaliano" />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Start recording" }),
+    );
+    await screen.findByText("Recording control is temporarily unavailable.");
+    fireEvent.click(screen.getByRole("button", { name: "Start recording" }));
+    await screen.findByText("You do not have permission to operate recording.");
+
+    expect(sendRecordingCommand).toHaveBeenNthCalledWith(
+      1,
+      "modoitaliano",
+      "start",
+      "recording-command-transport-1",
+    );
+    expect(sendRecordingCommand).toHaveBeenNthCalledWith(
+      2,
+      "modoitaliano",
+      "start",
+      "recording-command-transport-1",
+    );
+    expect(newRecordingCommandKey).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/components/RecordingPanel.tsx
+++ b/frontend/app/components/RecordingPanel.tsx
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RecordingStatus } from "../models/broadcast";
+import {
+  fetchRecordingStatus,
+  newRecordingCommandKey,
+  RecordingApiError,
+  sendRecordingCommand,
+} from "../services/recording";
+
+const stateLabels: Record<RecordingStatus["state"], string> = {
+  disabled: "Recording disabled",
+  idle: "Ready to record",
+  requested: "Start requested",
+  active: "Recording active",
+  finalizing: "Finalizing — media is not safe yet",
+  complete: "Complete — final artifact verified",
+  failed: "Recording failed — broadcast controls remain available",
+};
+
+const failureLabels: Record<string, string> = {
+  "disk-exhausted": "Insufficient free disk space",
+  "quota-exhausted": "Recording storage quota reached",
+  "capture-failed": "Capture failed",
+  "restart-exhausted": "Recorder restart budget exhausted",
+  "manifest-corrupt": "Manifest verification failed",
+  "segment-corrupt": "Segment verification failed",
+  "finalize-failed": "Finalization failed",
+  "final-artifact-invalid": "Final artifact verification failed",
+  unknown: "Unclassified recording failure",
+};
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const index = Math.min(
+    Math.floor(Math.log(value) / Math.log(1000)),
+    units.length - 1,
+  );
+  return `${(value / 1000 ** index).toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+}
+
+function formatDuration(value: number): string {
+  const seconds = Math.max(0, Math.floor(value));
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainder = seconds % 60;
+  return hours > 0
+    ? `${hours}:${String(minutes).padStart(2, "0")}:${String(remainder).padStart(2, "0")}`
+    : `${minutes}:${String(remainder).padStart(2, "0")}`;
+}
+
+function hasDiskWarning(status: RecordingStatus): boolean {
+  const disk = status.disk;
+  if (!disk) return false;
+  return (
+    disk.freeBytes <= disk.minimumFreeBytes * 1.25 ||
+    (disk.quotaBytes > 0 && disk.usageBytes >= disk.quotaBytes * 0.9)
+  );
+}
+
+function recordingErrorMessage(error: unknown): string {
+  return error instanceof RecordingApiError
+    ? error.message
+    : "Recording control is temporarily unavailable.";
+}
+
+export function RecordingStatusView({
+  status,
+  busy,
+  message,
+  onStart,
+  onStop,
+  onRefresh,
+}: {
+  status: RecordingStatus | null;
+  busy: "start" | "stop" | null;
+  message: string;
+  onStart: () => void;
+  onStop: () => void;
+  onRefresh: () => void;
+}) {
+  const canStart =
+    status?.enabled === true &&
+    ["idle", "complete", "failed"].includes(status.state);
+  const canStop =
+    status?.enabled === true && ["requested", "active"].includes(status.state);
+  const diskWarning = status ? hasDiskWarning(status) : false;
+
+  return (
+    <section
+      aria-label="Program recording"
+      data-recording-state={status?.state ?? "unavailable"}
+      className="mx-3 mt-3 rounded-xl border border-zinc-700 bg-zinc-950/90 px-4 py-3 shadow-lg"
+    >
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-xs font-bold uppercase tracking-[0.2em] text-zinc-300">
+              Program recording
+            </h2>
+            {status?.state === "active" ? (
+              <span className="rounded bg-red-600 px-2 py-0.5 text-[10px] font-black tracking-widest text-white shadow-[0_0_12px_rgba(220,38,38,0.5)]">
+                REC
+              </span>
+            ) : null}
+            {diskWarning ? (
+              <span className="rounded border border-amber-600/60 bg-amber-950 px-2 py-0.5 text-[10px] font-bold uppercase text-amber-200">
+                Disk warning
+              </span>
+            ) : null}
+          </div>
+          <p
+            role="status"
+            aria-live="polite"
+            className={`mt-1 text-sm font-semibold ${status?.state === "failed" ? "text-red-300" : status?.state === "finalizing" ? "text-amber-300" : "text-zinc-100"}`}
+          >
+            {status
+              ? stateLabels[status.state]
+              : "Recording status unavailable"}
+          </p>
+          {status ? (
+            <p className="mt-1 text-xs text-zinc-400">
+              {formatDuration(status.durationSeconds)} ·{" "}
+              {formatBytes(
+                status.state === "complete" && status.finalBytes > 0
+                  ? status.finalBytes
+                  : status.bytes,
+              )}{" "}
+              · {status.segmentCount} segment
+              {status.segmentCount === 1 ? "" : "s"}
+              {status.restarts > 0 ? ` · ${status.restarts} restarts` : ""}
+            </p>
+          ) : null}
+          {status?.state === "failed" && status.error ? (
+            <p className="mt-1 text-xs text-red-300">
+              {failureLabels[status.error] ?? failureLabels.unknown}
+            </p>
+          ) : null}
+          {diskWarning && status?.disk ? (
+            <p className="mt-1 text-xs text-amber-300">
+              {formatBytes(status.disk.freeBytes)} free; recording requires a{" "}
+              {formatBytes(status.disk.minimumFreeBytes)} reserve.
+            </p>
+          ) : null}
+          {message ? (
+            <p role="alert" className="mt-1 text-xs text-amber-200">
+              {message}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {!status ? (
+            <button
+              type="button"
+              onClick={onRefresh}
+              className="rounded border border-zinc-600 bg-zinc-800 px-3 py-2 text-xs font-bold text-zinc-100 hover:bg-zinc-700"
+            >
+              Retry status
+            </button>
+          ) : null}
+          {canStart ? (
+            <button
+              type="button"
+              onClick={onStart}
+              disabled={busy !== null}
+              className="rounded border border-red-500/70 bg-red-950 px-4 py-2 text-xs font-black uppercase tracking-widest text-red-100 hover:bg-red-900 disabled:cursor-wait disabled:opacity-50"
+            >
+              {busy === "start" ? "Requesting…" : "Start recording"}
+            </button>
+          ) : null}
+          {canStop ? (
+            <button
+              type="button"
+              onClick={onStop}
+              disabled={busy !== null}
+              className="rounded border border-amber-500/70 bg-amber-950 px-4 py-2 text-xs font-black uppercase tracking-widest text-amber-100 hover:bg-amber-900 disabled:cursor-wait disabled:opacity-50"
+            >
+              {busy === "stop" ? "Stopping…" : "Stop and finalize"}
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function RecordingPanel({ programId }: { programId: string }) {
+  const [status, setStatus] = useState<RecordingStatus | null>(null);
+  const [busy, setBusy] = useState<"start" | "stop" | null>(null);
+  const [message, setMessage] = useState("");
+  const retryCommand = useRef<{
+    action: "start" | "stop";
+    key: string;
+  } | null>(null);
+
+  const refresh = useCallback(
+    async (clearMessage = true) => {
+      try {
+        setStatus(await fetchRecordingStatus(programId));
+        if (clearMessage) setMessage("");
+      } catch (error) {
+        setStatus(null);
+        if (clearMessage) {
+          setMessage(recordingErrorMessage(error));
+        }
+      }
+    },
+    [programId],
+  );
+
+  useEffect(() => {
+    setStatus(null);
+    setMessage("");
+    retryCommand.current = null;
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), 2_500);
+    const reconcile = () => void refresh();
+    const reconcileVisible = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+    window.addEventListener("focus", reconcile);
+    window.addEventListener("online", reconcile);
+    document.addEventListener("visibilitychange", reconcileVisible);
+    return () => {
+      window.clearInterval(timer);
+      window.removeEventListener("focus", reconcile);
+      window.removeEventListener("online", reconcile);
+      document.removeEventListener("visibilitychange", reconcileVisible);
+    };
+  }, [refresh]);
+
+  const command = async (action: "start" | "stop") => {
+    if (
+      action === "stop" &&
+      !window.confirm(
+        "Stop recording and begin finalization? Recording cannot resume, and the media is not complete until Alana verifies the final artifact.",
+      )
+    ) {
+      return;
+    }
+    const pending = retryCommand.current;
+    const key =
+      pending?.action === action ? pending.key : newRecordingCommandKey(action);
+    setBusy(action);
+    setMessage("");
+    try {
+      const next = await sendRecordingCommand(programId, action, key);
+      retryCommand.current = null;
+      setStatus(next);
+    } catch (error) {
+      if (!(error instanceof RecordingApiError) || error.status >= 500) {
+        retryCommand.current = { action, key };
+      } else {
+        retryCommand.current = null;
+      }
+      setMessage(recordingErrorMessage(error));
+      await refresh(false);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <RecordingStatusView
+      status={status}
+      busy={busy}
+      message={message}
+      onStart={() => void command("start")}
+      onStop={() => void command("stop")}
+      onRefresh={() => void refresh()}
+    />
+  );
+}

--- a/frontend/app/models/broadcast.ts
+++ b/frontend/app/models/broadcast.ts
@@ -41,6 +41,46 @@ export interface ProgramState {
   mediaGroups: ProgramMediaGroupEntry[];
 }
 
+export type RecordingState =
+  | "disabled"
+  | "idle"
+  | "requested"
+  | "active"
+  | "finalizing"
+  | "complete"
+  | "failed";
+
+export interface RecordingStatus {
+  enabled: boolean;
+  state: RecordingState;
+  requestedAt: string | null;
+  startedAt: string | null;
+  stoppedAt: string | null;
+  finalizedAt: string | null;
+  updatedAt: string | null;
+  segmentCount: number;
+  bytes: number;
+  durationSeconds: number;
+  droppedFrames: number;
+  errors: number;
+  restarts: number;
+  finalizationState: "not-requested" | "pending" | "verified" | "failed";
+  finalBytes: number;
+  error: string | null;
+  disk: {
+    freeBytes: number;
+    usageBytes: number;
+    quotaBytes: number;
+    minimumFreeBytes: number;
+  } | null;
+  commandResult?: {
+    action: "start" | "stop";
+    status: number;
+    result: string;
+    duplicate: boolean;
+  };
+}
+
 export interface InstantItem {
   id: number;
   name: string;

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -20,6 +20,7 @@ export default [
       route('console-fixture', 'routes/console-fixture.tsx'),
       route('song-intro-fixture', 'routes/song-intro-fixture.tsx'),
       route('slideshow-fixture', 'routes/slideshow-fixture.tsx'),
+      route('recording-fixture', 'routes/recording-fixture.tsx'),
       route('flight', 'routes/flight.tsx')
     ]),
     route('overlay', 'routes/overlay.tsx')

--- a/frontend/app/routes/control.tsx
+++ b/frontend/app/routes/control.tsx
@@ -37,6 +37,7 @@ import { PlaybackBar } from "../components/PlaybackBar";
 import { BroadcastSwitcherDeck } from "../components/BroadcastSwitcherDeck";
 import { useConsolePreferences } from "../contexts/ConsolePreferencesContext";
 import { RadioPanel } from "../components/RadioPanel";
+import { RecordingPanel } from "../components/RecordingPanel";
 import {
   InstantsPanel,
   PlaylistPanel,
@@ -3298,6 +3299,7 @@ export default function Control() {
           void setFadeToBlack(programState?.fadeToBlack !== true)
         }
       />
+      <RecordingPanel programId={activeProgramId} />
       <div
         className={`flex-1 min-h-[420px] w-full ${consoleWorkspace === "compact" ? "hidden" : ""}`}
         data-workspace-content={consoleWorkspace}

--- a/frontend/app/routes/recording-fixture.tsx
+++ b/frontend/app/routes/recording-fixture.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+import { useSearchParams } from "react-router";
+import { RecordingStatusView } from "../components/RecordingPanel";
+import type { RecordingState, RecordingStatus } from "../models/broadcast";
+
+const states = new Set<RecordingState>([
+  "disabled",
+  "idle",
+  "requested",
+  "active",
+  "finalizing",
+  "complete",
+  "failed",
+]);
+
+export default function RecordingFixture() {
+  const [params] = useSearchParams();
+  const stateValue = params.get("state") as RecordingState | null;
+  const state = stateValue && states.has(stateValue) ? stateValue : "active";
+  const status = useMemo<RecordingStatus>(
+    () => ({
+      enabled: state !== "disabled",
+      state,
+      requestedAt: "2026-09-06T18:00:00Z",
+      startedAt: "2026-09-06T18:00:01Z",
+      stoppedAt:
+        state === "finalizing" || state === "complete"
+          ? "2026-09-06T18:42:00Z"
+          : null,
+      finalizedAt: state === "complete" ? "2026-09-06T18:42:04Z" : null,
+      updatedAt: "2026-09-06T18:42:04Z",
+      segmentCount: 504,
+      bytes: 1_940_000_000,
+      durationSeconds: 2_520,
+      droppedFrames: 0,
+      errors: state === "failed" ? 1 : 0,
+      restarts: 1,
+      finalizationState:
+        state === "complete"
+          ? "verified"
+          : state === "finalizing"
+            ? "pending"
+            : state === "failed"
+              ? "failed"
+              : "not-requested",
+      finalBytes: state === "complete" ? 1_938_000_000 : 0,
+      error: state === "failed" ? "disk-exhausted" : null,
+      disk: {
+        freeBytes: state === "failed" ? 900_000_000 : 8_000_000_000,
+        usageBytes: 1_940_000_000,
+        quotaBytes: 50_000_000_000,
+        minimumFreeBytes: 1_000_000_000,
+      },
+    }),
+    [state],
+  );
+
+  return (
+    <main
+      className="min-h-screen bg-zinc-950 p-6 text-zinc-100"
+      data-visual-fixture={state}
+    >
+      <RecordingStatusView
+        status={status}
+        busy={null}
+        message=""
+        onStart={() => undefined}
+        onStop={() => undefined}
+        onRefresh={() => undefined}
+      />
+    </main>
+  );
+}

--- a/frontend/app/services/recording.ts
+++ b/frontend/app/services/recording.ts
@@ -1,0 +1,90 @@
+import type { RecordingStatus } from "../models/broadcast";
+import { authFetch } from "./api";
+
+export class RecordingApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+const messages: Record<string, string> = {
+  "pipeline-not-ready": "Alana is not ready to record the composed program.",
+  disabled: "Recording is disabled in Alana.",
+  "already-active": "A recording is already active or finalizing.",
+  "not-active": "There is no active recording to stop.",
+  "disk-exhausted": "Alana does not have enough free disk space.",
+  "quota-exhausted": "Alana has reached its recording storage quota.",
+  "capture-failed": "Alana could not capture the composed program.",
+  "restart-exhausted": "Alana exhausted its recording restart budget.",
+  "manifest-corrupt": "Alana could not verify the recording manifest.",
+  "segment-corrupt": "Alana found a corrupt recording segment.",
+  "finalize-failed": "Alana could not finalize the recording.",
+  "final-artifact-invalid": "Alana could not verify the final recording.",
+};
+
+async function parseResponse(response: Response): Promise<RecordingStatus> {
+  const payload = (await response.json().catch(() => null)) as
+    | RecordingStatus
+    | { error?: unknown; reason?: unknown }
+    | null;
+  if (!response.ok) {
+    const errorPayload = payload as Record<string, unknown> | null;
+    const reason =
+      errorPayload && typeof errorPayload.reason === "string"
+        ? errorPayload.reason
+        : "";
+    const message =
+      response.status === 403
+        ? "You do not have permission to operate recording."
+        : response.status === 401
+          ? "Your session is no longer authorized."
+          : (messages[reason] ??
+            (response.status >= 500
+              ? "Recording control is temporarily unavailable."
+              : "The recording command was rejected."));
+    throw new RecordingApiError(response.status, message);
+  }
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    !("state" in payload) ||
+    typeof payload.state !== "string"
+  ) {
+    throw new RecordingApiError(
+      502,
+      "Recording control returned an invalid response.",
+    );
+  }
+  return payload as RecordingStatus;
+}
+
+export async function fetchRecordingStatus(
+  programId: string,
+): Promise<RecordingStatus> {
+  const response = await authFetch(
+    `/program/${encodeURIComponent(programId)}/recording`,
+  );
+  return parseResponse(response);
+}
+
+export async function sendRecordingCommand(
+  programId: string,
+  action: "start" | "stop",
+  idempotencyKey: string,
+): Promise<RecordingStatus> {
+  const response = await authFetch(
+    `/program/${encodeURIComponent(programId)}/recording/${action}`,
+    {
+      method: "POST",
+      headers: { "Idempotency-Key": idempotencyKey },
+    },
+  );
+  return parseResponse(response);
+}
+
+export function newRecordingCommandKey(action: "start" | "stop"): string {
+  return `alcantara-recording-${action}-${crypto.randomUUID()}`;
+}


### PR DESCRIPTION
## Summary

- add authenticated, permission-cataloged recording status/start/stop routes that proxy the landed Alana recorder contract with bounded response fields, replay-safe idempotency, private runtime configuration, audit logs, and Prometheus metrics
- add a truthful operator panel where only confirmed active capture shows REC; requested, finalizing, verified complete, disabled, unavailable, disk pressure, and bounded failures remain distinct without changing broadcast-live controls
- add a committed private Alana fixture, backend/frontend coverage, a visual-state fixture, and operator rollout/recovery documentation

Closes #56

## Verification

- Base: `main` at `43945e6100372bea91d03f61ea9c4763312f3dd5`
- `pnpm --dir backend exec jest --runInBand`: 24 suites, 110 tests passed
- focused backend contract/config/metrics: 4 suites, 14 tests passed
- recording authorization and metrics E2E: 2 suites, 5 tests passed
- `pnpm --dir frontend test`: 10 files, 42 tests passed
- focused recording UI: 11 tests passed
- `pnpm --dir backend build`: passed
- `pnpm --dir frontend build`: passed
- `pnpm --dir backend test:deployment`: 4 tests passed
- changed backend files pass ESLint; staged diff check passed
- real committed HTTP fixture: idle -> requested; same start key returned `duplicate=true`; then active -> stop -> verified complete with nonzero final bytes
- installed Chrome at 1440x900 rendered active, finalizing, complete, and failed states: active alone showed REC; finalizing withheld safe-media wording; failed showed the bounded disk warning while the broadcast shell remained intact; no horizontal overflow

## Existing and live boundaries

- The repository-wide backend E2E aggregate still fails in the existing `app.e2e-spec.ts` before execution because Jest cannot resolve the existing `music-metadata` import. The new recording and metrics E2E suites pass independently.
- The repository-wide frontend typecheck and backend lint retain their existing unrelated baseline failures; none names a changed recording file, and changed backend files lint clean.
- Docker Desktop returned client metadata with `Server=null` and did not answer daemon requests, so the committed Compose wiring could not be exercised in this run. The fixture HTTP process and browser visual path were verified independently.
- No production secret, private Alana network, real capture/media, deployment, or merge was exercised. Production requires adding `alanaControlUrl` and `alanaControlToken` to the existing Alcantara secret and validating the private Alana runtime before rollout.
- Work occurred only in `/Users/gaulatti/source/gaulatti/alcantara.worktrees/issue-56-recording-controls`; the original checkout and the separate dirty #57 worktree were not modified. The mandatory agent updater passed once with no managed changes; the wiki remote was unavailable, so documentation is included in this PR.

## Summary by Sourcery

Integrate truthful, authenticated Alana recording controls into the operator experience without conflating recording state with broadcast state.

New Features:
- Add authenticated operator routes for reading, starting, and stopping Alana program recordings with bounded status responses and replay-safe idempotency.
- Add a recording control panel that distinguishes requested, active, finalizing, verified complete, failed, disabled, and unavailable states, showing REC only for confirmed active capture.
- Add local Alana recording fixtures and visual state fixtures for end-to-end and browser verification.

Bug Fixes:
- Prevent recording failures or unavailable states from being represented as broadcast-live state or from disrupting broadcast controls.

Enhancements:
- Add private Alana runtime configuration validation, structured command auditing, bounded recording metrics, recovery semantics, and rollout guidance.

Build:
- Extend local Compose wiring with the Alana recording fixture and backend configuration.

Deployment:
- Require Alana control credentials and URL in the production secret and validate them during runtime preflight.

Documentation:
- Document the Alana recording contract, state semantics, authorization, idempotency, metrics, private configuration, rollout, and recovery boundaries.

Tests:
- Add backend client, authorization, configuration, metrics, fixture, and recording API coverage.
- Add frontend lifecycle, disk-warning, reconciliation, confirmation, and idempotent retry coverage.