### PR TITLE
fix(deploy): keep alcantara logs host-local

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -175,8 +175,6 @@ jobs:
               return 1
             }
 
-            LOG_STREAM_UUID=$(uuidgen)
-
             if ! docker run -d --name alcantara-backend \
             --network broadcast-control \
             -p ${{ vars.HTTP_PORT }}:${{ vars.HTTP_PORT }} \
@@ -201,10 +199,9 @@ jobs:
             -e WEBRTC_RENDERER_KEY="${{ secrets.WEBRTC_RENDERER_KEY }}" \
             -e CONTAINERIZED=true \
             --restart=always \
-            --log-driver=awslogs \
-            --log-opt awslogs-region=${{ vars.AWS_REGION }} \
-            --log-opt awslogs-group=${{ vars.LOGS_GROUP }} \
-            --log-opt awslogs-stream="$LOG_STREAM_UUID" \
+            --log-driver=local \
+            --log-opt max-size=10m \
+            --log-opt max-file=3 \
             -v ~/.aws:/root/.aws:ro \
             --volumes-from "$PALAZZO_CONTAINER_ID:ro" \
             ghcr.io/${{ github.repository }}:latest; then

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Secrets Manager bootstrap, allowlisted URLs, failure behavior, and metrics.
 Macondo provisions the shared Cumulus host, network, and Arauco database. The
 service-specific AWS integration lives in [`infra/aws`](infra/aws): Alcántara
 owns its GitHub OIDC deployment role, API DNS record, and the policies granting
-the Cumulus host access to media storage and logs. Macondo grants its instance
+the Cumulus host access to media storage. Macondo grants its instance
 role access to every database secret it provisions; the backend resolves
 Arauco credentials inside the container through that instance profile.
 
@@ -345,6 +345,13 @@ the Palazzo credential and approved URL list. The previous container is retained
 until the replacement passes its startup check and is automatically restored if
 the replacement fails. This keeps the existing radio controller alive when a
 configuration or startup defect reaches deployment.
+
+Production backend stdout and stderr remain available through `docker logs`,
+using Docker's host-local `local` driver with a 10 MiB maximum per file and
+three retained files. Alcantara does not require a CloudWatch Logs group or
+write grant to start, restart, or roll back. See
+[Production backend logging](docs/production-backend-logging.md) for validation
+and rollback procedures.
 
 The replacement joins `broadcast-control` so the private
 `http://palazzo:3100` program-scoped machine API remains resolvable. Set the

--- a/backend/README.md
+++ b/backend/README.md
@@ -94,13 +94,20 @@ variable `ON_PREMISES` is exactly `true`. When it is false or absent, GitHub
 OIDC assumes the `alcantara-github-deploy` role and uses SSM to deploy to the
 single EC2 host tagged `Name=macondo-services`. The service-owned stack in
 `infra/aws` owns that role, the API DNS record, and the Cumulus host grants for
-media storage and logs. Macondo grants its instance role access to the database
+media storage. Macondo grants its instance role access to the database
 secrets it provisions. Set the non-secret `ARAUCO_SECRET_ARN` and
 `MEDIA_S3_BUCKET` repository variables; the container resolves Arauco
 credentials through the instance profile and requires TLS for the RDS
 connection with Amazon's bundled RDS CA and full hostname verification, so
 database credentials never pass through GitHub or appear in Docker
 configuration.
+
+Both production host paths use Docker's bounded host-local `local` log driver
+(`max-size=10m`, `max-file=3`). Application stdout and stderr remain available
+through `docker logs`; startup, restart, and rollback do not require a
+CloudWatch Logs group or writer grant. See
+[`../docs/production-backend-logging.md`](../docs/production-backend-logging.md)
+for cutover validation and rollback.
 
 The Cumulus path deliberately refuses to migrate or start against a fresh,
 empty Arauco database. Restore the production backup first. Deployment checks

--- a/backend/test/deployment-gate.test.js
+++ b/backend/test/deployment-gate.test.js
@@ -58,3 +58,36 @@ test('keeps the backend private to nginx and preserves realtime proxy behavior',
   assert.match(nginx, /proxy_set_header Upgrade \$http_upgrade/);
   assert.match(nginx, /proxy_read_timeout 24h/);
 });
+
+test('uses bounded host-local logs without a CloudWatch dependency', () => {
+  for (const deployment of [workflow, deployScript]) {
+    assert.match(deployment, /--log-driver=local/);
+    assert.match(deployment, /--log-opt max-size=10m/);
+    assert.match(deployment, /--log-opt max-file=3/);
+    assert.doesNotMatch(deployment, /--log-driver=awslogs/);
+    assert.doesNotMatch(deployment, /awslogs-/);
+    assert.doesNotMatch(deployment, /LOGS_GROUP/);
+  }
+});
+
+test('retains the previous container until the local-logging replacement is healthy', () => {
+  for (const deployment of [workflow, deployScript]) {
+    const retainPrevious = deployment.indexOf(
+      'docker rename alcantara-backend alcantara-backend-previous',
+    );
+    const createReplacement = deployment.indexOf('--log-driver=local');
+    const removePrevious = deployment.lastIndexOf(
+      'docker rm alcantara-backend-previous',
+    );
+
+    assert.ok(retainPrevious >= 0);
+    assert.ok(createReplacement > retainPrevious);
+    assert.ok(removePrevious > createReplacement);
+    assert.match(deployment, /rollback_backend\(\)/);
+    assert.match(
+      deployment,
+      /docker rename alcantara-backend-previous alcantara-backend/,
+    );
+    assert.match(deployment, /docker start alcantara-backend/);
+  }
+});

--- a/deploy/cumulus.sh
+++ b/deploy/cumulus.sh
@@ -80,10 +80,9 @@ if ! docker run -d --name alcantara-backend \
   -e CONTAINERIZED=true \
   --volume /etc/palazzo/control-token:/run/secrets/palazzo-control-token:ro \
   --restart=always \
-  --log-driver=awslogs \
-  --log-opt awslogs-region=us-east-1 \
-  --log-opt awslogs-group=/services/alcantara \
-  --log-opt "awslogs-stream=alcantara-$(date +%Y%m%dT%H%M%S)" \
+  --log-driver=local \
+  --log-opt max-size=10m \
+  --log-opt max-file=3 \
   "$image"; then
   rollback_backend
   exit 1

--- a/docs/production-backend-logging.md
+++ b/docs/production-backend-logging.md
@@ -1,0 +1,56 @@
+# Production backend logging
+
+Alcantara writes application diagnostics to stdout and stderr. Both production
+deployment paths configure Docker's `local` logging driver with a 10 MiB limit
+per file and three retained files. Operators can continue to inspect recent
+output with:
+
+```bash
+docker logs --tail 200 alcantara-backend
+docker inspect alcantara-backend \
+  --format '{{.HostConfig.LogConfig.Type}} {{json .HostConfig.LogConfig.Config}}'
+```
+
+The expected inspection result has driver `local`, `max-size` `10m`, and
+`max-file` `3`. Backend startup, health checks, authenticated status reads, and
+automatic rollback do not depend on `/services/alcantara`, CloudWatch Logs
+writer permissions, or a hosted replacement collector. Historical CloudWatch
+log data is outside this repository's retention contract and is not deleted by
+deployment or infrastructure changes.
+
+## Cutover verification
+
+After the reviewed change reaches `main` and the normal backend deployment
+finishes:
+
+1. Confirm the deployment used the intended `main` commit and completed its
+   startup check.
+2. Inspect `alcantara-backend` and confirm the bounded `local` driver options
+   above.
+3. Restart the container once and confirm the public health endpoint and an
+   authenticated status read succeed.
+4. Confirm `docker logs --tail 200 alcantara-backend` remains useful and does
+   not expose program, token, or user values.
+5. Compare the `AWS/Logs` `IncomingBytes` metric for log group
+   `/services/alcantara` before and after the cutover window. New application
+   events must remain at zero after old buffered deliveries have settled.
+
+Do not copy log contents or credentials into GitHub evidence. Record only the
+commit, timestamps, resource name, driver options, health/status outcome, and
+metric totals.
+
+## Rollback
+
+The deployment scripts keep the previous container until the replacement
+passes its startup check. A failed replacement automatically removes the new
+container, renames the previous container back to `alcantara-backend`, starts
+it, and checks recovery where the host path supports that check. Because the
+previous container retains its original logging configuration, this rollback
+does not depend on the new driver.
+
+To reverse the logging cutover after a successful deployment, revert the single
+merged logging change through the normal review path, deploy that exact revert
+commit, and apply the reverted `infra/aws` stack. Verify the restored container
+driver and the `/services/alcantara` writer grant before considering rollback
+complete. Do not recreate a log group, alter a live container, or add a writer
+grant manually.

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -5,7 +5,7 @@ shared Cumulus host, network, and Arauco database. This stack owns:
 
 - `alcantara-github-deploy`, restricted to `gaulatti/alcantara` `main` and SSM
   commands to the EC2 instance tagged `Name=macondo-services`;
-- the host grants for Alcántara media and `/services/alcantara` logs; and
+- the host grants for Alcántara media storage; and
 - `api.alcantara.gaulatti.com` pointing to the Cumulus Elastic IP.
 
 Copy `.env.example` to `.env`, populate it with the non-secret identifiers from
@@ -27,3 +27,8 @@ identifier and resolve credentials through that instance profile. The existing
 Route 53 record must be adopted into this stack during the first deployment
 rather than duplicated. After deployment, set the GitHub repository variables
 `ARAUCO_SECRET_ARN` and `MEDIA_S3_BUCKET` to the corresponding identifiers.
+
+Application logging is intentionally absent from this stack. Production
+containers retain bounded host-local logs, so the Cumulus role needs no
+CloudWatch Logs writer actions and Alcantara does not look up or create an
+application log group.

--- a/infra/aws/lib/alcantara-infrastructure-stack.ts
+++ b/infra/aws/lib/alcantara-infrastructure-stack.ts
@@ -1,6 +1,5 @@
 import { CfnOutput, Duration, Stack, StackProps } from "aws-cdk-lib";
 import { Policy, PolicyStatement, Role } from "aws-cdk-lib/aws-iam";
-import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { ARecord, HostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
@@ -31,11 +30,6 @@ export class AlcantaraInfrastructureStack extends Stack {
       "MediaBucket",
       config.mediaBucketName,
     );
-    const backendLogGroup = LogGroup.fromLogGroupName(
-      this,
-      "BackendLogGroup",
-      "/services/alcantara",
-    );
     const hostPolicy = new Policy(this, "AlcantaraCumulusHostPolicy", {
       policyName: "alcantara-cumulus-host",
       statements: [
@@ -53,10 +47,6 @@ export class AlcantaraInfrastructureStack extends Stack {
             "s3:PutObjectVersionTagging",
           ],
           resources: [mediaBucket.bucketArn, `${mediaBucket.bucketArn}/*`],
-        }),
-        new PolicyStatement({
-          actions: ["logs:CreateLogStream", "logs:PutLogEvents"],
-          resources: [backendLogGroup.logGroupArn],
         }),
       ],
     });

--- a/infra/aws/test/alcantara-infrastructure.test.ts
+++ b/infra/aws/test/alcantara-infrastructure.test.ts
@@ -18,7 +18,7 @@ const template = (): Template => {
   );
 };
 
-test("owns Alcantara application permissions outside Macondo", () => {
+test("owns only the Alcantara application permissions needed on Cumulus", () => {
   const rendered = template();
   rendered.hasResourceProperties("AWS::IAM::Policy", {
     PolicyName: "alcantara-cumulus-host",
@@ -27,8 +27,9 @@ test("owns Alcantara application permissions outside Macondo", () => {
   expect(policies).not.toContain("secretsmanager:GetSecretValue");
   expect(policies).toContain("s3:PutObject");
   expect(policies).toContain("example-alcantara-assets");
-  expect(policies).toContain("logs:PutLogEvents");
-  expect(policies).toContain("/services/alcantara");
+  expect(policies).not.toContain("logs:");
+  expect(policies).not.toContain("/services/alcantara");
+  rendered.resourceCountIs("AWS::Logs::LogGroup", 0);
 });
 
 test("owns the API record and main-branch deployment role", () => {


### PR DESCRIPTION
## Summary

- use Docker's bounded host-local `local` log driver on both production backend launch paths
- remove Alcantara's CloudWatch log-group reference and direct host writer grant
- add regression coverage plus cutover validation and one-change rollback guidance

## Verification

- Base: `origin/main` at `b98730070cf25ce445587df32088437e78f14d74`
- `pnpm --dir backend run test:deployment` — 6/6 passed, covering both launch paths, absence of CloudWatch options, exact local retention, and previous-container rollback ordering
- `pnpm --dir infra/aws test` — 2/2 passed
- `pnpm --dir infra/aws run build` — passed
- `pnpm --dir infra/aws run synth` with documented example identifiers — passed; synthesized output contains no `AWS::Logs`, `logs:` action, or `/services/alcantara` log-group reference
- `pnpm --dir backend exec jest --runInBand` — 24 suites / 110 tests passed
- metrics and recording E2E suites passed, including authenticated recording status
- `pnpm --dir backend run build` — passed
- `bash -n deploy/cumulus.sh` and actionlint v1.7.12 — passed
- Full local Compose stack built and became healthy; backend health returned 200 before and after restart, and an authenticated recording-status read returned 200 (`idle`)
- Exact backend image started and restarted with `local`, `max-size=10m`, and `max-file=3`; recent output remained available through `docker logs`
- Known local fixture credential values were absent from backend logs
- Disposable previous-container rollback exercise restored the prior container to running state

## Read-only production baseline

- `/services/alcantara` exists with 30-day retention and 6,987,110 stored bytes
- `AWS/Logs IncomingBytes` totaled 2,857,612 bytes across 73 hourly points from 2026-09-04 00:00 UTC through 2026-09-07 03:00 UTC
- The deployed `AlcantaraInfrastructureStack` still contains `logs:CreateLogStream` and `logs:PutLogEvents`; this PR's synth removes both
- No log contents or secret values were read or copied into this evidence

## Remaining boundary

No deployment, live container restart, or AWS mutation was performed. Therefore the production driver, live authenticated status, stack grant removal, and post-cutover zero-ingestion window remain to be verified after merge through the documented deployment path.

Remote `main` has unrelated baseline verification debt: the no-fix backend lint command reports 378 existing issues, and the full app E2E suite cannot resolve `music-metadata`. Ticket-focused tests, the normal unit suite, metrics/recording E2E suites, builds, synth, local runtime, and deployment-policy checks pass. The public wiki remote was unavailable, so the operational documentation is included in-repository.

Closes #58

## Summary by Sourcery

Switch production backend deployments to bounded host-local Docker logging and remove their CloudWatch Logs infrastructure dependency.

Bug Fixes:
- Keep production backend logs host-local and bounded instead of sending them to CloudWatch Logs.

Enhancements:
- Remove Alcantara's CloudWatch log-group dependency and host log-writer permissions while preserving deployment rollback behavior.
- Add production logging cutover validation and rollback guidance for operators.

Deployment:
- Configure both production backend deployment paths with Docker's local log driver, retaining 10 MiB per file and three files.

Documentation:
- Document host-local backend log inspection, cutover verification, and rollback procedures.

Tests:
- Add deployment regression coverage for bounded local logging, CloudWatch option removal, and previous-container rollback ordering.
- Update infrastructure tests to verify that no CloudWatch log resources or permissions are synthesized.