### PR TITLE
feat(deploy): validate alana config before image build

### DIFF
--- a/.agents/skills/ai-agentic-update/SKILL.md
+++ b/.agents/skills/ai-agentic-update/SKILL.md
@@ -40,9 +40,21 @@ product change. If its scoped commit fails, stop rather than continuing with
 dirty managed metadata. The updater does not push, deploy, reset, rebase, or
 discard product or wiki work.
 
+If the fetched revision changes the updater implementation, the current process
+hands off once to a temporary copy of the fetched updater. A guard prevents
+handoff loops and makes a failure visible. The central sync also recognizes the
+exact no-commit call made by pre-commit legacy updaters and creates the required
+narrow bootstrap commit during that same first invocation; this compatibility
+does not make ordinary manual `sync --write --repository` calls commit.
+
 If the updater fails or cannot verify the central source, stop before making
 other repository mutations and report the exact failure. Do not silently work
 against an unverified or stale standard.
+
+For a task worktree already stopped by the legacy dirty-metadata failure, do not
+blindly invoke the updater again. Preserve unrelated work and restart the ticket
+from a fresh current-default-branch worktree after the compatibility release is
+published.
 
 An explicit invocation authorizes the updater's fetch and its narrowly scoped
 changes to the central checkout/cache and current repository. It does not

--- a/.agents/skills/ai-agentic-update/scripts/update
+++ b/.agents/skills/ai-agentic-update/scripts/update
@@ -273,9 +273,13 @@ if [[ "${target_common}" == "${reference_common}" ]]; then
 fi
 
 snapshot=''
+handoff_script=''
 cleanup() {
   if [[ -n "${snapshot}" && -d "${snapshot}" ]]; then
     rm -rf "${snapshot}"
+  fi
+  if [[ -n "${handoff_script}" && -f "${handoff_script}" ]]; then
+    rm -f "${handoff_script}"
   fi
 }
 trap cleanup EXIT
@@ -299,6 +303,38 @@ if [[ ! -x "${update_source}/scripts/sync" ]]; then
   fi
   printf 'error: central source does not contain an executable scripts/sync: %s\n' "${update_source}" >&2
   exit 1
+fi
+
+fetched_updater="${update_source}/.agents/skills/ai-agentic-update/scripts/update"
+running_updater="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+if [[ -x "${fetched_updater}" ]] && ! cmp -s "${running_updater}" "${fetched_updater}"; then
+  if [[ -n "${AI_AGENTIC_UPDATE_HANDOFF:-}" ]]; then
+    printf 'error: updater handoff did not converge at central revision %s\n' \
+      "${central_commit}" >&2
+    exit 1
+  fi
+
+  handoff_script="$(mktemp "${TMPDIR:-/tmp}/ai-agentic-update-handoff.XXXXXX")"
+  cp "${fetched_updater}" "${handoff_script}"
+  chmod 0755 "${handoff_script}"
+  rm -rf "${snapshot}"
+  snapshot=''
+  printf 'agentic-handoff\trepository=%s\tcommit=%s\n' \
+    "${TARGET_REPOSITORY}" "${central_commit}"
+
+  handoff_args=(
+    --repository "${TARGET_REPOSITORY}"
+    --reference-repository "${REFERENCE_REPOSITORY}"
+  )
+  if [[ "${FETCH}" != 'true' ]]; then
+    handoff_args+=(--no-fetch)
+  fi
+  if AI_AGENTIC_UPDATE_HANDOFF='1' "${handoff_script}" "${handoff_args[@]}"; then
+    handoff_status=0
+  else
+    handoff_status=$?
+  fi
+  exit "${handoff_status}"
 fi
 
 AI_AGENTIC_CODING_COMMIT="${central_commit}" \

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -3,9 +3,12 @@ name: Backend CI
 on:
   pull_request:
     paths:
-      - 'backend/**'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/backend-ci.yml'
+      - "backend/**"
+      - "deploy/**"
+      - "infra/aws/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/backend-ci.yml"
+      - ".github/workflows/backend-deploy.yml"
 
 permissions:
   contents: read
@@ -28,7 +31,10 @@ jobs:
           pnpm --dir backend run prisma:generate
           pnpm --dir backend exec jest --runInBand
           METRICS_SCRAPE_OUTPUT=/tmp/alcantara.prom pnpm --dir backend exec jest --config ./test/jest-e2e.json --runInBand --testPathPatterns=metrics
+          pnpm --dir backend run test:deployment
           pnpm --dir backend run build
+          pnpm --dir infra/aws exec jest --runInBand
+          pnpm --dir infra/aws run build
       - name: Parse actual authenticated scrape
         run: |
           test -s /tmp/alcantara.prom

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -5,13 +5,42 @@ on:
     branches:
       - main
     paths:
-      - 'backend/**'
-      - 'deploy/**'
-      - 'infra/**'
-      - '.github/workflows/backend-deploy.yml'
+      - "backend/**"
+      - "deploy/**"
+      - "infra/**"
+      - ".github/workflows/backend-deploy.yml"
+
+env:
+  ALCANTARA_CONFIG_SECRET_ID: broadcast/production/config
 
 jobs:
+  production-config-preflight:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout production contract
+        uses: actions/checkout@v4
+
+      - name: Configure read-only production preflight credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::792025092931:role/alcantara-github-deploy
+
+      - name: Validate production runtime secret without revealing values
+        run: |
+          set -euo pipefail
+          aws secretsmanager get-secret-value \
+            --secret-id "$ALCANTARA_CONFIG_SECRET_ID" \
+            --query SecretString \
+            --output text \
+            | node backend/src/config/runtime-secret-contract.js
+
   build:
+    needs: production-config-preflight
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -127,7 +156,7 @@ jobs:
             docker run --rm \
             -e NODE_ENV=production \
             -e AWS_REGION="${{ vars.AWS_REGION }}" \
-            -e ALCANTARA_CONFIG_SECRET_ID="${{ vars.ALCANTARA_CONFIG_SECRET_ID }}" \
+            -e ALCANTARA_CONFIG_SECRET_ID="${{ env.ALCANTARA_CONFIG_SECRET_ID }}" \
             -e PALAZZO_CONTROL_TOKEN_FILE=/run/secrets/palazzo-control-token \
             -e PALAZZO_ALLOWED_URLS=http://palazzo:3100 \
             --volumes-from "$PALAZZO_CONTAINER_ID:ro" \
@@ -186,7 +215,7 @@ jobs:
             -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
             -e ALLOWED_ORIGINS="${{ vars.FQDN }}" \
             -e AWS_REGION="${{ vars.AWS_REGION }}" \
-            -e ALCANTARA_CONFIG_SECRET_ID="${{ vars.ALCANTARA_CONFIG_SECRET_ID }}" \
+            -e ALCANTARA_CONFIG_SECRET_ID="${{ env.ALCANTARA_CONFIG_SECRET_ID }}" \
             -e PALAZZO_CONTROL_TOKEN_FILE=/run/secrets/palazzo-control-token \
             -e PALAZZO_ALLOWED_URLS=http://palazzo:3100 \
             -e POMPEII_TEAM_ID=1 \
@@ -250,7 +279,7 @@ jobs:
           fi
           CUMULUS_INSTANCE_ID="$(jq -r '.[0]' <<<"$INSTANCE_IDS")"
 
-          BROADCAST_SECRET_ID='broadcast/production/config'
+          BROADCAST_SECRET_ID="$ALCANTARA_CONFIG_SECRET_ID"
           DATABASE_SECRET_ID='${{ vars.ARAUCO_SECRET_ARN }}'
           MEDIA_BUCKET='${{ vars.MEDIA_S3_BUCKET }}'
           for value in "$DATABASE_SECRET_ID" "$MEDIA_BUCKET"; do

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ This starts PostgreSQL, applies every committed migration non-interactively,
 loads deterministic fictional data, and starts the backend, frontend, and
 LiveKit. No AWS or Cognito account is needed for local development. Ports are
 configurable via `.env`:
+
 - **Backend** (NestJS, default port 3000) with hot reload via `nest start --watch`
 - **Frontend** (React Router/Vite, default port 5173) with HMR
 
@@ -265,11 +266,13 @@ concurrency, sharing, reset, privacy, and API behavior are documented in
 [Operator console preferences](docs/operator-preferences.md).
 
 Rebuild images after dependency changes:
+
 ```bash
 docker compose up --build
 ```
 
 Run in background:
+
 ```bash
 docker compose up -d
 ```
@@ -354,10 +357,11 @@ write grant to start, restart, or roll back. See
 and rollback procedures.
 
 The replacement joins `broadcast-control` so the private
-`http://palazzo:3100` program-scoped machine API remains resolvable. Set the
-production `ALCANTARA_CONFIG_SECRET_ID` repository variable to the
-application-scoped Secrets Manager payload, including Alana's private recording
-control URL and token. During migration, deployment also
+`http://palazzo:3100` program-scoped machine API remains resolvable. Production
+uses the code-owned `broadcast/production/config` Secrets Manager payload,
+including Alana's private recording control URL and token. The deployment
+workflow validates that payload without printing it before image build or push.
+During migration, deployment also
 discovers and inherits the running Palazzo container's existing read-only
 control-token mount as a backwards-compatible credential source. Preflight fails without
 replacing the live backend when that mount is absent or ambiguous, neither

--- a/backend/README.md
+++ b/backend/README.md
@@ -80,12 +80,14 @@ Fresh databases replay the PostgreSQL baseline normally. Production never uses
 complete migration history twice against a fresh PostgreSQL database to verify
 both non-interactive execution and repeatability.
 
-The application process also requires `ALCANTARA_CONFIG_SECRET_ID` and
-`AWS_REGION` in production. Before constructing Nest providers it loads the
-allowlisted `palazzoControlToken`, `palazzoAllowedUrls`, `alanaControlToken`,
-and `alanaControlUrl` fields from that Secrets Manager payload. Missing,
-malformed, or unavailable configuration fails startup; tokens are never
-frontend variables or Docker build arguments. See
+The application process uses the code-owned `broadcast/production/config`
+secret identifier and requires `AWS_REGION` in production. Before constructing
+Nest providers it loads the allowlisted `palazzoControlToken`,
+`palazzoAllowedUrls`, `alanaControlToken`, and `alanaControlUrl` fields from that
+Secrets Manager payload. Missing, malformed, or unavailable configuration fails
+startup; tokens are never frontend variables or Docker build arguments. The
+GitHub deployment workflow performs the same value-redacting payload check
+before registry login, image build, or push. See
 [`../docs/radio-telemetry.md`](../docs/radio-telemetry.md) and
 [`../docs/program-recording.md`](../docs/program-recording.md).
 

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -9,6 +9,11 @@
         "include": "proto/*.proto",
         "outDir": "dist/src",
         "watchAssets": true
+      },
+      {
+        "include": "config/runtime-secret-contract.js",
+        "outDir": "dist/src",
+        "watchAssets": true
       }
     ]
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:deployment": "node --test test/deployment-gate.test.js",
+    "test:deployment": "node --test test/deployment-gate.test.js test/runtime-secret-contract.test.js test/alana-recording-fixture.test.mjs",
     "seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {

--- a/backend/src/config/runtime-secret-contract.d.ts
+++ b/backend/src/config/runtime-secret-contract.d.ts
@@ -1,0 +1,25 @@
+export const RUNTIME_SECRET_KEYS: readonly [
+  'palazzoControlToken',
+  'palazzoAllowedUrls',
+  'alanaControlToken',
+  'alanaControlUrl',
+];
+
+export type RuntimeSecretPayload = {
+  palazzoControlToken: string;
+  palazzoAllowedUrls: string;
+  alanaControlToken: string;
+  alanaControlUrl: string;
+};
+
+export function isPrivateServiceHostname(hostname: string): boolean;
+export function isValidAlanaControlToken(value: string): boolean;
+export function isValidPrivateControlToken(value: string): boolean;
+export function normalizeAlanaControlUrl(value: string): string;
+export function normalizePrivateServiceUrl(
+  value: string,
+  fieldName: string,
+): string;
+export function parseRuntimeSecretPayload(
+  secretString: string | undefined,
+): RuntimeSecretPayload;

--- a/backend/src/config/runtime-secret-contract.js
+++ b/backend/src/config/runtime-secret-contract.js
@@ -1,0 +1,177 @@
+const { isIP } = require('node:net');
+
+const RUNTIME_SECRET_KEYS = Object.freeze([
+  'palazzoControlToken',
+  'palazzoAllowedUrls',
+  'alanaControlToken',
+  'alanaControlUrl',
+]);
+const allowedSecretFields = new Set(RUNTIME_SECRET_KEYS);
+const alanaTokenPattern = /^[a-f0-9]{64}$/;
+
+function isValidPrivateControlToken(value) {
+  return (
+    typeof value === 'string' &&
+    value.length >= 16 &&
+    value.length <= 4096 &&
+    ![...value].some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 0x20 || code === 0x7f;
+    })
+  );
+}
+
+function isValidAlanaControlToken(value) {
+  return typeof value === 'string' && alanaTokenPattern.test(value);
+}
+
+function normalizePrivateServiceUrl(value, fieldName) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${fieldName} contains an invalid URL`);
+  }
+  if (
+    !['http:', 'https:'].includes(parsed.protocol) ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash ||
+    (parsed.pathname !== '/' && parsed.pathname !== '')
+  ) {
+    throw new Error(`${fieldName} contains an invalid URL`);
+  }
+  return parsed.origin;
+}
+
+function isPrivateIpv4(hostname) {
+  const octets = hostname.split('.').map(Number);
+  return (
+    octets[0] === 10 ||
+    octets[0] === 127 ||
+    (octets[0] === 169 && octets[1] === 254) ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168)
+  );
+}
+
+function isPrivateIpv6(hostname) {
+  const normalized = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (normalized === '::1') return true;
+  const first = normalized.split(':', 1)[0];
+  if (first.startsWith('fc') || first.startsWith('fd')) return true;
+  return /^fe[89ab]/.test(first);
+}
+
+function isPrivateServiceHostname(hostname) {
+  const normalized = hostname.replace(/\.$/, '').toLowerCase();
+  const ipVersion = isIP(normalized.replace(/^\[|\]$/g, ''));
+  if (ipVersion === 4) return isPrivateIpv4(normalized);
+  if (ipVersion === 6) return isPrivateIpv6(normalized);
+  const labels = normalized.split('.');
+  if (
+    labels.some(
+      (label) => !/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label),
+    )
+  ) {
+    return false;
+  }
+  return (
+    normalized === 'localhost' ||
+    normalized.endsWith('.localhost') ||
+    normalized.endsWith('.internal') ||
+    normalized.endsWith('.local') ||
+    !normalized.includes('.')
+  );
+}
+
+function normalizeAlanaControlUrl(value) {
+  const normalized = normalizePrivateServiceUrl(value, 'ALANA_CONTROL_URL');
+  const parsed = new URL(normalized);
+  if (!isPrivateServiceHostname(parsed.hostname)) {
+    throw new Error('ALANA_CONTROL_URL must use a private service hostname');
+  }
+  return normalized;
+}
+
+function parseRuntimeSecretPayload(secretString) {
+  let payload;
+  try {
+    payload = JSON.parse(secretString ?? '');
+  } catch {
+    throw new Error('Alcantara runtime configuration is malformed');
+  }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Alcantara runtime configuration is malformed');
+  }
+
+  const selected = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (!allowedSecretFields.has(key)) continue;
+    if (typeof value !== 'string' || !value.trim()) {
+      throw new Error('Alcantara runtime configuration is malformed');
+    }
+    if (key === 'alanaControlToken' && value !== value.trim()) {
+      throw new Error('ALANA_CONTROL_TOKEN is missing or invalid');
+    }
+    selected[key] = value.trim();
+  }
+  if (RUNTIME_SECRET_KEYS.some((key) => !selected[key])) {
+    throw new Error('Alcantara private service configuration is incomplete');
+  }
+  if (!isValidPrivateControlToken(selected.palazzoControlToken)) {
+    throw new Error('PALAZZO_CONTROL_TOKEN is missing or invalid');
+  }
+  const palazzoUrls = selected.palazzoAllowedUrls
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => normalizePrivateServiceUrl(value, 'PALAZZO_ALLOWED_URLS'));
+  if (!palazzoUrls.length) {
+    throw new Error('PALAZZO_ALLOWED_URLS must contain an approved URL');
+  }
+  if (!isValidAlanaControlToken(selected.alanaControlToken)) {
+    throw new Error('ALANA_CONTROL_TOKEN is missing or invalid');
+  }
+  normalizeAlanaControlUrl(selected.alanaControlUrl);
+  return selected;
+}
+
+async function readStdin() {
+  const chunks = [];
+  let length = 0;
+  for await (const chunk of process.stdin) {
+    length += chunk.length;
+    if (length > 65_536) {
+      throw new Error('Alcantara runtime configuration is malformed');
+    }
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function main() {
+  try {
+    parseRuntimeSecretPayload(await readStdin());
+    process.stdout.write('Alcantara production secret contract passed\n');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown failure';
+    process.stderr.write(
+      `Alcantara production secret contract failed: ${message}\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) void main();
+
+module.exports = {
+  RUNTIME_SECRET_KEYS,
+  isPrivateServiceHostname,
+  isValidAlanaControlToken,
+  isValidPrivateControlToken,
+  normalizeAlanaControlUrl,
+  normalizePrivateServiceUrl,
+  parseRuntimeSecretPayload,
+};

--- a/backend/src/config/runtime-secret-contract.js
+++ b/backend/src/config/runtime-secret-contract.js
@@ -110,15 +110,20 @@ function parseRuntimeSecretPayload(secretString) {
   for (const [key, value] of Object.entries(payload)) {
     if (!allowedSecretFields.has(key)) continue;
     if (typeof value !== 'string' || !value.trim()) {
-      throw new Error('Alcantara runtime configuration is malformed');
+      throw new Error(
+        `Alcantara runtime configuration field ${key} is malformed`,
+      );
     }
     if (key === 'alanaControlToken' && value !== value.trim()) {
       throw new Error('ALANA_CONTROL_TOKEN is missing or invalid');
     }
     selected[key] = value.trim();
   }
-  if (RUNTIME_SECRET_KEYS.some((key) => !selected[key])) {
-    throw new Error('Alcantara private service configuration is incomplete');
+  const missingKeys = RUNTIME_SECRET_KEYS.filter((key) => !selected[key]);
+  if (missingKeys.length) {
+    throw new Error(
+      `Alcantara private service configuration is incomplete; missing keys: ${missingKeys.join(', ')}`,
+    );
   }
   if (!isValidPrivateControlToken(selected.palazzoControlToken)) {
     throw new Error('PALAZZO_CONTROL_TOKEN is missing or invalid');

--- a/backend/src/config/runtime-secrets.spec.ts
+++ b/backend/src/config/runtime-secrets.spec.ts
@@ -16,6 +16,9 @@ function productionEnvironment() {
   };
 }
 
+const ALANA_TOKEN =
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
 describe('loadRuntimeSecrets', () => {
   it('selects only allowlisted private-service scalars from the production payload', async () => {
     const environment = productionEnvironment();
@@ -23,7 +26,7 @@ describe('loadRuntimeSecrets', () => {
       SecretString: JSON.stringify({
         palazzoControlToken: 'fictional-production-token',
         palazzoAllowedUrls: 'http://palazzo:3100',
-        alanaControlToken: 'fictional-alana-control-token',
+        alanaControlToken: ALANA_TOKEN,
         alanaControlUrl: 'http://alana:8080',
         untrustedProperty: 'must-not-enter-environment',
       }),
@@ -32,7 +35,7 @@ describe('loadRuntimeSecrets', () => {
     expect(environment).toMatchObject({
       PALAZZO_CONTROL_TOKEN: 'fictional-production-token',
       PALAZZO_ALLOWED_URLS: 'http://palazzo:3100',
-      ALANA_CONTROL_TOKEN: 'fictional-alana-control-token',
+      ALANA_CONTROL_TOKEN: ALANA_TOKEN,
       ALANA_CONTROL_URL: 'http://alana:8080',
     });
     expect(environment).not.toHaveProperty('untrustedProperty');
@@ -59,7 +62,7 @@ describe('loadRuntimeSecrets', () => {
   it('supports explicit token files for both private services during production migration', async () => {
     readFileMock
       .mockResolvedValueOnce('existing-palazzo-control-token\n')
-      .mockResolvedValueOnce('existing-alana-control-token\n');
+      .mockResolvedValueOnce(`${ALANA_TOKEN}\n`);
     const environment = {
       NODE_ENV: 'production',
       PALAZZO_CONTROL_TOKEN_FILE: '/run/secrets/palazzo-control-token',
@@ -76,7 +79,7 @@ describe('loadRuntimeSecrets', () => {
     );
     expect(environment).toMatchObject({
       PALAZZO_CONTROL_TOKEN: 'existing-palazzo-control-token',
-      ALANA_CONTROL_TOKEN: 'existing-alana-control-token',
+      ALANA_CONTROL_TOKEN: ALANA_TOKEN,
     });
   });
 
@@ -108,7 +111,7 @@ describe('loadRuntimeSecrets', () => {
     ).toThrow('PALAZZO_ALLOWED_URLS contains an invalid URL');
     expect(() =>
       validateAlanaRuntimeConfiguration({
-        ALANA_CONTROL_TOKEN: 'fictional-alana-control-token',
+        ALANA_CONTROL_TOKEN: ALANA_TOKEN,
         ALANA_CONTROL_URL: 'http://alana:8080/private/path',
       }),
     ).toThrow('ALANA_CONTROL_URL contains an invalid URL');

--- a/backend/src/config/runtime-secrets.ts
+++ b/backend/src/config/runtime-secrets.ts
@@ -3,6 +3,13 @@ import {
   SecretsManagerClient,
 } from '@aws-sdk/client-secrets-manager';
 import { readFile } from 'node:fs/promises';
+import {
+  isValidAlanaControlToken,
+  isValidPrivateControlToken,
+  normalizeAlanaControlUrl,
+  normalizePrivateServiceUrl,
+  parseRuntimeSecretPayload,
+} from './runtime-secret-contract';
 
 interface SecretClient {
   send(command: GetSecretValueCommand): Promise<{ SecretString?: string }>;
@@ -22,48 +29,9 @@ interface RuntimeEnvironment {
   [key: string]: string | undefined;
 }
 
-const ALLOWED_SECRET_FIELDS = new Set([
-  'palazzoControlToken',
-  'palazzoAllowedUrls',
-  'alanaControlToken',
-  'alanaControlUrl',
-]);
-
-export function isValidPrivateControlToken(value: string): boolean {
-  return (
-    value.length >= 16 &&
-    value.length <= 4096 &&
-    ![...value].some((character) => {
-      const code = character.charCodeAt(0);
-      return code <= 0x20 || code === 0x7f;
-    })
-  );
-}
+export { isValidPrivateControlToken, normalizePrivateServiceUrl };
 
 export const isValidPalazzoControlToken = isValidPrivateControlToken;
-
-export function normalizePrivateServiceUrl(
-  value: string,
-  fieldName: string,
-): string {
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    throw new Error(`${fieldName} contains an invalid URL`);
-  }
-  if (
-    !['http:', 'https:'].includes(parsed.protocol) ||
-    parsed.username ||
-    parsed.password ||
-    parsed.search ||
-    parsed.hash ||
-    (parsed.pathname !== '/' && parsed.pathname !== '')
-  ) {
-    throw new Error(`${fieldName} contains an invalid URL`);
-  }
-  return parsed.origin;
-}
 
 export function normalizePalazzoBaseUrl(value: string): string {
   return normalizePrivateServiceUrl(value, 'PALAZZO_ALLOWED_URLS');
@@ -90,14 +58,11 @@ export function validatePalazzoRuntimeConfiguration(
 export function validateAlanaRuntimeConfiguration(
   environment: RuntimeEnvironment = process.env,
 ): void {
-  const token = environment.ALANA_CONTROL_TOKEN?.trim() ?? '';
-  if (!isValidPrivateControlToken(token)) {
+  const token = environment.ALANA_CONTROL_TOKEN ?? '';
+  if (!isValidAlanaControlToken(token)) {
     throw new Error('ALANA_CONTROL_TOKEN is missing or invalid');
   }
-  normalizePrivateServiceUrl(
-    environment.ALANA_CONTROL_URL?.trim() ?? '',
-    'ALANA_CONTROL_URL',
-  );
+  normalizeAlanaControlUrl(environment.ALANA_CONTROL_URL?.trim() ?? '');
 }
 
 export function validateRuntimeConfiguration(
@@ -128,7 +93,7 @@ export async function loadRuntimeSecrets(
         readFile(alanaTokenFile, 'utf8'),
       ]);
       environment.PALAZZO_CONTROL_TOKEN = palazzoToken.trim();
-      environment.ALANA_CONTROL_TOKEN = alanaToken.trim();
+      environment.ALANA_CONTROL_TOKEN = alanaToken.replace(/\r?\n$/, '');
     } catch {
       throw new Error('Alcantara runtime configuration is unavailable');
     }
@@ -148,31 +113,7 @@ export async function loadRuntimeSecrets(
   } catch {
     throw new Error('Alcantara runtime configuration is unavailable');
   }
-  let payload: unknown;
-  try {
-    payload = JSON.parse(response.SecretString ?? '');
-  } catch {
-    throw new Error('Alcantara runtime configuration is malformed');
-  }
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    throw new Error('Alcantara runtime configuration is malformed');
-  }
-  const selected: Record<string, string> = {};
-  for (const [key, value] of Object.entries(payload)) {
-    if (!ALLOWED_SECRET_FIELDS.has(key)) continue;
-    if (typeof value !== 'string' || !value.trim()) {
-      throw new Error('Alcantara runtime configuration is malformed');
-    }
-    selected[key] = value.trim();
-  }
-  if (
-    !selected.palazzoControlToken ||
-    !selected.palazzoAllowedUrls ||
-    !selected.alanaControlToken ||
-    !selected.alanaControlUrl
-  ) {
-    throw new Error('Alcantara private service configuration is incomplete');
-  }
+  const selected = parseRuntimeSecretPayload(response.SecretString);
   environment.PALAZZO_CONTROL_TOKEN = selected.palazzoControlToken;
   environment.PALAZZO_ALLOWED_URLS = selected.palazzoAllowedUrls;
   environment.ALANA_CONTROL_TOKEN = selected.alanaControlToken;

--- a/backend/src/recording/alana-recording.client.spec.ts
+++ b/backend/src/recording/alana-recording.client.spec.ts
@@ -10,7 +10,8 @@ import {
   type RecordingFetch,
 } from './alana-recording.client';
 
-const TOKEN = 'alana-fictional-control-token';
+const TOKEN =
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const BASE_URL = 'http://alana:8080';
 
 const status = (overrides: Record<string, unknown> = {}) => ({

--- a/backend/src/recording/alana-recording.client.ts
+++ b/backend/src/recording/alana-recording.client.ts
@@ -14,9 +14,9 @@ import {
   type RecordingStatus,
 } from './recording.contract';
 import {
-  isValidPrivateControlToken,
-  normalizePrivateServiceUrl,
-} from '../config/runtime-secrets';
+  isValidAlanaControlToken,
+  normalizeAlanaControlUrl,
+} from '../config/runtime-secret-contract';
 
 export const ALANA_RECORDING_FETCH = Symbol('ALANA_RECORDING_FETCH');
 
@@ -42,15 +42,16 @@ export class AlanaRecordingClient {
     transport?: RecordingFetch,
   ) {
     const isTest = config.get<string>('NODE_ENV') === 'test';
-    this.baseUrl = normalizePrivateServiceUrl(
+    this.baseUrl = normalizeAlanaControlUrl(
       config.get<string>('ALANA_CONTROL_URL') ??
-        (isTest ? 'http://alana.test:8080' : ''),
-      'ALANA_CONTROL_URL',
+        (isTest ? 'http://alana:8080' : ''),
     );
     this.token =
-      config.get<string>('ALANA_CONTROL_TOKEN')?.trim() ??
-      (isTest ? 'alana-test-control-token' : '');
-    if (!isValidPrivateControlToken(this.token)) {
+      config.get<string>('ALANA_CONTROL_TOKEN') ??
+      (isTest
+        ? '0000000000000000000000000000000000000000000000000000000000000000'
+        : '');
+    if (!isValidAlanaControlToken(this.token)) {
       throw new Error('ALANA_CONTROL_TOKEN is missing or invalid');
     }
     this.timeoutMs = 5_000;

--- a/backend/test/alana-recording-fixture.test.mjs
+++ b/backend/test/alana-recording-fixture.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import test from 'node:test';
+import { createAlanaRecordingFixture } from './fixtures/alana-recording-server.mjs';
+
+const token =
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+async function json(response) {
+  return { status: response.status, body: await response.json() };
+}
+
+async function waitForScheduled(scheduled) {
+  for (let attempt = 0; attempt < 20 && scheduled.length === 0; attempt += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(scheduled.length, 1);
+}
+
+test('fake Alana deterministically covers start, status, stop, finalize, and errors', async (t) => {
+  const scheduled = [];
+  const server = createAlanaRecordingFixture({
+    token,
+    schedule: (callback) => scheduled.push(callback),
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  t.after(() => server.close());
+  const address = server.address();
+  assert.notEqual(address, null);
+  assert.equal(typeof address, 'object');
+  const origin = `http://127.0.0.1:${address.port}`;
+  const path = '/v1/programs/modoitaliano/recording';
+  const headers = { Authorization: `Bearer ${token}` };
+
+  const initial = await json(await fetch(`${origin}${path}`, { headers }));
+  assert.deepEqual(
+    { status: initial.status, state: initial.body.state },
+    { status: 200, state: 'idle' },
+  );
+  assert.equal(initial.body.updatedAt, '2026-09-07T00:00:00.000Z');
+
+  const notActive = await json(
+    await fetch(`${origin}${path}/stop`, {
+      method: 'POST',
+      headers: { ...headers, 'Idempotency-Key': 'stop-idle' },
+    }),
+  );
+  assert.deepEqual(
+    {
+      status: notActive.status,
+      result: notActive.body.commandResult.result,
+    },
+    { status: 409, result: 'not-active' },
+  );
+
+  const started = await json(
+    await fetch(`${origin}${path}/start`, {
+      method: 'POST',
+      headers: { ...headers, 'Idempotency-Key': 'start-1' },
+    }),
+  );
+  assert.deepEqual(
+    { status: started.status, state: started.body.state },
+    { status: 202, state: 'requested' },
+  );
+  assert.equal(scheduled.length, 1);
+  scheduled.shift()();
+
+  const active = await json(await fetch(`${origin}${path}`, { headers }));
+  assert.deepEqual(
+    { status: active.status, state: active.body.state },
+    { status: 200, state: 'active' },
+  );
+  assert.equal(active.body.startedAt, '2026-09-07T00:00:03.000Z');
+
+  const alreadyActive = await json(
+    await fetch(`${origin}${path}/start`, {
+      method: 'POST',
+      headers: { ...headers, 'Idempotency-Key': 'start-2' },
+    }),
+  );
+  assert.deepEqual(
+    {
+      status: alreadyActive.status,
+      result: alreadyActive.body.commandResult.result,
+    },
+    { status: 409, result: 'already-active' },
+  );
+
+  const stopping = fetch(`${origin}${path}/stop`, {
+    method: 'POST',
+    headers: { ...headers, 'Idempotency-Key': 'stop-1' },
+  });
+  await waitForScheduled(scheduled);
+  scheduled.shift()();
+  const complete = await json(await stopping);
+  assert.deepEqual(
+    {
+      status: complete.status,
+      state: complete.body.state,
+      finalizationState: complete.body.finalizationState,
+    },
+    { status: 200, state: 'complete', finalizationState: 'verified' },
+  );
+  assert.equal(complete.body.finalizedAt, '2026-09-07T00:00:07.000Z');
+
+  const duplicate = await json(
+    await fetch(`${origin}${path}/stop`, {
+      method: 'POST',
+      headers: { ...headers, 'Idempotency-Key': 'stop-1' },
+    }),
+  );
+  assert.deepEqual(
+    {
+      status: duplicate.status,
+      duplicate: duplicate.body.commandResult.duplicate,
+    },
+    { status: 200, duplicate: true },
+  );
+
+  const conflictingKey = await json(
+    await fetch(`${origin}${path}/start`, {
+      method: 'POST',
+      headers: { ...headers, 'Idempotency-Key': 'stop-1' },
+    }),
+  );
+  assert.deepEqual(
+    {
+      status: conflictingKey.status,
+      result: conflictingKey.body.commandResult.result,
+      duplicate: conflictingKey.body.commandResult.duplicate,
+    },
+    { status: 409, result: 'failed', duplicate: true },
+  );
+
+  const unauthorized = await json(await fetch(`${origin}${path}`));
+  assert.deepEqual(unauthorized, {
+    status: 401,
+    body: { error: 'unauthorized' },
+  });
+  assert.doesNotMatch(JSON.stringify(unauthorized), new RegExp(token));
+});

--- a/backend/test/alana-recording-fixture.test.mjs
+++ b/backend/test/alana-recording-fixture.test.mjs
@@ -10,18 +10,29 @@ async function json(response) {
   return { status: response.status, body: await response.json() };
 }
 
-async function waitForScheduled(scheduled) {
-  for (let attempt = 0; attempt < 20 && scheduled.length === 0; attempt += 1) {
-    await new Promise((resolve) => setImmediate(resolve));
-  }
-  assert.equal(scheduled.length, 1);
+function controlledScheduler() {
+  const callbacks = [];
+  const waiters = [];
+  return {
+    schedule(callback) {
+      callbacks.push(callback);
+      waiters.shift()?.();
+    },
+    async runNext() {
+      if (callbacks.length === 0) {
+        await new Promise((resolve) => waiters.push(resolve));
+      }
+      assert.equal(callbacks.length, 1);
+      callbacks.shift()();
+    },
+  };
 }
 
 test('fake Alana deterministically covers start, status, stop, finalize, and errors', async (t) => {
-  const scheduled = [];
+  const scheduler = controlledScheduler();
   const server = createAlanaRecordingFixture({
     token,
-    schedule: (callback) => scheduled.push(callback),
+    schedule: scheduler.schedule,
   });
   server.listen(0, '127.0.0.1');
   await once(server, 'listening');
@@ -64,8 +75,7 @@ test('fake Alana deterministically covers start, status, stop, finalize, and err
     { status: started.status, state: started.body.state },
     { status: 202, state: 'requested' },
   );
-  assert.equal(scheduled.length, 1);
-  scheduled.shift()();
+  await scheduler.runNext();
 
   const active = await json(await fetch(`${origin}${path}`, { headers }));
   assert.deepEqual(
@@ -92,8 +102,7 @@ test('fake Alana deterministically covers start, status, stop, finalize, and err
     method: 'POST',
     headers: { ...headers, 'Idempotency-Key': 'stop-1' },
   });
-  await waitForScheduled(scheduled);
-  scheduled.shift()();
+  await scheduler.runNext();
   const complete = await json(await stopping);
   assert.deepEqual(
     {

--- a/backend/test/deployment-gate.test.js
+++ b/backend/test/deployment-gate.test.js
@@ -13,6 +13,31 @@ const restoreCheck = readFileSync(
 );
 const nginx = readFileSync('../deploy/cumulus.nginx.conf', 'utf8');
 
+test('validates the production secret contract before build, push, or host mutation', () => {
+  const preflight = workflow.indexOf('  production-config-preflight:');
+  const build = workflow.indexOf('\n  build:');
+  const deploy = workflow.indexOf('\n  deploy:');
+
+  assert.ok(preflight >= 0);
+  assert.ok(build > preflight);
+  assert.ok(deploy > build);
+  assert.match(workflow, /build:\n    needs: production-config-preflight/);
+  assert.match(
+    workflow,
+    /deploy:\n    runs-on: ubuntu-latest\n    needs: build/,
+  );
+  assert.match(workflow, /secretsmanager get-secret-value/);
+  assert.match(
+    workflow,
+    /node backend\/src\/config\/runtime-secret-contract\.js/,
+  );
+  assert.match(
+    workflow,
+    /ALCANTARA_CONFIG_SECRET_ID: broadcast\/production\/config/,
+  );
+  assert.doesNotMatch(workflow, /echo .*SecretString/);
+});
+
 test('preserves on-premises deployment and selects Cumulus when the gate is not true', () => {
   assert.match(workflow, /if: vars\.ON_PREMISES == 'true'/);
   assert.match(workflow, /if: vars\.ON_PREMISES != 'true'/);

--- a/backend/test/fixtures/alana-recording-server.mjs
+++ b/backend/test/fixtures/alana-recording-server.mjs
@@ -1,72 +1,125 @@
 import { createServer } from 'node:http';
-import { URL } from 'node:url';
+import { pathToFileURL, URL } from 'node:url';
 
-const port = Number(process.env.PORT ?? '8080');
-const programId = process.env.PROGRAM_ID ?? 'modoitaliano';
-const token = process.env.ALANA_CONTROL_TOKEN ?? '';
-const basePath = `/v1/programs/${encodeURIComponent(programId)}/recording`;
-const commands = new Map();
+const defaultStart = '2026-09-07T00:00:00.000Z';
 
-const timestamp = () => new Date().toISOString();
-const disk = {
-  freeBytes: 8_000_000_000,
-  usageBytes: 24_000_000,
-  quotaBytes: 50_000_000_000,
-  minimumFreeBytes: 1_000_000_000,
-};
-let state = {
-  enabled: true,
-  state: 'idle',
-  requestedAt: null,
-  startedAt: null,
-  stoppedAt: null,
-  finalizedAt: null,
-  updatedAt: timestamp(),
-  segmentCount: 0,
-  bytes: 0,
-  durationSeconds: 0,
-  droppedFrames: 0,
-  errors: 0,
-  restarts: 0,
-  finalizationState: 'not-requested',
-  finalBytes: 0,
-  error: null,
-  disk,
-};
+export function createAlanaRecordingFixture({
+  programId = 'modoitaliano',
+  token,
+  schedule = (callback) => setTimeout(callback, 250),
+  startTimestamp = defaultStart,
+} = {}) {
+  if (!token) throw new Error('fixture token is required');
+  const basePath = `/v1/programs/${encodeURIComponent(programId)}/recording`;
+  const commands = new Map();
+  const epoch = Date.parse(startTimestamp);
+  if (!Number.isFinite(epoch)) throw new Error('fixture timestamp is invalid');
+  let tick = 0;
+  const timestamp = () => new Date(epoch + tick++ * 1_000).toISOString();
+  const disk = {
+    freeBytes: 8_000_000_000,
+    usageBytes: 24_000_000,
+    quotaBytes: 50_000_000_000,
+    minimumFreeBytes: 1_000_000_000,
+  };
+  let state = {
+    enabled: true,
+    state: 'idle',
+    requestedAt: null,
+    startedAt: null,
+    stoppedAt: null,
+    finalizedAt: null,
+    updatedAt: timestamp(),
+    segmentCount: 0,
+    bytes: 0,
+    durationSeconds: 0,
+    droppedFrames: 0,
+    errors: 0,
+    restarts: 0,
+    finalizationState: 'not-requested',
+    finalBytes: 0,
+    error: null,
+    disk,
+  };
 
-function send(response, status, payload) {
-  response.writeHead(status, {
-    'Content-Type': 'application/json',
-    'Cache-Control': 'no-store',
-  });
-  response.end(`${JSON.stringify(payload)}\n`);
-}
+  function send(response, status, payload) {
+    response.writeHead(status, {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    });
+    response.end(`${JSON.stringify(payload)}\n`);
+  }
 
-function command(response, action, key) {
-  const prior = commands.get(key);
-  if (prior) {
-    if (prior.action !== action) {
-      send(response, 409, {
+  function command(response, action, key) {
+    const prior = commands.get(key);
+    if (prior) {
+      if (prior.action !== action) {
+        send(response, 409, {
+          ...state,
+          commandResult: {
+            action,
+            status: 409,
+            result: 'failed',
+            duplicate: true,
+          },
+        });
+        return;
+      }
+      send(response, prior.status, {
         ...state,
-        commandResult: {
-          action,
-          status: 409,
-          result: 'failed',
-          duplicate: true,
-        },
+        commandResult: { ...prior, duplicate: true },
       });
       return;
     }
-    send(response, prior.status, {
-      ...state,
-      commandResult: { ...prior, duplicate: true },
-    });
-    return;
-  }
 
-  if (action === 'start') {
-    if (['requested', 'active', 'finalizing'].includes(state.state)) {
-      const result = { action, status: 409, result: 'already-active' };
+    if (action === 'start') {
+      if (['requested', 'active', 'finalizing'].includes(state.state)) {
+        const result = { action, status: 409, result: 'already-active' };
+        commands.set(key, result);
+        send(response, 409, {
+          ...state,
+          commandResult: { ...result, duplicate: false },
+        });
+        return;
+      }
+      state = {
+        ...state,
+        state: 'requested',
+        requestedAt: timestamp(),
+        startedAt: null,
+        stoppedAt: null,
+        finalizedAt: null,
+        updatedAt: timestamp(),
+        segmentCount: 0,
+        bytes: 0,
+        durationSeconds: 0,
+        finalizationState: 'not-requested',
+        finalBytes: 0,
+        error: null,
+      };
+      const result = { action, status: 202, result: 'accepted' };
+      commands.set(key, result);
+      send(response, 202, {
+        ...state,
+        commandResult: { ...result, duplicate: false },
+      });
+      schedule(() => {
+        if (state.state !== 'requested') return;
+        state = {
+          ...state,
+          state: 'active',
+          startedAt: timestamp(),
+          updatedAt: timestamp(),
+          segmentCount: 1,
+          bytes: 1_250_000,
+          durationSeconds: 5,
+        };
+      });
+      return;
+    }
+
+    if (!['requested', 'active'].includes(state.state)) {
+      const result = { action, status: 409, result: 'not-active' };
       commands.set(key, result);
       send(response, 409, {
         ...state,
@@ -76,102 +129,72 @@ function command(response, action, key) {
     }
     state = {
       ...state,
-      state: 'requested',
-      requestedAt: timestamp(),
-      startedAt: null,
-      stoppedAt: null,
-      finalizedAt: null,
+      state: 'finalizing',
+      stoppedAt: timestamp(),
       updatedAt: timestamp(),
-      segmentCount: 0,
-      bytes: 0,
-      durationSeconds: 0,
-      finalizationState: 'not-requested',
-      finalBytes: 0,
-      error: null,
+      finalizationState: 'pending',
     };
-    const result = { action, status: 202, result: 'accepted' };
+    const result = { action, status: 200, result: 'complete' };
     commands.set(key, result);
-    send(response, 202, {
-      ...state,
-      commandResult: { ...result, duplicate: false },
-    });
-    setTimeout(() => {
-      if (state.state !== 'requested') return;
+    schedule(() => {
+      if (state.state !== 'finalizing') return;
       state = {
         ...state,
-        state: 'active',
-        startedAt: timestamp(),
+        state: 'complete',
+        finalizedAt: timestamp(),
         updatedAt: timestamp(),
-        segmentCount: 1,
-        bytes: 1_250_000,
-        durationSeconds: 5,
+        finalizationState: 'verified',
+        finalBytes: Math.max(state.bytes, 1_250_000),
       };
-    }, 250);
-    return;
+      send(response, 200, {
+        ...state,
+        commandResult: { ...result, duplicate: false },
+      });
+    });
   }
 
-  if (!['requested', 'active'].includes(state.state)) {
-    const result = { action, status: 409, result: 'not-active' };
-    commands.set(key, result);
-    send(response, 409, {
-      ...state,
-      commandResult: { ...result, duplicate: false },
-    });
-    return;
-  }
-  state = {
-    ...state,
-    state: 'finalizing',
-    stoppedAt: timestamp(),
-    updatedAt: timestamp(),
-    finalizationState: 'pending',
-  };
-  const result = { action, status: 200, result: 'complete' };
-  commands.set(key, result);
-  setTimeout(() => {
-    if (state.state !== 'finalizing') return;
-    state = {
-      ...state,
-      state: 'complete',
-      finalizedAt: timestamp(),
-      updatedAt: timestamp(),
-      finalizationState: 'verified',
-      finalBytes: Math.max(state.bytes, 1_250_000),
-    };
-    send(response, 200, {
-      ...state,
-      commandResult: { ...result, duplicate: false },
-    });
-  }, 250);
-}
-
-createServer((request, response) => {
-  const path = new URL(request.url ?? '/', 'http://fixture').pathname;
-  if (request.method === 'GET' && path === '/health') {
-    send(response, 200, { status: 'ok' });
-    return;
-  }
-  if (request.headers.authorization !== `Bearer ${token}`) {
-    send(response, 401, { error: 'unauthorized' });
-    return;
-  }
-  if (request.method === 'GET' && path === basePath) {
-    send(response, 200, state);
-    return;
-  }
-  if (
-    request.method === 'POST' &&
-    (path === `${basePath}/start` || path === `${basePath}/stop`)
-  ) {
-    const key = String(request.headers['idempotency-key'] ?? '');
-    if (!key || key.length > 200) {
-      send(response, 400, { error: 'idempotency-key-required' });
+  const server = createServer((request, response) => {
+    const path = new URL(request.url ?? '/', 'http://fixture').pathname;
+    if (request.method === 'GET' && path === '/health') {
+      send(response, 200, { status: 'ok' });
       return;
     }
-    command(response, path.endsWith('/start') ? 'start' : 'stop', key);
-    return;
-  }
-  send(response, 404, { error: 'not-found' });
-}).listen(port, '0.0.0.0', () => {
-  process.stdout.write('Alana recording fixture ready\n');
-});
+    if (request.headers.authorization !== `Bearer ${token}`) {
+      send(response, 401, { error: 'unauthorized' });
+      return;
+    }
+    if (request.method === 'GET' && path === basePath) {
+      send(response, 200, state);
+      return;
+    }
+    if (
+      request.method === 'POST' &&
+      (path === `${basePath}/start` || path === `${basePath}/stop`)
+    ) {
+      const key = String(request.headers['idempotency-key'] ?? '');
+      if (!key || key.length > 200) {
+        send(response, 400, { error: 'idempotency-key-required' });
+        return;
+      }
+      command(response, path.endsWith('/start') ? 'start' : 'stop', key);
+      return;
+    }
+    send(response, 404, { error: 'not-found' });
+  });
+
+  return server;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const port = Number(process.env.PORT ?? '8080');
+  const server = createAlanaRecordingFixture({
+    programId: process.env.PROGRAM_ID ?? 'modoitaliano',
+    token: process.env.ALANA_CONTROL_TOKEN ?? '',
+  });
+  server.listen(port, '0.0.0.0', () => {
+    process.stdout.write('Alana recording fixture ready\n');
+  });
+}

--- a/backend/test/fixtures/production-runtime-secret.json
+++ b/backend/test/fixtures/production-runtime-secret.json
@@ -1,0 +1,6 @@
+{
+  "palazzoControlToken": "fictional-palazzo-control-token",
+  "palazzoAllowedUrls": "http://palazzo:3100",
+  "alanaControlToken": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "alanaControlUrl": "http://alana:8080"
+}

--- a/backend/test/runtime-secret-contract.test.js
+++ b/backend/test/runtime-secret-contract.test.js
@@ -1,0 +1,103 @@
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+const {
+  RUNTIME_SECRET_KEYS,
+  isValidAlanaControlToken,
+  normalizeAlanaControlUrl,
+  parseRuntimeSecretPayload,
+} = require('../src/config/runtime-secret-contract');
+
+const fixturePath = join(
+  __dirname,
+  'fixtures',
+  'production-runtime-secret.json',
+);
+const contractPath = join(
+  __dirname,
+  '..',
+  'src',
+  'config',
+  'runtime-secret-contract.js',
+);
+
+test('accepts only the exact required production secret keys', () => {
+  const payload = JSON.parse(readFileSync(fixturePath, 'utf8'));
+  payload.untrustedValue = 'must-not-enter-runtime';
+
+  const selected = parseRuntimeSecretPayload(JSON.stringify(payload));
+
+  assert.deepEqual(Object.keys(selected), [...RUNTIME_SECRET_KEYS]);
+  assert.equal(selected.untrustedValue, undefined);
+});
+
+test('requires a 64-character lowercase hexadecimal Alana bearer token', () => {
+  assert.equal(isValidAlanaControlToken('a'.repeat(64)), true);
+  assert.equal(isValidAlanaControlToken('A'.repeat(64)), false);
+  assert.equal(isValidAlanaControlToken('a'.repeat(63)), false);
+  assert.equal(isValidAlanaControlToken(`a${' '.repeat(63)}`), false);
+  const payload = JSON.parse(readFileSync(fixturePath, 'utf8'));
+  payload.alanaControlToken = ` ${payload.alanaControlToken}`;
+  assert.throws(
+    () => parseRuntimeSecretPayload(JSON.stringify(payload)),
+    /ALANA_CONTROL_TOKEN is missing or invalid/,
+  );
+});
+
+test('allows only origin-only private Alana service targets', () => {
+  assert.equal(
+    normalizeAlanaControlUrl('http://alana:8080'),
+    'http://alana:8080',
+  );
+  assert.equal(
+    normalizeAlanaControlUrl('https://recorder.broadcast.internal'),
+    'https://recorder.broadcast.internal',
+  );
+  assert.throws(
+    () => normalizeAlanaControlUrl('http://198.51.100.10:8080'),
+    /private service hostname/,
+  );
+  assert.throws(
+    () => normalizeAlanaControlUrl('http://-:8080'),
+    /private service hostname/,
+  );
+  assert.throws(
+    () => normalizeAlanaControlUrl('https://user:password@alana:8080/path'),
+    /invalid URL/,
+  );
+});
+
+test('the fixture-driven production preflight never prints configuration values', () => {
+  const input = readFileSync(fixturePath, 'utf8');
+  const result = spawnSync(process.execPath, [contractPath], {
+    encoding: 'utf8',
+    input,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, 'Alcantara production secret contract passed\n');
+  for (const value of Object.values(JSON.parse(input))) {
+    assert.doesNotMatch(result.stdout + result.stderr, new RegExp(value));
+  }
+});
+
+test('invalid production input fails with redacted evidence', () => {
+  const sensitiveValue = 'DO_NOT_PRINT_THIS_VALUE';
+  const input = JSON.stringify({
+    palazzoControlToken: 'fictional-palazzo-control-token',
+    palazzoAllowedUrls: 'http://palazzo:3100',
+    alanaControlToken: sensitiveValue,
+    alanaControlUrl: 'https://public.example.com',
+  });
+  const result = spawnSync(process.execPath, [contractPath], {
+    encoding: 'utf8',
+    input,
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /ALANA_CONTROL_TOKEN is missing or invalid/);
+  assert.doesNotMatch(result.stdout + result.stderr, /DO_NOT_PRINT_THIS_VALUE/);
+  assert.doesNotMatch(result.stdout + result.stderr, /public\.example\.com/);
+});

--- a/backend/test/runtime-secret-contract.test.js
+++ b/backend/test/runtime-secret-contract.test.js
@@ -101,3 +101,22 @@ test('invalid production input fails with redacted evidence', () => {
   assert.doesNotMatch(result.stdout + result.stderr, /DO_NOT_PRINT_THIS_VALUE/);
   assert.doesNotMatch(result.stdout + result.stderr, /public\.example\.com/);
 });
+
+test('incomplete production input names only the missing keys', () => {
+  const payload = JSON.parse(readFileSync(fixturePath, 'utf8'));
+  delete payload.alanaControlToken;
+  delete payload.alanaControlUrl;
+  const result = spawnSync(process.execPath, [contractPath], {
+    encoding: 'utf8',
+    input: JSON.stringify(payload),
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /missing keys: alanaControlToken, alanaControlUrl/,
+  );
+  for (const value of Object.values(payload)) {
+    assert.doesNotMatch(result.stdout + result.stderr, new RegExp(value));
+  }
+});

--- a/compose.yml
+++ b/compose.yml
@@ -41,7 +41,7 @@ services:
     environment:
       PORT: "8080"
       PROGRAM_ID: modoitaliano
-      ALANA_CONTROL_TOKEN: alana-local-control-token
+      ALANA_CONTROL_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     healthcheck:
       test:
         [
@@ -85,7 +85,7 @@ services:
       METRICS_TOKEN_FILE: /run/secrets/alcantara-metrics-token
       PALAZZO_CONTROL_TOKEN: palazzo-local-control-token
       PALAZZO_ALLOWED_URLS: http://palazzo:3100
-      ALANA_CONTROL_TOKEN: alana-local-control-token
+      ALANA_CONTROL_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       ALANA_CONTROL_URL: http://alana-recording-fixture:8080
     volumes:
       - ./backend/src:/app/src

--- a/docs/program-recording.md
+++ b/docs/program-recording.md
@@ -54,22 +54,52 @@ after a reload or reconnect.
 
 ## Private service configuration
 
-`ALANA_CONTROL_URL` must be a private HTTP(S) origin without credentials, path,
-query, or fragment. `ALANA_CONTROL_TOKEN` is backend-only. Production loads the
-allowlisted `alanaControlUrl` and `alanaControlToken` scalars from the same
-application-scoped Secrets Manager payload as the Palazzo values before Nest
-constructs the adapter. Missing, malformed, or unavailable configuration fails
-the preflight without replacing the running backend.
+Production uses the code-owned Secrets Manager identifier
+`broadcast/production/config`. The payload must contain all four exact private
+service keys below. The loader ignores every other key rather than injecting it
+into the process environment.
+
+| Secret key            | Contract                                                                          | Owner                                                                         |
+| --------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `palazzoControlToken` | Existing opaque Palazzo bearer credential                                         | Palazzo operator                                                              |
+| `palazzoAllowedUrls`  | Existing comma-separated origin allowlist                                         | Alcantara operator                                                            |
+| `alanaControlToken`   | Exactly 64 lowercase hexadecimal characters (32 random bytes), with no whitespace | Alana operator generates; Alcantara secret owner installs the identical value |
+| `alanaControlUrl`     | One private HTTP(S) origin                                                        | Alana operator supplies; Alcantara secret owner installs                      |
+
+`alanaControlUrl` cannot contain credentials, a path, query, or fragment. Its
+host must be a single-label service name, `localhost`, a `.localhost`, `.local`,
+or `.internal` name, or a loopback/link-local/private IPv4 or IPv6 address.
+Public IP addresses and public DNS names fail closed. The intended shared
+Docker-network value is `http://alana:8080`; the production deployment ticket
+must still prove private routing rather than treating syntax validation as a
+network check.
+
+The backend receives the token only as `ALANA_CONTROL_TOKEN`, after the startup
+loader has selected and validated the secret. It is never a frontend variable,
+Docker build argument, command-line value, metric label, or log field. Contract
+and runtime preflight output names only the invalid field or a bounded failure;
+it never echoes the secret document, URL, token, provider response, or
+credential-bearing exception.
+
+The deploy workflow streams the selected secret directly from Secrets Manager
+into the zero-dependency contract validator before registry login, image build,
+or push. The workflow role can read only this named secret. The validator does
+not write a file or contact Alana. The target-host runtime preflight remains in
+place before database migration or backend replacement so retrieval and image
+startup fail closed at both boundaries.
 
 During a bounded migration, production can instead supply both
 `PALAZZO_CONTROL_TOKEN_FILE` and `ALANA_CONTROL_TOKEN_FILE`, plus their approved
-service URLs. No token or Alana address is exposed to the frontend.
+service URLs. The Alana file must contain the same 64-character token, with an
+optional final newline. No token or Alana address is exposed to the frontend.
 
 Local Compose starts a committed, private `alana-recording-fixture` service for
 the fictional `modoitaliano` program. It implements the landed status,
 Start/Stop, finalization, authorization, and idempotency shapes so the complete
 browser-to-backend path is testable without AWS, production media, an Alana
-checkout, or a real recorder. It never produces media and is not a deployment
+checkout, or a real recorder. Its injected clock and scheduler make requested,
+active, finalizing, complete, duplicate, conflict, unauthorized, and not-active
+results deterministic in tests. It never produces media and is not a deployment
 substitute.
 
 ## Audit and metrics
@@ -94,9 +124,56 @@ metrics.
 
 ## Rollout and recovery
 
-Before deployment, add the two Alana fields to the Alcantara production secret
-and verify that the selected Alana runtime is on the shared private network and
-has recording enabled. Exercise a bounded Start, observe `requested -> active`,
+Issue #61 does not create or rotate a credential. For an authorized installation
+or rotation, use only protected files and placeholder variables; never place a
+token in shell history, command arguments, GitHub evidence, or a repository:
+
+```bash
+SECRET_ID='<alcantara-runtime-secret-id>'
+NEW_SECRET_DOCUMENT='<protected-path-to-complete-new-secret-json>'
+NEW_ALANA_TOKEN_FILE='<protected-path-to-new-alana-token>'
+ALANA_TOKEN_DESTINATION='<alana-host-token-path>'
+
+node backend/src/config/runtime-secret-contract.js < "$NEW_SECRET_DOCUMENT"
+aws secretsmanager put-secret-value \
+  --secret-id "$SECRET_ID" \
+  --secret-string "file://$NEW_SECRET_DOCUMENT"
+install -m 0600 "$NEW_ALANA_TOKEN_FILE" "$ALANA_TOKEN_DESTINATION"
+```
+
+Alana accepts one token at a time, so first installation or rotation needs an
+explicit bounded maintenance window for recording control. The Alana operator
+owns token generation, the protected token file, and the Alana restart. The
+Alcantara secret owner owns the matching `alanaControlToken` and
+`alanaControlUrl` values. Record only the new and previous secret version IDs,
+the image SHA, and timestamps. Restart Alana and then deploy/restart Alcantara;
+do not enable recording until authenticated Status succeeds.
+
+Keep the previous protected token file and secret version until the lifecycle
+smoke passes. Placeholder-only rollback is:
+
+```bash
+SECRET_ID='<alcantara-runtime-secret-id>'
+PREVIOUS_SECRET_VERSION_ID='<previous-version-id>'
+FAILED_SECRET_VERSION_ID='<failed-version-id>'
+PREVIOUS_ALANA_TOKEN_FILE='<protected-path-to-previous-alana-token>'
+ALANA_TOKEN_DESTINATION='<alana-host-token-path>'
+
+aws secretsmanager update-secret-version-stage \
+  --secret-id "$SECRET_ID" \
+  --version-stage AWSCURRENT \
+  --move-to-version-id "$PREVIOUS_SECRET_VERSION_ID" \
+  --remove-from-version-id "$FAILED_SECRET_VERSION_ID"
+install -m 0600 "$PREVIOUS_ALANA_TOKEN_FILE" "$ALANA_TOKEN_DESTINATION"
+```
+
+Restart Alana and restore the previously recorded Alcantara image, then confirm
+authenticated Status before reopening Start/Stop. Delete neither protected
+token file nor secret version until rollback verification is complete.
+
+Before deployment, install the two Alana fields in the production secret and
+verify that the selected Alana runtime is on the shared private network and has
+recording enabled. Exercise a bounded Start, observe `requested -> active`,
 confirm Stop, observe `finalizing -> complete`, and verify the artifact directly
 through Alana's documented operator boundary.
 

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -3,8 +3,9 @@
 This CDK app owns Alcántara-specific AWS integration. Macondo owns only the
 shared Cumulus host, network, and Arauco database. This stack owns:
 
-- `alcantara-github-deploy`, restricted to `gaulatti/alcantara` `main` and SSM
-  commands to the EC2 instance tagged `Name=macondo-services`;
+- `alcantara-github-deploy`, restricted to `gaulatti/alcantara` `main`, read-only
+  access to `broadcast/production/config` for the pre-build secret contract
+  gate, and SSM commands to the EC2 instance tagged `Name=macondo-services`;
 - the host grants for Alcántara media storage; and
 - `api.alcantara.gaulatti.com` pointing to the Cumulus Elastic IP.
 
@@ -27,6 +28,9 @@ identifier and resolve credentials through that instance profile. The existing
 Route 53 record must be adopted into this stack during the first deployment
 rather than duplicated. After deployment, set the GitHub repository variables
 `ARAUCO_SECRET_ARN` and `MEDIA_S3_BUCKET` to the corresponding identifiers.
+The Alcantara runtime secret identifier is code-owned; its value is not a
+GitHub secret or variable. Deploy this stack's least-privilege role update
+before enabling the pre-build deployment gate.
 
 Application logging is intentionally absent from this stack. Production
 containers retain bounded host-local logs, so the Cumulus role needs no

--- a/infra/aws/lib/alcantara-infrastructure-stack.ts
+++ b/infra/aws/lib/alcantara-infrastructure-stack.ts
@@ -1,4 +1,11 @@
-import { CfnOutput, Duration, Stack, StackProps } from "aws-cdk-lib";
+import {
+  Arn,
+  ArnFormat,
+  CfnOutput,
+  Duration,
+  Stack,
+  StackProps,
+} from "aws-cdk-lib";
 import { Policy, PolicyStatement, Role } from "aws-cdk-lib/aws-iam";
 import { ARecord, HostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
 import { Bucket } from "aws-cdk-lib/aws-s3";
@@ -63,7 +70,19 @@ export class AlcantaraInfrastructureStack extends Stack {
       ttl: Duration.minutes(5),
     });
 
-    const githubDeployRole = createGitHubDeployRole(this);
+    const runtimeConfigSecretArn = Arn.format(
+      {
+        service: "secretsmanager",
+        resource: "secret",
+        resourceName: "broadcast/production/config-*",
+        arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+      },
+      this,
+    );
+    const githubDeployRole = createGitHubDeployRole(
+      this,
+      runtimeConfigSecretArn,
+    );
     new CfnOutput(this, "GitHubDeployRoleArn", {
       value: githubDeployRole.roleArn,
     });

--- a/infra/aws/lib/github-deploy.ts
+++ b/infra/aws/lib/github-deploy.ts
@@ -1,46 +1,49 @@
-import { Arn, ArnFormat, Stack } from 'aws-cdk-lib';
+import { Arn, ArnFormat, Stack } from "aws-cdk-lib";
 import {
   Effect,
   FederatedPrincipal,
   OpenIdConnectProvider,
   PolicyStatement,
   Role,
-} from 'aws-cdk-lib/aws-iam';
-import { Construct } from 'constructs';
+} from "aws-cdk-lib/aws-iam";
+import { Construct } from "constructs";
 
-export const createGitHubDeployRole = (scope: Construct): Role => {
+export const createGitHubDeployRole = (
+  scope: Construct,
+  runtimeConfigSecretArn: string,
+): Role => {
   const stack = Stack.of(scope);
   const provider = OpenIdConnectProvider.fromOpenIdConnectProviderArn(
     scope,
-    'GitHubProvider',
+    "GitHubProvider",
     `arn:${stack.partition}:iam::${stack.account}:oidc-provider/token.actions.githubusercontent.com`,
   );
-  const role = new Role(scope, 'GitHubDeployRole', {
-    roleName: 'alcantara-github-deploy',
+  const role = new Role(scope, "GitHubDeployRole", {
+    roleName: "alcantara-github-deploy",
     assumedBy: new FederatedPrincipal(
       provider.openIdConnectProviderArn,
       {
         StringEquals: {
-          'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
-          'token.actions.githubusercontent.com:sub':
-            'repo:gaulatti/alcantara:ref:refs/heads/main',
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub":
+            "repo:gaulatti/alcantara:ref:refs/heads/main",
         },
       },
-      'sts:AssumeRoleWithWebIdentity',
+      "sts:AssumeRoleWithWebIdentity",
     ),
   });
 
   role.addToPolicy(
     new PolicyStatement({
       effect: Effect.ALLOW,
-      actions: ['ssm:SendCommand'],
+      actions: ["ssm:SendCommand"],
       resources: [
         Arn.format(
           {
-            service: 'ssm',
-            account: '',
-            resource: 'document',
-            resourceName: 'AWS-RunShellScript',
+            service: "ssm",
+            account: "",
+            resource: "document",
+            resourceName: "AWS-RunShellScript",
             arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
           },
           stack,
@@ -51,28 +54,35 @@ export const createGitHubDeployRole = (scope: Construct): Role => {
   role.addToPolicy(
     new PolicyStatement({
       effect: Effect.ALLOW,
-      actions: ['ssm:SendCommand'],
+      actions: ["ssm:SendCommand"],
       resources: [
         Arn.format(
           {
-            service: 'ec2',
-            resource: 'instance',
-            resourceName: '*',
+            service: "ec2",
+            resource: "instance",
+            resourceName: "*",
             arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
           },
           stack,
         ),
       ],
       conditions: {
-        StringEquals: { 'ssm:resourceTag/Name': 'macondo-services' },
+        StringEquals: { "ssm:resourceTag/Name": "macondo-services" },
       },
     }),
   );
   role.addToPolicy(
     new PolicyStatement({
       effect: Effect.ALLOW,
-      actions: ['ec2:DescribeInstances', 'ssm:GetCommandInvocation'],
-      resources: ['*'],
+      actions: ["ec2:DescribeInstances", "ssm:GetCommandInvocation"],
+      resources: ["*"],
+    }),
+  );
+  role.addToPolicy(
+    new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["secretsmanager:GetSecretValue"],
+      resources: [runtimeConfigSecretArn],
     }),
   );
   return role;

--- a/infra/aws/test/alcantara-infrastructure.test.ts
+++ b/infra/aws/test/alcantara-infrastructure.test.ts
@@ -23,7 +23,12 @@ test("owns only the Alcantara application permissions needed on Cumulus", () => 
   rendered.hasResourceProperties("AWS::IAM::Policy", {
     PolicyName: "alcantara-cumulus-host",
   });
-  const policies = JSON.stringify(rendered.findResources("AWS::IAM::Policy"));
+  const policies = JSON.stringify(
+    Object.values(rendered.findResources("AWS::IAM::Policy")).filter(
+      (resource) =>
+        resource.Properties?.PolicyName === "alcantara-cumulus-host",
+    ),
+  );
   expect(policies).not.toContain("secretsmanager:GetSecretValue");
   expect(policies).toContain("s3:PutObject");
   expect(policies).toContain("example-alcantara-assets");
@@ -61,4 +66,9 @@ test("owns the API record and main-branch deployment role", () => {
   expect(policies).toContain("ssm:SendCommand");
   expect(policies).toContain("ssm:resourceTag/Name");
   expect(policies).toContain("macondo-services");
+  expect(policies).toContain("secretsmanager:GetSecretValue");
+  expect(policies).toContain(
+    ":secretsmanager:us-east-1:123456789012:secret:broadcast/production/config-*",
+  );
+  expect(policies).not.toContain("secret:*");
 });


### PR DESCRIPTION
Closes #61

## Summary

- define one shared, value-redacting runtime-secret contract with the exact Palazzo/Alana keys, a 64-character lowercase hexadecimal Alana token, and private origin-only Alana URLs
- validate the live production secret before registry login, image build, push, or host mutation, backed by a least-privilege read grant for only `broadcast/production/config`
- name missing or malformed fields without revealing any configuration value
- make the fake Alana lifecycle deterministic and cover Start, Status, Stop, finalization, idempotent replay, conflict, unauthorized, and not-active results
- document secret ownership plus placeholder-only installation, rotation, and rollback operations

## Current live evidence

Backend Deploy run [34079452785](https://github.com/gaulatti/alcantara/actions/runs/34079452785) on merged `main@b4c4820d96c16f8921cc5513a503ae60a2111983` built the image and ran migrations, then failed at runtime preflight with `Alcantara private service configuration is incomplete`. This change moves that configuration decision before registry login/build/push and reports the exact missing key names without reporting values.

## Verification

- `pnpm --dir backend exec jest --runInBand` — 110 tests passed
- `pnpm --dir backend run test:deployment` — 14 contract/deployment tests passed
- recording E2E — 2 tests passed
- authenticated Prometheus scrape E2E — 3 tests passed; emitted scrape passed `promtool check metrics`
- `pnpm --dir backend run build`
- focused ESLint and Prettier checks
- `pnpm --dir infra/aws exec jest --runInBand` — 2 tests passed
- `pnpm --dir infra/aws run build`
- synthetic-input `cdk synth AlcantaraInfrastructureStack`, including the exact secret ARN grant
- compiled runtime loader accepted the committed fictional production fixture without printing any value

## Boundaries

No production credential was read, stored, printed, created, or rotated. No AWS resource, Alana runtime, backend, UI, or production host was deployed or mutated.

The Compose fixture image built, but Docker Desktop failed while creating the container because its containerd `metadata.db` returned an input/output error. The same real HTTP fixture server passed its deterministic in-process lifecycle suite; Compose container startup remains unverified until Docker Desktop storage is healthy.

The public repository wiki remote is unavailable, so operational documentation is included in the repository.

## Summary by Sourcery

Validate the production private-service configuration contract before any deployment artifacts or infrastructure are modified.

New Features:
- Add a shared production runtime-secret contract covering Palazzo and Alana credentials and private service URLs.
- Gate deployment on value-redacting validation of the production secret before registry access, image build, push, or host changes.
- Make the Alana recording fixture configurable and deterministic across lifecycle, authorization, idempotency, conflict, and inactive-state scenarios.

Bug Fixes:
- Prevent deployments from reaching image build or runtime mutation when required private-service configuration is missing or invalid.
- Prevent invalid or public Alana credentials and endpoints from being accepted by runtime configuration loading.

Enhancements:
- Centralize runtime-secret validation and ensure diagnostics identify only keys or fields without exposing configuration values.
- Extend CI coverage to deployment contracts, runtime-secret validation, Alana lifecycle behavior, and AWS infrastructure builds.
- Restrict the GitHub deployment role to read only the production runtime secret and document ownership, installation, rotation, and rollback procedures.

CI:
- Run deployment, infrastructure, and deterministic Alana fixture checks in backend CI.

Deployment:
- Add a production configuration preflight and least-privilege Secrets Manager read access for broadcast/production/config.

Documentation:
- Document the shared production secret contract, secret ownership, private Alana endpoint requirements, and placeholder-only operational procedures.

Tests:
- Add contract tests for required keys, token and URL validation, redacted diagnostics, and preflight ordering.
- Add deterministic fake Alana lifecycle coverage for start, status, stop, finalization, replay, conflict, authorization, and inactive results.