### PR TITLE
feat(auth): adopt canonical Pompeii principals

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,10 +339,10 @@ BACKEND_PORT=3000 VITE_PORT=5173 docker compose up
 
 Alcantara authorizes through Pompeii, which now returns a canonical
 `principal_id` alongside the pool subject. Operator preferences, shared console
-layouts, and guest-invitation audit rows record it beside the subject in nullable
-columns; ownership matches the canonical principal when a row names one and falls
-back to the pool subject when it does not, so migrated and unmigrated rows both
-work during rollout.
+layouts, guest invitations, and guest lifecycle audit events record it beside
+the subject through nullable/additive references; ownership matches the
+canonical principal when a row names one and falls back to the pool subject when
+it does not, so migrated and unmigrated rows both work during rollout.
 
 Identities are never joined by email, no ownership row changes without a verified
 Pompeii mapping, and audit attribution is never rewritten. See

--- a/README.md
+++ b/README.md
@@ -329,6 +329,20 @@ BACKEND_PORT=3000 VITE_PORT=5173 docker compose up
 
 4. View the program page to see the live broadcast overlay
 
+## Identity
+
+Alcantara authorizes through Pompeii, which now returns a canonical
+`principal_id` alongside the pool subject. Operator preferences, shared console
+layouts, and guest-invitation audit rows record it beside the subject in nullable
+columns; ownership matches the canonical principal when a row names one and falls
+back to the pool subject when it does not, so migrated and unmigrated rows both
+work during rollout.
+
+Identities are never joined by email, no ownership row changes without a verified
+Pompeii mapping, and audit attribution is never rewritten. See
+[`docs/canonical-principals.md`](docs/canonical-principals.md) for the inventory,
+the dry-run report, and the rollback and reconciliation procedure.
+
 ## Architecture
 
 Production places the backend on the external `broadcast-control` Docker

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:deployment": "node --test test/deployment-gate.test.js",
     "seed": "ts-node prisma/seed.ts",
+    "principals:export": "ts-node src/identity/principals-cli.ts export",
     "principals:report": "ts-node src/identity/principals-cli.ts report",
     "principals:apply": "ts-node src/identity/principals-cli.ts apply"
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,9 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:deployment": "node --test test/deployment-gate.test.js",
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node prisma/seed.ts",
+    "principals:report": "ts-node src/identity/principals-cli.ts report",
+    "principals:apply": "ts-node src/identity/principals-cli.ts apply"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1016.0",

--- a/backend/prisma/migrations/20260906180000_canonical_principals/down.sql
+++ b/backend/prisma/migrations/20260906180000_canonical_principals/down.sql
@@ -1,0 +1,12 @@
+-- Reverses 20260906180000_canonical_principals.
+--
+-- Only the added columns and indexes are dropped. Every legacy ownership and
+-- audit value lives in the original subject columns, which this migration never
+-- touched, so reverting cannot lose ownership or audit attribution.
+
+DROP INDEX IF EXISTS "SharedConsoleLayout_ownerPrincipalId_idx";
+DROP INDEX IF EXISTS "OperatorPreference_principalId_deviceClass_idx";
+
+ALTER TABLE "GuestInvitation" DROP COLUMN IF EXISTS "createdByPrincipalId";
+ALTER TABLE "SharedConsoleLayout" DROP COLUMN IF EXISTS "ownerPrincipalId";
+ALTER TABLE "OperatorPreference" DROP COLUMN IF EXISTS "principalId";

--- a/backend/prisma/migrations/20260906180000_canonical_principals/migration.sql
+++ b/backend/prisma/migrations/20260906180000_canonical_principals/migration.sql
@@ -1,0 +1,18 @@
+-- Canonical Pompeii principal references.
+--
+-- Additive and reversible on purpose: every column is nullable, no existing
+-- value is rewritten, and no primary key moves. A pool subject cannot be mapped
+-- to a canonical principal here — that requires a verified mapping from
+-- Pompeii, which `principals-cli` applies separately — so this migration
+-- backfills nothing.
+--
+-- Every statement is IF NOT EXISTS so a restart part-way through re-runs safely.
+
+ALTER TABLE "OperatorPreference" ADD COLUMN IF NOT EXISTS "principalId" TEXT;
+ALTER TABLE "SharedConsoleLayout" ADD COLUMN IF NOT EXISTS "ownerPrincipalId" TEXT;
+ALTER TABLE "GuestInvitation" ADD COLUMN IF NOT EXISTS "createdByPrincipalId" TEXT;
+
+CREATE INDEX IF NOT EXISTS "OperatorPreference_principalId_deviceClass_idx"
+  ON "OperatorPreference" ("principalId", "deviceClass");
+CREATE INDEX IF NOT EXISTS "SharedConsoleLayout_ownerPrincipalId_idx"
+  ON "SharedConsoleLayout" ("ownerPrincipalId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -241,6 +241,10 @@ model NowPlayingConsumer {
 
 model OperatorPreference {
   subject     String
+  // Canonical Pompeii principal, once resolved. Nullable and additive: the
+  // primary key stays on the pool subject so no existing row moves, and reads
+  // resolve by principal first with a subject fallback.
+  principalId String?
   deviceClass String
   version     Int      @default(1)
   profile     Json
@@ -249,11 +253,15 @@ model OperatorPreference {
 
   @@id([subject, deviceClass])
   @@index([subject])
+  @@index([principalId, deviceClass])
 }
 
 model SharedConsoleLayout {
   id                String    @id @default(uuid())
   ownerSubject      String
+  /// Canonical Pompeii principal for the owner, once resolved. Ownership
+  /// matches this when present and falls back to ownerSubject when absent.
+  ownerPrincipalId  String?
   name              String
   description       String?
   scope             String
@@ -268,6 +276,7 @@ model SharedConsoleLayout {
   @@unique([scope, scopeId, name])
   @@index([scope, scopeId, retiredAt])
   @@index([ownerSubject])
+  @@index([ownerPrincipalId])
 }
 
 model GuestInvitation {
@@ -286,6 +295,10 @@ model GuestInvitation {
   activeSessionId    String?
   activeSessionUntil DateTime?
   createdByIdentity  String
+  /// Canonical Pompeii principal of the operator who created this invitation.
+  /// Audit only. createdByIdentity is never rewritten, so historical actor
+  /// display survives even when no verified mapping exists.
+  createdByPrincipalId String?
   createdAt          DateTime       @default(now())
   updatedAt          DateTime       @updatedAt
   commands           GuestCommand[]

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -14,6 +14,7 @@ export class AuthController {
     req: {
       user: {
         sub: string;
+        principalId: string | null;
         authorization?: {
           permission: string;
           permissions: string[];

--- a/backend/src/auth/pompeii-authorization.guard.spec.ts
+++ b/backend/src/auth/pompeii-authorization.guard.spec.ts
@@ -187,3 +187,49 @@ describe('PompeiiAuthorizationGuard', () => {
     ).rejects.toBeInstanceOf(ServiceUnavailableException);
   });
 });
+
+describe('canonical principal', () => {
+  const requestFor = () => ({ headers: { authorization: 'Bearer token' }, user: { sub: 'user' } });
+  const contextWith = (request: object): ExecutionContext =>
+    ({
+      getHandler: () => function handler() {},
+      getClass: () => class Controller {},
+      switchToHttp: () => ({ getRequest: () => request }),
+    }) as unknown as ExecutionContext;
+
+  const guardFor = (principalId: string | null) => {
+    const reflector = {
+      getAllAndOverride: jest
+        .fn()
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(ALCANTARA_PERMISSIONS.program.operate),
+    } as unknown as Reflector;
+    const pompeii = {
+      teamId: 1,
+      authorize: jest.fn().mockResolvedValue({
+        authenticated: true,
+        allowed: true,
+        reason: 'ALLOW',
+        subject: 'cognito-subject',
+        principalId,
+        effectivePermissions: [ALCANTARA_PERMISSIONS.program.operate],
+        roles: [],
+      }),
+    } as unknown as PompeiiService;
+    return new PompeiiAuthorizationGuard(reflector, pompeii);
+  };
+
+  it('carries the canonical principal onto the request when Pompeii resolves one', async () => {
+    const request = requestFor();
+    await expect(guardFor('principal-a').canActivate(contextWith(request))).resolves.toBe(true);
+
+    expect(request.user).toMatchObject({ principalId: 'principal-a', sub: 'cognito-subject' });
+  });
+
+  it('leaves the canonical principal absent rather than inventing one', async () => {
+    const request = requestFor();
+    await expect(guardFor(null).canActivate(contextWith(request))).resolves.toBe(true);
+
+    expect(request.user).toMatchObject({ principalId: null, sub: 'cognito-subject' });
+  });
+});

--- a/backend/src/auth/pompeii-authorization.guard.ts
+++ b/backend/src/auth/pompeii-authorization.guard.ts
@@ -73,6 +73,9 @@ export class PompeiiAuthorizationGuard {
     request.user = {
       ...(request.user ?? {}),
       sub: decision.subject,
+      // Recorded on new writes and used to read migrated rows. Absent until
+      // Pompeii resolves one, which keeps legacy rows reachable meanwhile.
+      principalId: decision.principalId,
       authorization: {
         permission,
         permissions: decision.effectivePermissions,

--- a/backend/src/auth/pompeii.service.spec.ts
+++ b/backend/src/auth/pompeii.service.spec.ts
@@ -3,17 +3,39 @@ import {
   LOCAL_POMPEII_GRPC_URL,
   PRODUCTION_POMPEII_GRPC_URL,
   PompeiiService,
+  mapAuthorizationDecision,
   resolvePompeiiGrpcUrl,
 } from './pompeii.service';
 
 describe('PompeiiService production contract', () => {
+  it('keeps the landed canonical principal beside the legacy subject', () => {
+    expect(
+      mapAuthorizationDecision({
+        authenticated: true,
+        allowed: true,
+        principal_id: ' principal-a ',
+        subject: 'pool-subject-a',
+      }),
+    ).toMatchObject({
+      authenticated: true,
+      allowed: true,
+      principalId: 'principal-a',
+      subject: 'pool-subject-a',
+    });
+    expect(
+      mapAuthorizationDecision({
+        authenticated: true,
+        allowed: true,
+        subject: 'legacy-subject',
+      }).principalId,
+    ).toBeNull();
+  });
+
   it('uses the code-owned production endpoint regardless of an override', () => {
     expect(resolvePompeiiGrpcUrl('production')).toBe(
       PRODUCTION_POMPEII_GRPC_URL,
     );
-    expect(PRODUCTION_POMPEII_GRPC_URL).toBe(
-      'api.pompeii.gaulatti.com:443',
-    );
+    expect(PRODUCTION_POMPEII_GRPC_URL).toBe('api.pompeii.gaulatti.com:443');
   });
 
   it('uses the code-owned local endpoint outside production', () => {

--- a/backend/src/auth/pompeii.service.ts
+++ b/backend/src/auth/pompeii.service.ts
@@ -28,6 +28,7 @@ type AuthorizeWireResponse = {
   subject?: string;
   effective_permissions?: string[];
   roles?: string[];
+  principal_id?: string;
 };
 
 export type AuthorizationDecision = {
@@ -35,6 +36,12 @@ export type AuthorizationDecision = {
   allowed: boolean;
   reason: string;
   subject: string;
+  /**
+   * Pompeii's canonical principal, stable for one real person across Cognito
+   * pools. `null` while an identity has not been resolved to a principal yet,
+   * which is the expected state during rollout. Never derived from an email.
+   */
+  principalId: string | null;
   effectivePermissions: string[];
   roles: string[];
 };
@@ -202,6 +209,7 @@ export class PompeiiService implements OnModuleInit, OnModuleDestroy {
         allowed: response.allowed === true,
         reason: response.reason || 'DENY_UNSPECIFIED',
         subject: response.subject || '',
+        principalId: response.principal_id?.trim() || null,
         effectivePermissions: response.effective_permissions ?? [],
         roles: response.roles ?? [],
       };

--- a/backend/src/auth/pompeii.service.ts
+++ b/backend/src/auth/pompeii.service.ts
@@ -46,6 +46,20 @@ export type AuthorizationDecision = {
   roles: string[];
 };
 
+export function mapAuthorizationDecision(
+  response: AuthorizeWireResponse,
+): AuthorizationDecision {
+  return {
+    authenticated: response.authenticated === true,
+    allowed: response.allowed === true,
+    reason: response.reason || 'DENY_UNSPECIFIED',
+    subject: response.subject || '',
+    principalId: response.principal_id?.trim() || null,
+    effectivePermissions: response.effective_permissions ?? [],
+    roles: response.roles ?? [],
+  };
+}
+
 type AuthorizationClient = Client & {
   authorize(
     request: {
@@ -204,15 +218,7 @@ export class PompeiiService implements OnModuleInit, OnModuleDestroy {
           );
         },
       );
-      const decision = {
-        authenticated: response.authenticated === true,
-        allowed: response.allowed === true,
-        reason: response.reason || 'DENY_UNSPECIFIED',
-        subject: response.subject || '',
-        principalId: response.principal_id?.trim() || null,
-        effectivePermissions: response.effective_permissions ?? [],
-        roles: response.roles ?? [],
-      };
+      const decision = mapAuthorizationDecision(response);
       this.recordMetric(
         'authorize',
         decision.authenticated && decision.allowed ? 'success' : 'denied',

--- a/backend/src/auth/test-auth.service.ts
+++ b/backend/src/auth/test-auth.service.ts
@@ -120,6 +120,7 @@ export class TestAuthService {
         allowed: false,
         reason: 'DENY_INVALID_TEST_TOKEN',
         subject: '',
+        principalId: null,
         effectivePermissions: [],
         roles: [],
       };
@@ -142,6 +143,9 @@ export class TestAuthService {
         ? 'ALLOW_TEST_AUTH'
         : 'DENY_PERMISSION',
       subject,
+      // Local test auth issues pool subjects only; it never fabricates a
+      // canonical principal, so the legacy read path is what it exercises.
+      principalId: null,
       effectivePermissions: permissions,
       roles: [...roles, `team:${teamId}`],
     };

--- a/backend/src/identity/fixtures/pompeii-principal-migration-report.json
+++ b/backend/src/identity/fixtures/pompeii-principal-migration-report.json
@@ -1,0 +1,24 @@
+{
+  "references": [
+    {
+      "consumer": "alcantara",
+      "reference": "SharedConsoleLayout:layout-1",
+      "subject": "fictional-subject-a",
+      "principal_id": "fictional-principal-a"
+    },
+    {
+      "consumer": "alcantara",
+      "reference": "GuestInvitation:invitation-1",
+      "subject": "fictional-subject-b",
+      "principal_id": "fictional-principal-b"
+    },
+    {
+      "consumer": "alcantara",
+      "reference": "GuestEvent:event-1",
+      "subject": "fictional-subject-b",
+      "principal_id": "fictional-principal-b"
+    }
+  ],
+  "collisions": [],
+  "missing": []
+}

--- a/backend/src/identity/principals-cli.spec.ts
+++ b/backend/src/identity/principals-cli.spec.ts
@@ -1,0 +1,425 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PrismaClient } from '@prisma/client';
+import {
+  mappingsFromMigrationReport,
+  readMigrationReportFile,
+  runPrincipalMigrationCli,
+  type PompeiiMigrationReport,
+} from './principals-cli';
+import type { IdentityRow } from './principals';
+import { loadDatabaseSecret } from '../config/database-secrets';
+
+const fixturePath = join(
+  __dirname,
+  'fixtures',
+  'pompeii-principal-migration-report.json',
+);
+
+function writeJson(value: unknown): string {
+  const path = join(mkdtempSync(join(tmpdir(), 'principals-')), 'report.json');
+  writeFileSync(path, JSON.stringify(value));
+  return path;
+}
+
+function transactionWithRows({
+  events = [],
+  invitations = [],
+  layouts = [],
+  preferences = [],
+  eventUpdateCount = 1,
+  invitationUpdateCount = 1,
+  layoutUpdateCount = 1,
+  preferenceUpdateCount = 1,
+}: {
+  events?: unknown[];
+  invitations?: unknown[];
+  layouts?: unknown[];
+  preferences?: unknown[];
+  eventUpdateCount?: number;
+  invitationUpdateCount?: number;
+  layoutUpdateCount?: number;
+  preferenceUpdateCount?: number;
+} = {}) {
+  return {
+    operatorPreference: {
+      findMany: jest.fn().mockResolvedValue(preferences),
+      updateMany: jest.fn().mockResolvedValue({ count: preferenceUpdateCount }),
+    },
+    sharedConsoleLayout: {
+      findMany: jest.fn().mockResolvedValue(layouts),
+      updateMany: jest.fn().mockResolvedValue({ count: layoutUpdateCount }),
+    },
+    guestInvitation: {
+      findMany: jest.fn().mockResolvedValue(invitations),
+      updateMany: jest.fn().mockResolvedValue({ count: invitationUpdateCount }),
+    },
+    guestEvent: {
+      findMany: jest.fn().mockResolvedValue(events),
+      updateMany: jest.fn().mockResolvedValue({ count: eventUpdateCount }),
+    },
+  };
+}
+
+function clientWithTransaction(
+  transaction: ReturnType<typeof transactionWithRows>,
+) {
+  const runTransaction = jest.fn(
+    async (callback: (value: never) => Promise<unknown>) =>
+      callback(transaction as never),
+  );
+  const client = {
+    $disconnect: jest.fn().mockResolvedValue(undefined),
+    $transaction: runTransaction,
+  } as unknown as PrismaClient;
+  return { client, runTransaction };
+}
+
+function cleanReport(
+  reference: string,
+  subject: string,
+  principalId: string,
+): PompeiiMigrationReport {
+  return {
+    references: [{ consumer: 'alcantara', reference, subject, principalId }],
+    collisions: [],
+    missing: [],
+  };
+}
+
+describe('Pompeii migration-report compatibility', () => {
+  it('accepts the committed landed producer shape without manual reshaping', () => {
+    const report = readMigrationReportFile(fixturePath);
+    const rows: IdentityRow[] = [
+      {
+        id: 'layout-1',
+        model: 'SharedConsoleLayout',
+        principalId: null,
+        subject: 'fictional-subject-a',
+      },
+      {
+        id: 'invitation-1',
+        model: 'GuestInvitation',
+        principalId: null,
+        subject: 'fictional-subject-b',
+      },
+      {
+        id: 'event-1',
+        model: 'GuestEvent',
+        principalId: null,
+        subject: 'fictional-subject-b',
+      },
+    ];
+
+    expect(mappingsFromMigrationReport(report, rows)).toEqual([
+      {
+        principalId: 'fictional-principal-a',
+        subject: 'fictional-subject-a',
+      },
+      {
+        principalId: 'fictional-principal-b',
+        subject: 'fictional-subject-b',
+      },
+      {
+        principalId: 'fictional-principal-b',
+        subject: 'fictional-subject-b',
+      },
+    ]);
+  });
+
+  it('rejects the old hand-authored mapping array and identity-bearing extras', () => {
+    expect(() =>
+      readMigrationReportFile(
+        writeJson([{ principalId: 'principal-a', subject: 'subject-a' }]),
+      ),
+    ).toThrow(/Pompeii principal-migration report object/);
+    expect(() =>
+      readMigrationReportFile(
+        writeJson({
+          references: [
+            {
+              consumer: 'alcantara',
+              reference: 'SharedConsoleLayout:layout-1',
+              subject: 'subject-a',
+              principal_id: 'principal-a',
+              email: 'person@example.test',
+            },
+          ],
+          collisions: [],
+          missing: [],
+        }),
+      ),
+    ).toThrow(/never from an email address/);
+  });
+
+  it('requires the Alcantara consumer and exact current reference inventory', () => {
+    const rows: IdentityRow[] = [
+      {
+        id: 'layout-1',
+        model: 'SharedConsoleLayout',
+        principalId: null,
+        subject: 'subject-a',
+      },
+    ];
+    const wrongConsumer = cleanReport(
+      'SharedConsoleLayout:layout-1',
+      'subject-a',
+      'principal-a',
+    );
+    wrongConsumer.references[0].consumer = 'other' as never;
+    expect(() => mappingsFromMigrationReport(wrongConsumer, rows)).toThrow(
+      /non-Alcantara consumer/,
+    );
+
+    expect(() =>
+      mappingsFromMigrationReport(
+        cleanReport('SharedConsoleLayout:other', 'subject-a', 'principal-a'),
+        rows,
+      ),
+    ).toThrow(/unknown Alcantara reference/);
+  });
+});
+
+describe('principal migration CLI safety', () => {
+  const quiet = { error: jest.fn(), log: jest.fn() };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('loads the Arauco database secret before Prisma construction or access', async () => {
+    const order: string[] = [];
+    const transaction = transactionWithRows();
+    const { client: prisma, runTransaction } =
+      clientWithTransaction(transaction);
+    const environment: {
+      ARAUCO_SECRET_ID: string;
+      AWS_REGION: string;
+      DATABASE_URL?: string;
+    } = {
+      ARAUCO_SECRET_ID: 'fictional-arauco-secret',
+      AWS_REGION: 'us-east-1',
+    };
+    const send = jest.fn().mockResolvedValue({
+      SecretString: JSON.stringify({
+        username: 'alcantara',
+        password: 'fictional-password',
+        host: 'database.example.test',
+        port: 5432,
+        dbname: 'alcantara',
+      }),
+    });
+
+    await expect(
+      runPrincipalMigrationCli(['export', 'references.json'], {
+        bootstrapDatabase: () => {
+          order.push('bootstrap');
+          return loadDatabaseSecret(environment, { send });
+        },
+        createPrisma: () => {
+          expect(environment.DATABASE_URL).toContain(
+            'database.example.test:5432/alcantara',
+          );
+          order.push('prisma');
+          return prisma;
+        },
+        writeReferences: () => {
+          order.push('write');
+        },
+        ...quiet,
+      }),
+    ).resolves.toBe(0);
+
+    expect(order).toEqual(['bootstrap', 'prisma', 'write']);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(runTransaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: 'Serializable',
+    });
+  });
+
+  it('aborts before Prisma construction or mutation when secret loading fails', async () => {
+    const createPrisma = jest.fn();
+
+    await expect(
+      runPrincipalMigrationCli(['apply', fixturePath], {
+        bootstrapDatabase: jest
+          .fn()
+          .mockRejectedValue(new Error('database bootstrap failed')),
+        createPrisma,
+        ...quiet,
+      }),
+    ).rejects.toThrow('database bootstrap failed');
+    expect(createPrisma).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing', { collisions: [], missing: [{}] }],
+    ['collision', { collisions: [{}], missing: [] }],
+  ])('refuses producer %s blockers before any update', async (_, blocker) => {
+    const report = cleanReport(
+      'SharedConsoleLayout:layout-1',
+      'subject-a',
+      'principal-a',
+    );
+    if (blocker.missing.length) {
+      report.references[0].principalId = null;
+      report.missing = [report.references[0]];
+    } else {
+      report.references.push({
+        ...report.references[0],
+        principalId: 'principal-b',
+      });
+      report.collisions = [
+        {
+          consumer: 'alcantara',
+          reference: 'SharedConsoleLayout:layout-1',
+          principalIds: ['principal-a', 'principal-b'],
+        },
+      ];
+    }
+    const transaction = transactionWithRows({
+      layouts: [
+        {
+          id: 'layout-1',
+          ownerPrincipalId: null,
+          ownerSubject: 'subject-a',
+        },
+      ],
+    });
+    const { client: prisma } = clientWithTransaction(transaction);
+
+    await expect(
+      runPrincipalMigrationCli(
+        [
+          'apply',
+          writeJson({
+            references: report.references.map((reference) => ({
+              consumer: reference.consumer,
+              reference: reference.reference,
+              subject: reference.subject,
+              ...(reference.principalId
+                ? { principal_id: reference.principalId }
+                : {}),
+            })),
+            collisions: report.collisions.map((collision) => ({
+              consumer: collision.consumer,
+              reference: collision.reference,
+              principal_ids: collision.principalIds,
+            })),
+            missing: report.missing.map((reference) => ({
+              consumer: reference.consumer,
+              reference: reference.reference,
+              subject: reference.subject,
+            })),
+          }),
+        ],
+        {
+          bootstrapDatabase: jest.fn().mockResolvedValue(undefined),
+          createPrisma: () => prisma,
+          ...quiet,
+        },
+      ),
+    ).resolves.toBe(1);
+    expect(transaction.sharedConsoleLayout.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('aborts the serializable apply when a scalar compare-and-set is stale', async () => {
+    const transaction = transactionWithRows({
+      layoutUpdateCount: 0,
+      layouts: [
+        {
+          id: 'layout-1',
+          ownerPrincipalId: null,
+          ownerSubject: 'subject-a',
+        },
+      ],
+    });
+    const { client: prisma } = clientWithTransaction(transaction);
+    const report = cleanReport(
+      'SharedConsoleLayout:layout-1',
+      'subject-a',
+      'principal-a',
+    );
+
+    await expect(
+      runPrincipalMigrationCli(
+        [
+          'apply',
+          writeJson({
+            references: [
+              {
+                consumer: 'alcantara',
+                reference: report.references[0].reference,
+                subject: 'subject-a',
+                principal_id: 'principal-a',
+              },
+            ],
+            collisions: [],
+            missing: [],
+          }),
+        ],
+        {
+          bootstrapDatabase: jest.fn().mockResolvedValue(undefined),
+          createPrisma: () => prisma,
+          ...quiet,
+        },
+      ),
+    ).rejects.toThrow(/changed concurrently/);
+    expect(transaction.sharedConsoleLayout.updateMany).toHaveBeenCalledWith({
+      data: { ownerPrincipalId: 'principal-a' },
+      where: {
+        id: 'layout-1',
+        ownerPrincipalId: null,
+        ownerSubject: 'subject-a',
+      },
+    });
+    expect(quiet.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('Applied'),
+    );
+  });
+
+  it('compare-and-sets the complete GuestEvent JSON and aborts a concurrent edit', async () => {
+    const details = {
+      note: 'preserve this concurrent boundary',
+      operatorIdentity: 'subject-a',
+    };
+    const transaction = transactionWithRows({
+      eventUpdateCount: 0,
+      events: [{ details, id: 'event-1' }],
+    });
+    const { client: prisma } = clientWithTransaction(transaction);
+
+    await expect(
+      runPrincipalMigrationCli(
+        [
+          'apply',
+          writeJson({
+            references: [
+              {
+                consumer: 'alcantara',
+                reference: 'GuestEvent:event-1',
+                subject: 'subject-a',
+                principal_id: 'principal-a',
+              },
+            ],
+            collisions: [],
+            missing: [],
+          }),
+        ],
+        {
+          bootstrapDatabase: jest.fn().mockResolvedValue(undefined),
+          createPrisma: () => prisma,
+          ...quiet,
+        },
+      ),
+    ).rejects.toThrow(/changed concurrently/);
+    expect(transaction.guestEvent.updateMany).toHaveBeenCalledWith({
+      data: {
+        details: { ...details, operatorPrincipalId: 'principal-a' },
+      },
+      where: { details: { equals: details }, id: 'event-1' },
+    });
+    expect(quiet.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('Applied'),
+    );
+  });
+});

--- a/backend/src/identity/principals-cli.ts
+++ b/backend/src/identity/principals-cli.ts
@@ -1,0 +1,163 @@
+import { readFileSync } from 'node:fs';
+import { PrismaClient } from '@prisma/client';
+import {
+  applicableChanges,
+  formatPlan,
+  hasConflicts,
+  planMigration,
+  type IdentityRow,
+  type SubjectMapping,
+} from './principals';
+
+/**
+ * Reports and applies the migration of pool-local subject references to
+ * canonical Pompeii principals.
+ *
+ *   pnpm principals:report ./mapping.json
+ *   pnpm principals:apply  ./mapping.json
+ *
+ * The mapping file is a JSON array of `{ "subject": "...", "principalId": "..." }`
+ * pairs obtained from Pompeii. Nothing here can derive one — identities are
+ * never joined by email — and an entry that even contains an email is refused.
+ *
+ * `report` changes nothing. `apply` writes only rows the report classified
+ * `mapped`, sets each canonical column conditionally on it still being null, and
+ * never touches a subject column. It is therefore safe to re-run: a crash
+ * part-way through resumes, and a completed run is a no-op.
+ */
+
+export function readMappingFile(path: string): SubjectMapping[] {
+  const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      'The mapping file must be a JSON array of {subject, principalId} pairs.',
+    );
+  }
+  return parsed.map((entry, index) => {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error(`Mapping entry ${index} is not an object.`);
+    }
+    const record = entry as Record<string, unknown>;
+    if (
+      typeof record.subject !== 'string' ||
+      typeof record.principalId !== 'string'
+    ) {
+      throw new Error(
+        `Mapping entry ${index} needs a string subject and principalId.`,
+      );
+    }
+    if ('email' in record) {
+      throw new Error(
+        `Mapping entry ${index} contains an email. Identity links come from Pompeii, never from an email address.`,
+      );
+    }
+    return { principalId: record.principalId, subject: record.subject };
+  });
+}
+
+async function collectRows(prisma: PrismaClient): Promise<IdentityRow[]> {
+  const [preferences, layouts, invitations] = await Promise.all([
+    prisma.operatorPreference.findMany({
+      select: { deviceClass: true, principalId: true, subject: true },
+    }),
+    prisma.sharedConsoleLayout.findMany({
+      select: { id: true, ownerPrincipalId: true, ownerSubject: true },
+    }),
+    prisma.guestInvitation.findMany({
+      select: { createdByIdentity: true, createdByPrincipalId: true, id: true },
+    }),
+  ]);
+
+  return [
+    ...preferences.map((row) => ({
+      id: `${row.subject}::${row.deviceClass}`,
+      model: 'OperatorPreference' as const,
+      principalId: row.principalId,
+      subject: row.subject,
+    })),
+    ...layouts.map((row) => ({
+      id: row.id,
+      model: 'SharedConsoleLayout' as const,
+      principalId: row.ownerPrincipalId,
+      subject: row.ownerSubject,
+    })),
+    ...invitations.map((row) => ({
+      id: row.id,
+      model: 'GuestInvitation' as const,
+      principalId: row.createdByPrincipalId,
+      subject: row.createdByIdentity,
+    })),
+  ];
+}
+
+async function main(): Promise<void> {
+  const [mode, mappingPath, ...flags] = process.argv.slice(2);
+  if (mode !== 'report' && mode !== 'apply') {
+    console.error(
+      'Usage: principals-cli <report|apply> <mapping.json> [--allow-conflicts]',
+    );
+    process.exitCode = 2;
+    return;
+  }
+  if (!mappingPath) {
+    console.error(
+      'A verified subject-to-principal mapping file is required.',
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const mappings = readMappingFile(mappingPath);
+  const prisma = new PrismaClient();
+  try {
+    const plan = planMigration(await collectRows(prisma), mappings);
+    console.log(formatPlan(plan));
+
+    if (mode === 'report') return;
+
+    if (hasConflicts(plan) && !flags.includes('--allow-conflicts')) {
+      console.error(
+        '\nRefusing to apply while conflicts remain. Resolve them, or pass --allow-conflicts to migrate only the clean rows.',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const changes = applicableChanges(plan);
+    await prisma.$transaction(async (transaction) => {
+      for (const row of changes) {
+        if (row.principalId === null) continue;
+        if (row.model === 'OperatorPreference') {
+          const [subject, deviceClass] = row.id.split('::');
+          await transaction.operatorPreference.updateMany({
+            data: { principalId: row.principalId },
+            where: { deviceClass, principalId: null, subject },
+          });
+        } else if (row.model === 'SharedConsoleLayout') {
+          await transaction.sharedConsoleLayout.updateMany({
+            data: { ownerPrincipalId: row.principalId },
+            where: { id: row.id, ownerPrincipalId: null },
+          });
+        } else {
+          // Audit only: createdByIdentity is never rewritten, so the historical
+          // actor still displays exactly as it always did.
+          await transaction.guestInvitation.updateMany({
+            data: { createdByPrincipalId: row.principalId },
+            where: { createdByPrincipalId: null, id: row.id },
+          });
+        }
+      }
+    });
+
+    console.log(`\nApplied ${changes.length} canonical principal references.`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/backend/src/identity/principals-cli.ts
+++ b/backend/src/identity/principals-cli.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { PrismaClient } from '@prisma/client';
+import { createHash } from 'node:crypto';
+import { Prisma, PrismaClient } from '@prisma/client';
 import {
   applicableChanges,
   formatPlan,
@@ -8,6 +9,13 @@ import {
   type IdentityRow,
   type SubjectMapping,
 } from './principals';
+import { createPostgresAdapter } from '../prisma-adapter';
+
+type CollectedIdentityRow = IdentityRow & {
+  deviceClass?: string;
+  details?: Record<string, Prisma.JsonValue>;
+  sourceId: string;
+};
 
 /**
  * Reports and applies the migration of pool-local subject references to
@@ -21,9 +29,9 @@ import {
  * never joined by email — and an entry that even contains an email is refused.
  *
  * `report` changes nothing. `apply` writes only rows the report classified
- * `mapped`, sets each canonical column conditionally on it still being null, and
- * never touches a subject column. It is therefore safe to re-run: a crash
- * part-way through resumes, and a completed run is a no-op.
+ * `mapped`, sets each canonical reference only while it is absent, and never
+ * touches a subject value. It is therefore safe to re-run: a crash part-way
+ * through resumes, and a completed run is a no-op.
  */
 
 export function readMappingFile(path: string): SubjectMapping[] {
@@ -55,8 +63,26 @@ export function readMappingFile(path: string): SubjectMapping[] {
   });
 }
 
-async function collectRows(prisma: PrismaClient): Promise<IdentityRow[]> {
-  const [preferences, layouts, invitations] = await Promise.all([
+function jsonObject(
+  value: Prisma.JsonValue | null,
+): Record<string, Prisma.JsonValue> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, Prisma.JsonValue>;
+}
+
+function preferenceReportId(subject: string, deviceClass: string): string {
+  return `preference-${createHash('sha256')
+    .update(subject)
+    .update('\0')
+    .update(deviceClass)
+    .digest('hex')
+    .slice(0, 16)}`;
+}
+
+async function collectRows(
+  prisma: PrismaClient,
+): Promise<CollectedIdentityRow[]> {
+  const [preferences, layouts, invitations, events] = await Promise.all([
     prisma.operatorPreference.findMany({
       select: { deviceClass: true, principalId: true, subject: true },
     }),
@@ -66,27 +92,55 @@ async function collectRows(prisma: PrismaClient): Promise<IdentityRow[]> {
     prisma.guestInvitation.findMany({
       select: { createdByIdentity: true, createdByPrincipalId: true, id: true },
     }),
+    prisma.guestEvent.findMany({
+      select: { details: true, id: true },
+    }),
   ]);
 
   return [
     ...preferences.map((row) => ({
-      id: `${row.subject}::${row.deviceClass}`,
+      collisionScope: row.deviceClass,
+      deviceClass: row.deviceClass,
+      id: preferenceReportId(row.subject, row.deviceClass),
       model: 'OperatorPreference' as const,
       principalId: row.principalId,
+      sourceId: row.subject,
       subject: row.subject,
     })),
     ...layouts.map((row) => ({
       id: row.id,
       model: 'SharedConsoleLayout' as const,
       principalId: row.ownerPrincipalId,
+      sourceId: row.id,
       subject: row.ownerSubject,
     })),
     ...invitations.map((row) => ({
       id: row.id,
       model: 'GuestInvitation' as const,
       principalId: row.createdByPrincipalId,
+      sourceId: row.id,
       subject: row.createdByIdentity,
     })),
+    ...events.flatMap((row): CollectedIdentityRow[] => {
+      const details = jsonObject(row.details);
+      if (!details) return [];
+      const subject = details.operatorIdentity;
+      if (typeof subject !== 'string' || !subject.trim()) return [];
+      const storedPrincipal = details.operatorPrincipalId;
+      return [
+        {
+          details,
+          id: row.id,
+          model: 'GuestEvent',
+          principalId:
+            typeof storedPrincipal === 'string' && storedPrincipal.trim()
+              ? storedPrincipal.trim()
+              : null,
+          sourceId: row.id,
+          subject,
+        },
+      ];
+    }),
   ];
 }
 
@@ -100,17 +154,21 @@ async function main(): Promise<void> {
     return;
   }
   if (!mappingPath) {
-    console.error(
-      'A verified subject-to-principal mapping file is required.',
-    );
+    console.error('A verified subject-to-principal mapping file is required.');
     process.exitCode = 2;
     return;
   }
 
   const mappings = readMappingFile(mappingPath);
-  const prisma = new PrismaClient();
+  const prisma = new PrismaClient({
+    adapter: createPostgresAdapter(process.env.DATABASE_URL),
+  });
   try {
-    const plan = planMigration(await collectRows(prisma), mappings);
+    const rows = await collectRows(prisma);
+    const rowsByPlanId = new Map(
+      rows.map((row) => [`${row.model}:${row.id}`, row]),
+    );
+    const plan = planMigration(rows, mappings);
     console.log(formatPlan(plan));
 
     if (mode === 'report') return;
@@ -127,23 +185,53 @@ async function main(): Promise<void> {
     await prisma.$transaction(async (transaction) => {
       for (const row of changes) {
         if (row.principalId === null) continue;
+        const source = rowsByPlanId.get(`${row.model}:${row.id}`);
+        if (!source)
+          throw new Error(`Migration source vanished for ${row.id}.`);
         if (row.model === 'OperatorPreference') {
-          const [subject, deviceClass] = row.id.split('::');
           await transaction.operatorPreference.updateMany({
             data: { principalId: row.principalId },
-            where: { deviceClass, principalId: null, subject },
+            where: {
+              deviceClass: source.deviceClass,
+              principalId: null,
+              subject: source.sourceId,
+            },
           });
         } else if (row.model === 'SharedConsoleLayout') {
           await transaction.sharedConsoleLayout.updateMany({
             data: { ownerPrincipalId: row.principalId },
-            where: { id: row.id, ownerPrincipalId: null },
+            where: { id: source.sourceId, ownerPrincipalId: null },
           });
-        } else {
+        } else if (row.model === 'GuestInvitation') {
           // Audit only: createdByIdentity is never rewritten, so the historical
           // actor still displays exactly as it always did.
           await transaction.guestInvitation.updateMany({
             data: { createdByPrincipalId: row.principalId },
-            where: { createdByPrincipalId: null, id: row.id },
+            where: { createdByPrincipalId: null, id: source.sourceId },
+          });
+        } else {
+          const stored = await transaction.guestEvent.findUnique({
+            select: { details: true },
+            where: { id: source.sourceId },
+          });
+          const details = jsonObject(stored?.details ?? null);
+          if (!details || details.operatorIdentity !== source.subject) {
+            throw new Error(
+              `GuestEvent ${row.id} changed after the dry run; retry the migration.`,
+            );
+          }
+          const currentPrincipal = details.operatorPrincipalId;
+          if (typeof currentPrincipal === 'string' && currentPrincipal.trim()) {
+            continue;
+          }
+          await transaction.guestEvent.update({
+            data: {
+              details: {
+                ...details,
+                operatorPrincipalId: row.principalId,
+              } as Prisma.InputJsonValue,
+            },
+            where: { id: source.sourceId },
           });
         }
       }

--- a/backend/src/identity/principals-cli.ts
+++ b/backend/src/identity/principals-cli.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { Prisma, PrismaClient } from '@prisma/client';
 import {
@@ -10,6 +10,7 @@ import {
   type SubjectMapping,
 } from './principals';
 import { createPostgresAdapter } from '../prisma-adapter';
+import { loadDatabaseSecret } from '../config/database-secrets';
 
 type CollectedIdentityRow = IdentityRow & {
   deviceClass?: string;
@@ -17,16 +18,55 @@ type CollectedIdentityRow = IdentityRow & {
   sourceId: string;
 };
 
+type ConsumerReference = {
+  consumer: 'alcantara';
+  reference: string;
+  subject: string;
+};
+
+type ResolvedConsumerReference = ConsumerReference & {
+  principalId: string | null;
+};
+
+type ProducerCollision = {
+  consumer: string;
+  principalIds: string[];
+  reference: string;
+};
+
+export type PompeiiMigrationReport = {
+  collisions: ProducerCollision[];
+  missing: ResolvedConsumerReference[];
+  references: ResolvedConsumerReference[];
+};
+
+type IdentityStore = Pick<
+  Prisma.TransactionClient,
+  | 'guestEvent'
+  | 'guestInvitation'
+  | 'operatorPreference'
+  | 'sharedConsoleLayout'
+>;
+
+type CliDependencies = {
+  bootstrapDatabase: () => Promise<void>;
+  createPrisma: () => PrismaClient;
+  error: (message: string) => void;
+  log: (message: string) => void;
+  writeReferences: (path: string, references: ConsumerReference[]) => void;
+};
+
 /**
  * Reports and applies the migration of pool-local subject references to
  * canonical Pompeii principals.
  *
- *   pnpm principals:report ./mapping.json
- *   pnpm principals:apply  ./mapping.json
+ *   pnpm principals:export ./references.json
+ *   pnpm principals:report ./pompeii-report.json
+ *   pnpm principals:apply  ./pompeii-report.json
  *
- * The mapping file is a JSON array of `{ "subject": "...", "principalId": "..." }`
- * pairs obtained from Pompeii. Nothing here can derive one — identities are
- * never joined by email — and an entry that even contains an email is refused.
+ * `export` writes Pompeii's consumer-reference input contract. `report` and
+ * `apply` consume Pompeii's complete migration report without manual reshaping.
+ * Nothing here can derive an identity — identities are never joined by email.
  *
  * `report` changes nothing. `apply` writes only rows the report classified
  * `mapped`, sets each canonical reference only while it is absent, and never
@@ -34,33 +74,94 @@ type CollectedIdentityRow = IdentityRow & {
  * through resumes, and a completed run is a no-op.
  */
 
-export function readMappingFile(path: string): SubjectMapping[] {
-  const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
-  if (!Array.isArray(parsed)) {
+function requiredString(
+  record: Record<string, unknown>,
+  field: string,
+  context: string,
+): string {
+  const value = record[field];
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${context} needs a non-empty ${field}.`);
+  }
+  return value.trim();
+}
+
+function resolvedReference(
+  entry: unknown,
+  context: string,
+): ResolvedConsumerReference {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    throw new Error(`${context} is not an object.`);
+  }
+  const record = entry as Record<string, unknown>;
+  if ('email' in record) {
     throw new Error(
-      'The mapping file must be a JSON array of {subject, principalId} pairs.',
+      `${context} contains an email. Identity links come from Pompeii, never from an email address.`,
     );
   }
-  return parsed.map((entry, index) => {
-    if (!entry || typeof entry !== 'object') {
-      throw new Error(`Mapping entry ${index} is not an object.`);
-    }
-    const record = entry as Record<string, unknown>;
-    if (
-      typeof record.subject !== 'string' ||
-      typeof record.principalId !== 'string'
-    ) {
-      throw new Error(
-        `Mapping entry ${index} needs a string subject and principalId.`,
-      );
-    }
-    if ('email' in record) {
-      throw new Error(
-        `Mapping entry ${index} contains an email. Identity links come from Pompeii, never from an email address.`,
-      );
-    }
-    return { principalId: record.principalId, subject: record.subject };
-  });
+  const principalId = record.principal_id;
+  if (
+    principalId !== undefined &&
+    (typeof principalId !== 'string' || !principalId.trim())
+  ) {
+    throw new Error(`${context} has an invalid principal_id.`);
+  }
+  return {
+    consumer: requiredString(record, 'consumer', context) as 'alcantara',
+    reference: requiredString(record, 'reference', context),
+    subject: requiredString(record, 'subject', context),
+    principalId: typeof principalId === 'string' ? principalId.trim() : null,
+  };
+}
+
+function producerCollision(entry: unknown, index: number): ProducerCollision {
+  const context = `Pompeii collision ${index}`;
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    throw new Error(`${context} is not an object.`);
+  }
+  const record = entry as Record<string, unknown>;
+  if (
+    !Array.isArray(record.principal_ids) ||
+    record.principal_ids.length < 2 ||
+    record.principal_ids.some(
+      (value) => typeof value !== 'string' || !value.trim(),
+    )
+  ) {
+    throw new Error(`${context} needs at least two principal_ids.`);
+  }
+  return {
+    consumer: requiredString(record, 'consumer', context),
+    reference: requiredString(record, 'reference', context),
+    principalIds: record.principal_ids.map((value) => (value as string).trim()),
+  };
+}
+
+export function readMigrationReportFile(path: string): PompeiiMigrationReport {
+  const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(
+      'The input must be a Pompeii principal-migration report object.',
+    );
+  }
+  const record = parsed as Record<string, unknown>;
+  if (
+    !Array.isArray(record.references) ||
+    !Array.isArray(record.collisions) ||
+    !Array.isArray(record.missing)
+  ) {
+    throw new Error(
+      'The Pompeii report needs references, collisions, and missing arrays.',
+    );
+  }
+  return {
+    references: record.references.map((entry, index) =>
+      resolvedReference(entry, `Pompeii reference ${index}`),
+    ),
+    collisions: record.collisions.map(producerCollision),
+    missing: record.missing.map((entry, index) =>
+      resolvedReference(entry, `Pompeii missing reference ${index}`),
+    ),
+  };
 }
 
 function jsonObject(
@@ -79,8 +180,147 @@ function preferenceReportId(subject: string, deviceClass: string): string {
     .slice(0, 16)}`;
 }
 
+function migrationReference(row: IdentityRow): string {
+  return `${row.model}:${row.id}`;
+}
+
+export function buildConsumerReferences(
+  rows: readonly IdentityRow[],
+): ConsumerReference[] {
+  return rows.flatMap((row) => {
+    const subject = row.subject?.trim();
+    if (!subject) return [];
+    return [
+      {
+        consumer: 'alcantara' as const,
+        reference: migrationReference(row),
+        subject,
+      },
+    ];
+  });
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]) {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  return (
+    left.length === leftSet.size &&
+    right.length === rightSet.size &&
+    leftSet.size === rightSet.size &&
+    [...leftSet].every((value) => rightSet.has(value))
+  );
+}
+
+/**
+ * Verifies that a Pompeii report describes exactly the current Alcantara
+ * inventory. This prevents a report for another consumer, a manually reshaped
+ * mapping, or a stale partial export from reaching the apply path.
+ */
+export function mappingsFromMigrationReport(
+  report: PompeiiMigrationReport,
+  rows: readonly IdentityRow[],
+): SubjectMapping[] {
+  const expectedReferences = buildConsumerReferences(rows);
+  const expectedByReference = new Map(
+    expectedReferences.map((reference) => [reference.reference, reference]),
+  );
+  if (expectedByReference.size !== expectedReferences.length) {
+    throw new Error(
+      'The Alcantara migration inventory has duplicate references.',
+    );
+  }
+
+  const seenReferences = new Set<string>();
+  const seenEntries = new Set<string>();
+  const resolvedByReference = new Map<string, ResolvedConsumerReference[]>();
+  for (const reference of report.references) {
+    if (reference.consumer !== 'alcantara') {
+      throw new Error('The Pompeii report contains a non-Alcantara consumer.');
+    }
+    const expected = expectedByReference.get(reference.reference);
+    if (!expected) {
+      throw new Error(
+        'The Pompeii report contains an unknown Alcantara reference.',
+      );
+    }
+    if (reference.subject !== expected.subject) {
+      throw new Error(
+        'The Pompeii report subject does not match the current Alcantara reference.',
+      );
+    }
+    const fingerprint = `${reference.reference}\0${reference.subject}\0${reference.principalId ?? ''}`;
+    if (seenEntries.has(fingerprint)) {
+      throw new Error(
+        'The Pompeii report contains a duplicate reference result.',
+      );
+    }
+    seenEntries.add(fingerprint);
+    seenReferences.add(reference.reference);
+    const group = resolvedByReference.get(reference.reference) ?? [];
+    group.push(reference);
+    resolvedByReference.set(reference.reference, group);
+  }
+  if (
+    expectedReferences.some(
+      (reference) => !seenReferences.has(reference.reference),
+    )
+  ) {
+    throw new Error(
+      'The Pompeii report does not cover the current Alcantara inventory.',
+    );
+  }
+
+  const actualMissing = report.references
+    .filter((reference) => reference.principalId === null)
+    .map((reference) => `${reference.reference}\0${reference.subject}`);
+  const declaredMissing = report.missing.map((reference) => {
+    if (
+      reference.consumer !== 'alcantara' ||
+      reference.principalId !== null ||
+      expectedByReference.get(reference.reference)?.subject !==
+        reference.subject
+    ) {
+      throw new Error('The Pompeii missing-reference report is inconsistent.');
+    }
+    return `${reference.reference}\0${reference.subject}`;
+  });
+  if (!sameStringSet(actualMissing, declaredMissing)) {
+    throw new Error('The Pompeii missing-reference report is inconsistent.');
+  }
+
+  const actualCollisions = new Map<string, string[]>();
+  for (const [reference, group] of resolvedByReference) {
+    const principalIds = [
+      ...new Set(
+        group.flatMap((entry) =>
+          entry.principalId === null ? [] : [entry.principalId],
+        ),
+      ),
+    ];
+    if (principalIds.length > 1) actualCollisions.set(reference, principalIds);
+  }
+  if (actualCollisions.size !== report.collisions.length) {
+    throw new Error('The Pompeii collision report is inconsistent.');
+  }
+  for (const collision of report.collisions) {
+    if (collision.consumer !== 'alcantara') {
+      throw new Error('The Pompeii collision report is inconsistent.');
+    }
+    const actual = actualCollisions.get(collision.reference);
+    if (!actual || !sameStringSet(actual, collision.principalIds)) {
+      throw new Error('The Pompeii collision report is inconsistent.');
+    }
+  }
+
+  return report.references.flatMap((reference) =>
+    reference.principalId
+      ? [{ principalId: reference.principalId, subject: reference.subject }]
+      : [],
+  );
+}
+
 async function collectRows(
-  prisma: PrismaClient,
+  prisma: IdentityStore,
 ): Promise<CollectedIdentityRow[]> {
   const [preferences, layouts, invitations, events] = await Promise.all([
     prisma.operatorPreference.findMany({
@@ -144,108 +384,216 @@ async function collectRows(
   ];
 }
 
-async function main(): Promise<void> {
-  const [mode, mappingPath, ...flags] = process.argv.slice(2);
-  if (mode !== 'report' && mode !== 'apply') {
-    console.error(
-      'Usage: principals-cli <report|apply> <mapping.json> [--allow-conflicts]',
-    );
-    process.exitCode = 2;
-    return;
+function assertOneCanonicalUpdate(
+  model: IdentityRow['model'],
+  count: number,
+): void {
+  if (count === 1) return;
+  throw new Error(
+    `${model} changed concurrently; no canonical principal changes were committed. Retry the migration.`,
+  );
+}
+
+const transactionOptions = {
+  isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+} as const;
+
+async function applyMigration(
+  transaction: Prisma.TransactionClient,
+  producerReport: PompeiiMigrationReport,
+  allowConflicts: boolean,
+) {
+  // Collection, producer-contract validation, planning, and every write share
+  // one serializable snapshot. A concurrent owner/audit change either misses a
+  // compare-and-set below or forces PostgreSQL to abort this whole transaction.
+  const rows = await collectRows(transaction);
+  const mappings = mappingsFromMigrationReport(producerReport, rows);
+  const plan = planMigration(rows, mappings);
+  if (
+    producerReport.collisions.length > 0 ||
+    producerReport.missing.length > 0
+  ) {
+    return { applied: 0, plan, refusal: 'producer' as const };
   }
-  if (!mappingPath) {
-    console.error('A verified subject-to-principal mapping file is required.');
-    process.exitCode = 2;
-    return;
+  if (hasConflicts(plan) && !allowConflicts) {
+    return { applied: 0, plan, refusal: 'consumer' as const };
   }
 
-  const mappings = readMappingFile(mappingPath);
-  const prisma = new PrismaClient({
-    adapter: createPostgresAdapter(process.env.DATABASE_URL),
-  });
-  try {
-    const rows = await collectRows(prisma);
-    const rowsByPlanId = new Map(
-      rows.map((row) => [`${row.model}:${row.id}`, row]),
-    );
-    const plan = planMigration(rows, mappings);
-    console.log(formatPlan(plan));
-
-    if (mode === 'report') return;
-
-    if (hasConflicts(plan) && !flags.includes('--allow-conflicts')) {
-      console.error(
-        '\nRefusing to apply while conflicts remain. Resolve them, or pass --allow-conflicts to migrate only the clean rows.',
+  const rowsByPlanId = new Map(
+    rows.map((row) => [`${row.model}:${row.id}`, row]),
+  );
+  let applied = 0;
+  for (const row of applicableChanges(plan)) {
+    if (row.principalId === null) continue;
+    const source = rowsByPlanId.get(`${row.model}:${row.id}`);
+    if (!source || !source.subject) {
+      throw new Error(
+        'The current Alcantara migration inventory changed unexpectedly.',
       );
-      process.exitCode = 1;
-      return;
     }
 
-    const changes = applicableChanges(plan);
-    await prisma.$transaction(async (transaction) => {
-      for (const row of changes) {
-        if (row.principalId === null) continue;
-        const source = rowsByPlanId.get(`${row.model}:${row.id}`);
-        if (!source)
-          throw new Error(`Migration source vanished for ${row.id}.`);
-        if (row.model === 'OperatorPreference') {
-          await transaction.operatorPreference.updateMany({
-            data: { principalId: row.principalId },
-            where: {
-              deviceClass: source.deviceClass,
-              principalId: null,
-              subject: source.sourceId,
-            },
-          });
-        } else if (row.model === 'SharedConsoleLayout') {
-          await transaction.sharedConsoleLayout.updateMany({
-            data: { ownerPrincipalId: row.principalId },
-            where: { id: source.sourceId, ownerPrincipalId: null },
-          });
-        } else if (row.model === 'GuestInvitation') {
-          // Audit only: createdByIdentity is never rewritten, so the historical
-          // actor still displays exactly as it always did.
-          await transaction.guestInvitation.updateMany({
-            data: { createdByPrincipalId: row.principalId },
-            where: { createdByPrincipalId: null, id: source.sourceId },
-          });
-        } else {
-          const stored = await transaction.guestEvent.findUnique({
-            select: { details: true },
-            where: { id: source.sourceId },
-          });
-          const details = jsonObject(stored?.details ?? null);
-          if (!details || details.operatorIdentity !== source.subject) {
-            throw new Error(
-              `GuestEvent ${row.id} changed after the dry run; retry the migration.`,
-            );
-          }
-          const currentPrincipal = details.operatorPrincipalId;
-          if (typeof currentPrincipal === 'string' && currentPrincipal.trim()) {
-            continue;
-          }
-          await transaction.guestEvent.update({
-            data: {
-              details: {
-                ...details,
-                operatorPrincipalId: row.principalId,
-              } as Prisma.InputJsonValue,
-            },
-            where: { id: source.sourceId },
-          });
-        }
+    let count: number;
+    if (row.model === 'OperatorPreference') {
+      const result = await transaction.operatorPreference.updateMany({
+        data: { principalId: row.principalId },
+        where: {
+          deviceClass: source.deviceClass,
+          principalId: null,
+          subject: source.sourceId,
+        },
+      });
+      count = result.count;
+    } else if (row.model === 'SharedConsoleLayout') {
+      const result = await transaction.sharedConsoleLayout.updateMany({
+        data: { ownerPrincipalId: row.principalId },
+        where: {
+          id: source.sourceId,
+          ownerPrincipalId: null,
+          ownerSubject: source.subject,
+        },
+      });
+      count = result.count;
+    } else if (row.model === 'GuestInvitation') {
+      // Audit only: createdByIdentity is never rewritten, so the historical
+      // actor still displays exactly as it always did.
+      const result = await transaction.guestInvitation.updateMany({
+        data: { createdByPrincipalId: row.principalId },
+        where: {
+          createdByIdentity: source.subject,
+          createdByPrincipalId: null,
+          id: source.sourceId,
+        },
+      });
+      count = result.count;
+    } else {
+      if (!source.details) {
+        throw new Error(
+          'The current Alcantara migration inventory changed unexpectedly.',
+        );
       }
-    });
+      const result = await transaction.guestEvent.updateMany({
+        data: {
+          details: {
+            ...source.details,
+            operatorPrincipalId: row.principalId,
+          } as Prisma.InputJsonValue,
+        },
+        where: {
+          details: { equals: source.details as Prisma.InputJsonValue },
+          id: source.sourceId,
+        },
+      });
+      count = result.count;
+    }
+    assertOneCanonicalUpdate(row.model, count);
+    applied += count;
+  }
 
-    console.log(`\nApplied ${changes.length} canonical principal references.`);
+  return { applied, plan, refusal: null };
+}
+
+function defaultDependencies(): CliDependencies {
+  return {
+    bootstrapDatabase: () => loadDatabaseSecret(),
+    createPrisma: () =>
+      new PrismaClient({
+        adapter: createPostgresAdapter(process.env.DATABASE_URL),
+      }),
+    error: (message) => console.error(message),
+    log: (message) => console.log(message),
+    writeReferences: (path, references) =>
+      writeFileSync(path, `${JSON.stringify(references, null, 2)}\n`, {
+        encoding: 'utf8',
+        flag: 'wx',
+        mode: 0o600,
+      }),
+  };
+}
+
+export async function runPrincipalMigrationCli(
+  args: readonly string[],
+  overrides: Partial<CliDependencies> = {},
+): Promise<number> {
+  const dependencies = { ...defaultDependencies(), ...overrides };
+  const [mode, inputPath, ...flags] = args;
+  if (mode !== 'export' && mode !== 'report' && mode !== 'apply') {
+    dependencies.error(
+      'Usage: principals-cli <export|report|apply> <path> [--allow-conflicts]',
+    );
+    return 2;
+  }
+  if (!inputPath) {
+    dependencies.error('A references or Pompeii report path is required.');
+    return 2;
+  }
+
+  // Production supplies ARAUCO_SECRET_ID, not DATABASE_URL. This canonical
+  // bootstrap must finish before Prisma or its Postgres adapter is constructed.
+  await dependencies.bootstrapDatabase();
+  const prisma = dependencies.createPrisma();
+  try {
+    if (mode === 'export') {
+      const rows = await prisma.$transaction(
+        (transaction) => collectRows(transaction),
+        transactionOptions,
+      );
+      const references = buildConsumerReferences(rows);
+      dependencies.writeReferences(inputPath, references);
+      dependencies.log(
+        `Wrote ${references.length} Alcantara references for Pompeii.`,
+      );
+      return 0;
+    }
+
+    const producerReport = readMigrationReportFile(inputPath);
+    if (mode === 'report') {
+      const rows = await collectRows(prisma);
+      const mappings = mappingsFromMigrationReport(producerReport, rows);
+      dependencies.log(formatPlan(planMigration(rows, mappings)));
+      dependencies.log(
+        `\nPompeii blockers: ${producerReport.collisions.length} collision(s), ${producerReport.missing.length} missing reference(s).`,
+      );
+      return 0;
+    }
+
+    const outcome = await prisma.$transaction(
+      (transaction) =>
+        applyMigration(
+          transaction,
+          producerReport,
+          flags.includes('--allow-conflicts'),
+        ),
+      transactionOptions,
+    );
+    dependencies.log(formatPlan(outcome.plan));
+    if (outcome.refusal === 'producer') {
+      dependencies.error(
+        `\nRefusing to apply: Pompeii reported ${producerReport.collisions.length} collision(s) and ${producerReport.missing.length} missing reference(s).`,
+      );
+      return 1;
+    }
+    if (outcome.refusal === 'consumer') {
+      dependencies.error(
+        '\nRefusing to apply while Alcantara conflicts remain. Resolve them, or pass --allow-conflicts to migrate only the clean rows.',
+      );
+      return 1;
+    }
+    dependencies.log(
+      `\nApplied ${outcome.applied} canonical principal references.`,
+    );
+    return 0;
   } finally {
     await prisma.$disconnect();
   }
 }
 
 if (require.main === module) {
-  main().catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 1;
-  });
+  runPrincipalMigrationCli(process.argv.slice(2))
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    });
 }

--- a/backend/src/identity/principals.spec.ts
+++ b/backend/src/identity/principals.spec.ts
@@ -1,0 +1,199 @@
+import {
+  applicableChanges,
+  formatPlan,
+  hasConflicts,
+  indexMappings,
+  ownsRow,
+  planMigration,
+  SUBJECT_BEARING_FIELDS,
+  type IdentityRow,
+} from './principals';
+
+const row = (overrides: Partial<IdentityRow> = {}): IdentityRow => ({
+  id: 'row-1',
+  model: 'SharedConsoleLayout',
+  principalId: null,
+  subject: 'subject-a',
+  ...overrides,
+});
+
+const mapping = [{ principalId: 'principal-a', subject: 'subject-a' }];
+
+describe('subject inventory', () => {
+  it('accounts for every subject-bearing field in the schema', () => {
+    // Kept in step with prisma/schema.prisma by hand; a new subject column that
+    // is not listed here would silently escape both the report and the apply.
+    expect(SUBJECT_BEARING_FIELDS.map((field) => `${field.model}.${field.subjectColumn}`)).toEqual([
+      'OperatorPreference.subject',
+      'SharedConsoleLayout.ownerSubject',
+      'GuestInvitation.createdByIdentity',
+    ]);
+    expect(SUBJECT_BEARING_FIELDS.filter((field) => field.kind === 'audit')).toHaveLength(1);
+  });
+});
+
+describe('dry run', () => {
+  it('reports mapped, already-migrated, missing, and orphan rows', () => {
+    const plan = planMigration(
+      [
+        row({ id: 'mapped' }),
+        row({ id: 'done', principalId: 'principal-a' }),
+        row({ id: 'unmapped', subject: 'subject-unknown' }),
+        row({ id: 'orphan', subject: null }),
+      ],
+      mapping,
+    );
+
+    expect(plan.summary).toEqual({
+      mapped: 1,
+      'already-migrated': 1,
+      missing: 1,
+      conflicting: 0,
+      ambiguous: 0,
+      orphan: 1,
+    });
+    expect(plan.rows).toHaveLength(4);
+    expect(hasConflicts(plan)).toBe(false);
+  });
+
+  it('reports a row that already names a different principal and never overwrites it', () => {
+    const plan = planMigration([row({ principalId: 'principal-other' })], mapping);
+
+    expect(plan.rows[0].classification).toBe('conflicting');
+    expect(plan.rows[0].principalId).toBe('principal-other');
+    expect(applicableChanges(plan)).toEqual([]);
+    expect(hasConflicts(plan)).toBe(true);
+  });
+
+  it('refuses a subject that maps to more than one principal', () => {
+    const ambiguousMapping = [
+      { principalId: 'principal-a', subject: 'subject-a' },
+      { principalId: 'principal-b', subject: 'subject-a' },
+    ];
+    const { ambiguous, bySubject } = indexMappings(ambiguousMapping);
+    expect(ambiguous.has('subject-a')).toBe(true);
+    expect(bySubject.has('subject-a')).toBe(false);
+
+    const plan = planMigration([row()], ambiguousMapping);
+    expect(plan.rows[0].classification).toBe('ambiguous');
+    expect(plan.ambiguousSubjects).toBe(1);
+    expect(applicableChanges(plan)).toEqual([]);
+    expect(hasConflicts(plan)).toBe(true);
+  });
+
+  it('ignores blank mapping entries rather than treating them as identities', () => {
+    const { bySubject } = indexMappings([
+      { principalId: '', subject: 'subject-a' },
+      { principalId: 'principal-b', subject: '   ' },
+      { principalId: ' principal-c ', subject: ' subject-c ' },
+    ]);
+
+    expect(bySubject.get('subject-a')).toBeUndefined();
+    expect(bySubject.get('subject-c')).toBe('principal-c');
+  });
+
+  it('leaves an unmapped row usable rather than orphaning it', () => {
+    const plan = planMigration([row({ subject: 'subject-unknown' })], mapping);
+
+    expect(plan.rows[0].classification).toBe('missing');
+    expect(plan.rows[0].principalId).toBeNull();
+    expect(applicableChanges(plan)).toEqual([]);
+  });
+});
+
+describe('idempotence', () => {
+  it('has nothing left to do on a second run', () => {
+    const first = planMigration([row()], mapping);
+    expect(applicableChanges(first)).toHaveLength(1);
+
+    const applied = row({ principalId: first.rows[0].principalId });
+    const second = planMigration([applied], mapping);
+
+    expect(second.rows[0].classification).toBe('already-migrated');
+    expect(applicableChanges(second)).toEqual([]);
+  });
+
+  it('resumes a partially applied run without redoing finished rows', () => {
+    const plan = planMigration(
+      [row({ id: 'done', principalId: 'principal-a' }), row({ id: 'pending' })],
+      mapping,
+    );
+
+    expect(applicableChanges(plan).map((item) => item.id)).toEqual(['pending']);
+  });
+});
+
+describe('the report', () => {
+  it('names no subject, principal, or email', () => {
+    const report = formatPlan(
+      planMigration(
+        [row({ principalId: 'principal-other' }), row({ id: 'row-2', model: 'GuestInvitation' })],
+        mapping,
+      ),
+    );
+
+    expect(report).not.toContain('subject-a');
+    expect(report).not.toContain('principal-a');
+    expect(report).not.toContain('principal-other');
+    expect(report).not.toMatch(/@/);
+    expect(report).toContain('conflicting: 1');
+    expect(report).toContain('GuestInvitation.createdByIdentity');
+  });
+});
+
+describe('reads during the migration window', () => {
+  it('matches a migrated row by canonical principal, across pools', () => {
+    const migrated = { principalId: 'principal-a', subject: 'subject-a' };
+
+    expect(ownsRow(migrated, { principalId: 'principal-a', subject: 'subject-b' })).toBe(true);
+    expect(ownsRow(migrated, { principalId: 'principal-b', subject: 'subject-a' })).toBe(false);
+    // The pool subject alone no longer opens a migrated row.
+    expect(ownsRow(migrated, { principalId: null, subject: 'subject-a' })).toBe(false);
+  });
+
+  it('matches an unmigrated row by its pool subject', () => {
+    const legacy = { principalId: null, subject: 'subject-a' };
+
+    expect(ownsRow(legacy, { principalId: 'principal-a', subject: 'subject-a' })).toBe(true);
+    expect(ownsRow(legacy, { principalId: null, subject: 'subject-a' })).toBe(true);
+    expect(ownsRow(legacy, { principalId: 'principal-a', subject: 'subject-z' })).toBe(false);
+  });
+
+  it('never falls through to another person when no principal is resolved', () => {
+    expect(ownsRow({ principalId: null, subject: 'subject-a' }, { principalId: null, subject: 'subject-z' })).toBe(false);
+    expect(ownsRow({ principalId: null, subject: null }, { principalId: null, subject: 'subject-a' })).toBe(false);
+  });
+});
+
+describe('the mapping file', () => {
+  const { readMappingFile } = require('./principals-cli') as typeof import('./principals-cli');
+  const { writeFileSync, mkdtempSync } = require('node:fs');
+  const { join } = require('node:path');
+  const { tmpdir } = require('node:os');
+
+  const write = (contents: unknown) => {
+    const path = join(mkdtempSync(join(tmpdir(), 'principals-')), 'mapping.json');
+    writeFileSync(path, JSON.stringify(contents));
+    return path;
+  };
+
+  it('accepts verified subject-to-principal pairs', () => {
+    expect(readMappingFile(write([{ principalId: 'principal-a', subject: 'subject-a' }]))).toEqual([
+      { principalId: 'principal-a', subject: 'subject-a' },
+    ]);
+  });
+
+  it('refuses an entry carrying an email, so identities cannot be joined by one', () => {
+    expect(() =>
+      readMappingFile(write([
+        { email: 'person@example.com', principalId: 'principal-a', subject: 'subject-a' },
+      ])),
+    ).toThrow(/never from an email address/);
+  });
+
+  it('refuses a malformed file rather than importing a partial mapping', () => {
+    expect(() => readMappingFile(write({ subject: 'subject-a' }))).toThrow(/JSON array/);
+    expect(() => readMappingFile(write([{ subject: 'subject-a' }]))).toThrow(/principalId/);
+    expect(() => readMappingFile(write(['subject-a']))).toThrow(/not an object/);
+  });
+});

--- a/backend/src/identity/principals.spec.ts
+++ b/backend/src/identity/principals.spec.ts
@@ -1,7 +1,3 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { readMappingFile } from './principals-cli';
 import {
   applicableChanges,
   formatPlan,
@@ -255,50 +251,5 @@ describe('reads during the migration window', () => {
         { principalId: null, subject: 'subject-a' },
       ),
     ).toBe(false);
-  });
-});
-
-describe('the mapping file', () => {
-  const write = (contents: unknown) => {
-    const path = join(
-      mkdtempSync(join(tmpdir(), 'principals-')),
-      'mapping.json',
-    );
-    writeFileSync(path, JSON.stringify(contents));
-    return path;
-  };
-
-  it('accepts verified subject-to-principal pairs', () => {
-    expect(
-      readMappingFile(
-        write([{ principalId: 'principal-a', subject: 'subject-a' }]),
-      ),
-    ).toEqual([{ principalId: 'principal-a', subject: 'subject-a' }]);
-  });
-
-  it('refuses an entry carrying an email, so identities cannot be joined by one', () => {
-    expect(() =>
-      readMappingFile(
-        write([
-          {
-            email: 'person@example.com',
-            principalId: 'principal-a',
-            subject: 'subject-a',
-          },
-        ]),
-      ),
-    ).toThrow(/never from an email address/);
-  });
-
-  it('refuses a malformed file rather than importing a partial mapping', () => {
-    expect(() => readMappingFile(write({ subject: 'subject-a' }))).toThrow(
-      /JSON array/,
-    );
-    expect(() => readMappingFile(write([{ subject: 'subject-a' }]))).toThrow(
-      /principalId/,
-    );
-    expect(() => readMappingFile(write(['subject-a']))).toThrow(
-      /not an object/,
-    );
   });
 });

--- a/backend/src/identity/principals.spec.ts
+++ b/backend/src/identity/principals.spec.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readMappingFile } from './principals-cli';
 import {
   applicableChanges,
   formatPlan,
@@ -23,12 +27,19 @@ describe('subject inventory', () => {
   it('accounts for every subject-bearing field in the schema', () => {
     // Kept in step with prisma/schema.prisma by hand; a new subject column that
     // is not listed here would silently escape both the report and the apply.
-    expect(SUBJECT_BEARING_FIELDS.map((field) => `${field.model}.${field.subjectColumn}`)).toEqual([
+    expect(
+      SUBJECT_BEARING_FIELDS.map(
+        (field) => `${field.model}.${field.subjectColumn}`,
+      ),
+    ).toEqual([
       'OperatorPreference.subject',
       'SharedConsoleLayout.ownerSubject',
       'GuestInvitation.createdByIdentity',
+      'GuestEvent.details.operatorIdentity',
     ]);
-    expect(SUBJECT_BEARING_FIELDS.filter((field) => field.kind === 'audit')).toHaveLength(1);
+    expect(
+      SUBJECT_BEARING_FIELDS.filter((field) => field.kind === 'audit'),
+    ).toHaveLength(2);
   });
 });
 
@@ -50,6 +61,7 @@ describe('dry run', () => {
       missing: 1,
       conflicting: 0,
       ambiguous: 0,
+      colliding: 0,
       orphan: 1,
     });
     expect(plan.rows).toHaveLength(4);
@@ -57,7 +69,10 @@ describe('dry run', () => {
   });
 
   it('reports a row that already names a different principal and never overwrites it', () => {
-    const plan = planMigration([row({ principalId: 'principal-other' })], mapping);
+    const plan = planMigration(
+      [row({ principalId: 'principal-other' })],
+      mapping,
+    );
 
     expect(plan.rows[0].classification).toBe('conflicting');
     expect(plan.rows[0].principalId).toBe('principal-other');
@@ -99,6 +114,58 @@ describe('dry run', () => {
     expect(plan.rows[0].principalId).toBeNull();
     expect(applicableChanges(plan)).toEqual([]);
   });
+
+  it('reports rows that would collide on one canonical device profile', () => {
+    const plan = planMigration(
+      [
+        row({
+          collisionScope: 'desktop',
+          id: 'preference-a',
+          model: 'OperatorPreference',
+          subject: 'subject-a',
+        }),
+        row({
+          collisionScope: 'desktop',
+          id: 'preference-b',
+          model: 'OperatorPreference',
+          subject: 'subject-b',
+        }),
+      ],
+      [
+        { principalId: 'principal-a', subject: 'subject-a' },
+        { principalId: 'principal-a', subject: 'subject-b' },
+      ],
+    );
+
+    expect(plan.rows.map((item) => item.classification)).toEqual([
+      'colliding',
+      'colliding',
+    ]);
+    expect(plan.summary.colliding).toBe(2);
+    expect(applicableChanges(plan)).toEqual([]);
+    expect(hasConflicts(plan)).toBe(true);
+  });
+
+  it('does not call distinct device profiles a collision', () => {
+    const plan = planMigration(
+      [
+        row({
+          collisionScope: 'desktop',
+          id: 'preference-a',
+          model: 'OperatorPreference',
+        }),
+        row({
+          collisionScope: 'phone',
+          id: 'preference-b',
+          model: 'OperatorPreference',
+        }),
+      ],
+      mapping,
+    );
+
+    expect(plan.summary.mapped).toBe(2);
+    expect(plan.summary.colliding).toBe(0);
+  });
 });
 
 describe('idempotence', () => {
@@ -127,7 +194,10 @@ describe('the report', () => {
   it('names no subject, principal, or email', () => {
     const report = formatPlan(
       planMigration(
-        [row({ principalId: 'principal-other' }), row({ id: 'row-2', model: 'GuestInvitation' })],
+        [
+          row({ id: 'subject-a::desktop', principalId: 'principal-other' }),
+          row({ id: 'row-2', model: 'GuestInvitation' }),
+        ],
         mapping,
       ),
     );
@@ -135,6 +205,7 @@ describe('the report', () => {
     expect(report).not.toContain('subject-a');
     expect(report).not.toContain('principal-a');
     expect(report).not.toContain('principal-other');
+    expect(report).not.toContain('subject-a::desktop');
     expect(report).not.toMatch(/@/);
     expect(report).toContain('conflicting: 1');
     expect(report).toContain('GuestInvitation.createdByIdentity');
@@ -145,55 +216,89 @@ describe('reads during the migration window', () => {
   it('matches a migrated row by canonical principal, across pools', () => {
     const migrated = { principalId: 'principal-a', subject: 'subject-a' };
 
-    expect(ownsRow(migrated, { principalId: 'principal-a', subject: 'subject-b' })).toBe(true);
-    expect(ownsRow(migrated, { principalId: 'principal-b', subject: 'subject-a' })).toBe(false);
+    expect(
+      ownsRow(migrated, { principalId: 'principal-a', subject: 'subject-b' }),
+    ).toBe(true);
+    expect(
+      ownsRow(migrated, { principalId: 'principal-b', subject: 'subject-a' }),
+    ).toBe(false);
     // The pool subject alone no longer opens a migrated row.
-    expect(ownsRow(migrated, { principalId: null, subject: 'subject-a' })).toBe(false);
+    expect(ownsRow(migrated, { principalId: null, subject: 'subject-a' })).toBe(
+      false,
+    );
   });
 
   it('matches an unmigrated row by its pool subject', () => {
     const legacy = { principalId: null, subject: 'subject-a' };
 
-    expect(ownsRow(legacy, { principalId: 'principal-a', subject: 'subject-a' })).toBe(true);
-    expect(ownsRow(legacy, { principalId: null, subject: 'subject-a' })).toBe(true);
-    expect(ownsRow(legacy, { principalId: 'principal-a', subject: 'subject-z' })).toBe(false);
+    expect(
+      ownsRow(legacy, { principalId: 'principal-a', subject: 'subject-a' }),
+    ).toBe(true);
+    expect(ownsRow(legacy, { principalId: null, subject: 'subject-a' })).toBe(
+      true,
+    );
+    expect(
+      ownsRow(legacy, { principalId: 'principal-a', subject: 'subject-z' }),
+    ).toBe(false);
   });
 
   it('never falls through to another person when no principal is resolved', () => {
-    expect(ownsRow({ principalId: null, subject: 'subject-a' }, { principalId: null, subject: 'subject-z' })).toBe(false);
-    expect(ownsRow({ principalId: null, subject: null }, { principalId: null, subject: 'subject-a' })).toBe(false);
+    expect(
+      ownsRow(
+        { principalId: null, subject: 'subject-a' },
+        { principalId: null, subject: 'subject-z' },
+      ),
+    ).toBe(false);
+    expect(
+      ownsRow(
+        { principalId: null, subject: null },
+        { principalId: null, subject: 'subject-a' },
+      ),
+    ).toBe(false);
   });
 });
 
 describe('the mapping file', () => {
-  const { readMappingFile } = require('./principals-cli') as typeof import('./principals-cli');
-  const { writeFileSync, mkdtempSync } = require('node:fs');
-  const { join } = require('node:path');
-  const { tmpdir } = require('node:os');
-
   const write = (contents: unknown) => {
-    const path = join(mkdtempSync(join(tmpdir(), 'principals-')), 'mapping.json');
+    const path = join(
+      mkdtempSync(join(tmpdir(), 'principals-')),
+      'mapping.json',
+    );
     writeFileSync(path, JSON.stringify(contents));
     return path;
   };
 
   it('accepts verified subject-to-principal pairs', () => {
-    expect(readMappingFile(write([{ principalId: 'principal-a', subject: 'subject-a' }]))).toEqual([
-      { principalId: 'principal-a', subject: 'subject-a' },
-    ]);
+    expect(
+      readMappingFile(
+        write([{ principalId: 'principal-a', subject: 'subject-a' }]),
+      ),
+    ).toEqual([{ principalId: 'principal-a', subject: 'subject-a' }]);
   });
 
   it('refuses an entry carrying an email, so identities cannot be joined by one', () => {
     expect(() =>
-      readMappingFile(write([
-        { email: 'person@example.com', principalId: 'principal-a', subject: 'subject-a' },
-      ])),
+      readMappingFile(
+        write([
+          {
+            email: 'person@example.com',
+            principalId: 'principal-a',
+            subject: 'subject-a',
+          },
+        ]),
+      ),
     ).toThrow(/never from an email address/);
   });
 
   it('refuses a malformed file rather than importing a partial mapping', () => {
-    expect(() => readMappingFile(write({ subject: 'subject-a' }))).toThrow(/JSON array/);
-    expect(() => readMappingFile(write([{ subject: 'subject-a' }]))).toThrow(/principalId/);
-    expect(() => readMappingFile(write(['subject-a']))).toThrow(/not an object/);
+    expect(() => readMappingFile(write({ subject: 'subject-a' }))).toThrow(
+      /JSON array/,
+    );
+    expect(() => readMappingFile(write([{ subject: 'subject-a' }]))).toThrow(
+      /principalId/,
+    );
+    expect(() => readMappingFile(write(['subject-a']))).toThrow(
+      /not an object/,
+    );
   });
 });

--- a/backend/src/identity/principals.ts
+++ b/backend/src/identity/principals.ts
@@ -27,6 +27,12 @@ export type SubjectMapping = {
   principalId: string;
 };
 
+/** The backward-compatible identity Alcantara receives from Pompeii. */
+export type CanonicalIdentity = {
+  subject: string;
+  principalId: string | null;
+};
+
 /** Every table and column in Alcantara that carries a pool-local subject. */
 export const SUBJECT_BEARING_FIELDS = [
   {
@@ -47,6 +53,12 @@ export const SUBJECT_BEARING_FIELDS = [
     model: 'GuestInvitation',
     subjectColumn: 'createdByIdentity',
   },
+  {
+    canonicalColumn: 'details.operatorPrincipalId',
+    kind: 'audit',
+    model: 'GuestEvent',
+    subjectColumn: 'details.operatorIdentity',
+  },
 ] as const;
 
 export type SubjectBearingField = (typeof SUBJECT_BEARING_FIELDS)[number];
@@ -62,6 +74,8 @@ export type RowClassification =
   | 'conflicting'
   /** The subject appears in the mapping more than once, with different principals. */
   | 'ambiguous'
+  /** Multiple owned rows would converge on one principal-specific key. */
+  | 'colliding'
   /** The row carries no subject at all. */
   | 'orphan';
 
@@ -72,6 +86,11 @@ export type IdentityRow = {
   model: SubjectBearingField['model'];
   principalId: string | null;
   subject: string | null;
+  /**
+   * The model-local uniqueness suffix used to detect ownership collisions.
+   * Operator preferences use their device class; non-unique models omit it.
+   */
+  collisionScope?: string;
 };
 
 export type PlanRow = {
@@ -93,6 +112,7 @@ const CLASSIFICATIONS: readonly RowClassification[] = [
   'missing',
   'conflicting',
   'ambiguous',
+  'colliding',
   'orphan',
 ];
 
@@ -134,15 +154,27 @@ function classify(
     return { ...base, classification: 'orphan', principalId: row.principalId };
   }
   if (ambiguous.has(subject)) {
-    return { ...base, classification: 'ambiguous', principalId: row.principalId };
+    return {
+      ...base,
+      classification: 'ambiguous',
+      principalId: row.principalId,
+    };
   }
 
   const mapped = bySubject.get(subject) ?? null;
   if (row.principalId) {
     if (mapped && mapped !== row.principalId) {
-      return { ...base, classification: 'conflicting', principalId: row.principalId };
+      return {
+        ...base,
+        classification: 'conflicting',
+        principalId: row.principalId,
+      };
     }
-    return { ...base, classification: 'already-migrated', principalId: row.principalId };
+    return {
+      ...base,
+      classification: 'already-migrated',
+      principalId: row.principalId,
+    };
   }
   if (!mapped) {
     return { ...base, classification: 'missing', principalId: null };
@@ -160,6 +192,36 @@ export function planMigration(
 ): MigrationPlan {
   const { ambiguous, bySubject } = indexMappings(mappings);
   const planned = rows.map((row) => classify(row, bySubject, ambiguous));
+
+  // OperatorPreference remains keyed by the legacy subject during rollout.
+  // Two pool subjects for the same person and device would therefore become
+  // two canonical matches, making reads nondeterministic. Report both rows and
+  // refuse to apply either one until an operator reconciles them explicitly.
+  const collisionGroups = new Map<string, number[]>();
+  rows.forEach((row, index) => {
+    if (row.model !== 'OperatorPreference' || !row.collisionScope) return;
+    const principalId = planned[index].principalId;
+    if (!principalId) return;
+    const key = `${principalId}\u0000${row.collisionScope}`;
+    const group = collisionGroups.get(key) ?? [];
+    group.push(index);
+    collisionGroups.set(key, group);
+  });
+  for (const group of collisionGroups.values()) {
+    if (group.length < 2) continue;
+    for (const index of group) {
+      if (
+        planned[index].classification !== 'ambiguous' &&
+        planned[index].classification !== 'conflicting'
+      ) {
+        planned[index] = {
+          ...planned[index],
+          classification: 'colliding',
+        };
+      }
+    }
+  }
+
   const summary = Object.fromEntries(
     CLASSIFICATIONS.map((key) => [key, 0]),
   ) as Record<RowClassification, number>;
@@ -174,12 +236,16 @@ export function applicableChanges(plan: MigrationPlan): PlanRow[] {
 
 /** True when the plan contains anything a person must resolve before applying. */
 export function hasConflicts(plan: MigrationPlan): boolean {
-  return plan.summary.conflicting > 0 || plan.summary.ambiguous > 0;
+  return (
+    plan.summary.conflicting > 0 ||
+    plan.summary.ambiguous > 0 ||
+    plan.summary.colliding > 0
+  );
 }
 
 /**
- * A human-readable dry-run report. It contains counts and opaque row ids only —
- * never a subject, a principal, or an email.
+ * A human-readable dry-run report. It contains counts only — never a subject,
+ * principal, email, mapping value, or record identifier.
  */
 export function formatPlan(plan: MigrationPlan): string {
   const lines = ['Canonical principal migration — dry run', ''];
@@ -194,15 +260,19 @@ export function formatPlan(plan: MigrationPlan): string {
     }
   }
   lines.push('', 'Totals:');
-  for (const key of CLASSIFICATIONS) lines.push(`  ${key}: ${plan.summary[key]}`);
+  for (const key of CLASSIFICATIONS)
+    lines.push(`  ${key}: ${plan.summary[key]}`);
   if (plan.ambiguousSubjects > 0) {
-    lines.push('', `${plan.ambiguousSubjects} subject(s) map to more than one principal and are skipped.`);
+    lines.push(
+      '',
+      `${plan.ambiguousSubjects} subject(s) map to more than one principal and are skipped.`,
+    );
   }
   if (hasConflicts(plan)) {
-    lines.push('', 'Conflicts found. Nothing is rewritten automatically; resolve them first.');
-    for (const row of plan.rows.filter((item) => item.classification === 'conflicting')) {
-      lines.push(`  ${row.model} ${row.id} already names a different principal`);
-    }
+    lines.push(
+      '',
+      'Conflicts found. Nothing is rewritten automatically; resolve them first.',
+    );
   }
   return lines.join('\n');
 }
@@ -228,7 +298,9 @@ export function ownsRow(
   identity: { principalId: string | null; subject: string },
 ): boolean {
   if (row.principalId) {
-    return identity.principalId !== null && row.principalId === identity.principalId;
+    return (
+      identity.principalId !== null && row.principalId === identity.principalId
+    );
   }
   return row.subject === identity.subject;
 }

--- a/backend/src/identity/principals.ts
+++ b/backend/src/identity/principals.ts
@@ -1,0 +1,234 @@
+/**
+ * Migrating pool-local subject references to canonical Pompeii principals.
+ *
+ * A Cognito pool subject is not portable: the same operator signing in through
+ * a different pool gets a different subject, so their preferences, their shared
+ * layouts, and their audit trail all fragment. Pompeii issues a canonical
+ * `principal_id` that is stable for that person across pools.
+ *
+ * Three rules shape this module:
+ *
+ * 1. **Never join identities by email.** The only accepted input is a
+ *    subject-to-principal mapping Pompeii has verified. Nothing here can derive
+ *    one, deliberately.
+ * 2. **No ownership row changes without a verified mapping.** An unmapped row
+ *    stays exactly as it is and stays usable.
+ * 3. **Audit attribution is never rewritten.** `GuestInvitation.createdByIdentity`
+ *    keeps its original value forever; the canonical principal is recorded
+ *    beside it, so a historical actor still displays even when no mapping
+ *    exists and no link is fabricated.
+ *
+ * Everything is pure; the caller owns the database.
+ */
+
+/** A subject-to-principal pair Pompeii has verified. */
+export type SubjectMapping = {
+  subject: string;
+  principalId: string;
+};
+
+/** Every table and column in Alcantara that carries a pool-local subject. */
+export const SUBJECT_BEARING_FIELDS = [
+  {
+    canonicalColumn: 'principalId',
+    kind: 'ownership',
+    model: 'OperatorPreference',
+    subjectColumn: 'subject',
+  },
+  {
+    canonicalColumn: 'ownerPrincipalId',
+    kind: 'ownership',
+    model: 'SharedConsoleLayout',
+    subjectColumn: 'ownerSubject',
+  },
+  {
+    canonicalColumn: 'createdByPrincipalId',
+    kind: 'audit',
+    model: 'GuestInvitation',
+    subjectColumn: 'createdByIdentity',
+  },
+] as const;
+
+export type SubjectBearingField = (typeof SUBJECT_BEARING_FIELDS)[number];
+
+export type RowClassification =
+  /** A verified mapping exists and the row can move. */
+  | 'mapped'
+  /** Already carries the canonical principal the mapping names. */
+  | 'already-migrated'
+  /** No mapping was supplied for this subject. The row stays usable as-is. */
+  | 'missing'
+  /** The row already names a *different* principal. Never overwritten. */
+  | 'conflicting'
+  /** The subject appears in the mapping more than once, with different principals. */
+  | 'ambiguous'
+  /** The row carries no subject at all. */
+  | 'orphan';
+
+/** One row of any subject-bearing model, reduced to what the plan needs. */
+export type IdentityRow = {
+  /** Opaque row identity for the report. Never an operator identifier. */
+  id: string;
+  model: SubjectBearingField['model'];
+  principalId: string | null;
+  subject: string | null;
+};
+
+export type PlanRow = {
+  classification: RowClassification;
+  id: string;
+  model: SubjectBearingField['model'];
+  principalId: string | null;
+};
+
+export type MigrationPlan = {
+  ambiguousSubjects: number;
+  rows: PlanRow[];
+  summary: Record<RowClassification, number>;
+};
+
+const CLASSIFICATIONS: readonly RowClassification[] = [
+  'mapped',
+  'already-migrated',
+  'missing',
+  'conflicting',
+  'ambiguous',
+  'orphan',
+];
+
+/**
+ * Collapses a mapping list, reporting any subject claimed by more than one
+ * principal. An ambiguous subject is never applied: choosing between two
+ * candidate principals is a human decision.
+ */
+export function indexMappings(mappings: readonly SubjectMapping[]): {
+  ambiguous: Set<string>;
+  bySubject: Map<string, string>;
+} {
+  const bySubject = new Map<string, string>();
+  const ambiguous = new Set<string>();
+  for (const mapping of mappings) {
+    const subject = mapping.subject?.trim();
+    const principalId = mapping.principalId?.trim();
+    if (!subject || !principalId) continue;
+    const existing = bySubject.get(subject);
+    if (existing && existing !== principalId) {
+      ambiguous.add(subject);
+      continue;
+    }
+    bySubject.set(subject, principalId);
+  }
+  for (const subject of ambiguous) bySubject.delete(subject);
+  return { ambiguous, bySubject };
+}
+
+function classify(
+  row: IdentityRow,
+  bySubject: Map<string, string>,
+  ambiguous: Set<string>,
+): PlanRow {
+  const subject = row.subject?.trim() ?? '';
+  const base = { id: row.id, model: row.model };
+
+  if (!subject) {
+    return { ...base, classification: 'orphan', principalId: row.principalId };
+  }
+  if (ambiguous.has(subject)) {
+    return { ...base, classification: 'ambiguous', principalId: row.principalId };
+  }
+
+  const mapped = bySubject.get(subject) ?? null;
+  if (row.principalId) {
+    if (mapped && mapped !== row.principalId) {
+      return { ...base, classification: 'conflicting', principalId: row.principalId };
+    }
+    return { ...base, classification: 'already-migrated', principalId: row.principalId };
+  }
+  if (!mapped) {
+    return { ...base, classification: 'missing', principalId: null };
+  }
+  return { ...base, classification: 'mapped', principalId: mapped };
+}
+
+/**
+ * Classifies every subject-bearing row against a verified mapping without
+ * changing anything. This is the dry run.
+ */
+export function planMigration(
+  rows: readonly IdentityRow[],
+  mappings: readonly SubjectMapping[],
+): MigrationPlan {
+  const { ambiguous, bySubject } = indexMappings(mappings);
+  const planned = rows.map((row) => classify(row, bySubject, ambiguous));
+  const summary = Object.fromEntries(
+    CLASSIFICATIONS.map((key) => [key, 0]),
+  ) as Record<RowClassification, number>;
+  for (const row of planned) summary[row.classification] += 1;
+  return { ambiguousSubjects: ambiguous.size, rows: planned, summary };
+}
+
+/** The rows a migration may write: only what the dry run classified `mapped`. */
+export function applicableChanges(plan: MigrationPlan): PlanRow[] {
+  return plan.rows.filter((row) => row.classification === 'mapped');
+}
+
+/** True when the plan contains anything a person must resolve before applying. */
+export function hasConflicts(plan: MigrationPlan): boolean {
+  return plan.summary.conflicting > 0 || plan.summary.ambiguous > 0;
+}
+
+/**
+ * A human-readable dry-run report. It contains counts and opaque row ids only —
+ * never a subject, a principal, or an email.
+ */
+export function formatPlan(plan: MigrationPlan): string {
+  const lines = ['Canonical principal migration — dry run', ''];
+  for (const field of SUBJECT_BEARING_FIELDS) {
+    const rows = plan.rows.filter((row) => row.model === field.model);
+    lines.push(
+      `${field.model}.${field.subjectColumn} -> ${field.canonicalColumn} (${field.kind}): ${rows.length} rows`,
+    );
+    for (const key of CLASSIFICATIONS) {
+      const count = rows.filter((row) => row.classification === key).length;
+      if (count > 0) lines.push(`  ${key}: ${count}`);
+    }
+  }
+  lines.push('', 'Totals:');
+  for (const key of CLASSIFICATIONS) lines.push(`  ${key}: ${plan.summary[key]}`);
+  if (plan.ambiguousSubjects > 0) {
+    lines.push('', `${plan.ambiguousSubjects} subject(s) map to more than one principal and are skipped.`);
+  }
+  if (hasConflicts(plan)) {
+    lines.push('', 'Conflicts found. Nothing is rewritten automatically; resolve them first.');
+    for (const row of plan.rows.filter((item) => item.classification === 'conflicting')) {
+      lines.push(`  ${row.model} ${row.id} already names a different principal`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Resolves which identity a read should use.
+ *
+ * A caller with a canonical principal reads migrated rows by principal and
+ * unmigrated rows by subject, so both remain reachable during the migration
+ * window. A caller without one reads by subject only — it must never fall
+ * through to another person's rows.
+ */
+export function identityFilters(identity: {
+  principalId: string | null;
+  subject: string;
+}): { principalId: string | null; subject: string } {
+  return { principalId: identity.principalId, subject: identity.subject };
+}
+
+/** Whether a stored row belongs to the caller, under either identity. */
+export function ownsRow(
+  row: { principalId: string | null; subject: string | null },
+  identity: { principalId: string | null; subject: string },
+): boolean {
+  if (row.principalId) {
+    return identity.principalId !== null && row.principalId === identity.principalId;
+  }
+  return row.subject === identity.subject;
+}

--- a/backend/src/operator-preferences/operator-preferences.controller.spec.ts
+++ b/backend/src/operator-preferences/operator-preferences.controller.spec.ts
@@ -1,0 +1,42 @@
+import { OperatorPreferencesController } from './operator-preferences.controller';
+
+describe('OperatorPreferencesController canonical identity boundary', () => {
+  const authorization = {
+    permissions: ['alcantara:access'],
+    teamId: 1,
+  };
+  const request = {
+    user: {
+      authorization,
+      principalId: 'principal-a',
+      sub: 'pool-subject-a',
+    },
+  };
+  const preferences = {
+    get: jest.fn(),
+    publish: jest.fn(),
+  };
+  const controller = new OperatorPreferencesController(preferences as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('passes both identities to private preference reads', async () => {
+    await controller.get('desktop', request);
+
+    expect(preferences.get).toHaveBeenCalledWith(
+      { principalId: 'principal-a', subject: 'pool-subject-a' },
+      'desktop',
+    );
+  });
+
+  it('passes both identities to shared-layout writes', async () => {
+    const body = { name: 'Fixture' };
+    await controller.publish(body, request);
+
+    expect(preferences.publish).toHaveBeenCalledWith(
+      { principalId: 'principal-a', subject: 'pool-subject-a' },
+      body,
+      authorization,
+    );
+  });
+});

--- a/backend/src/operator-preferences/operator-preferences.controller.ts
+++ b/backend/src/operator-preferences/operator-preferences.controller.ts
@@ -11,14 +11,26 @@ import {
 } from '@nestjs/common';
 import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
 import { RequirePermission } from '../auth/require-permission.decorator';
+import type { CanonicalIdentity } from '../identity/principals';
 import {
   OperatorPreferencesService,
   type OperatorAuthorization,
 } from './operator-preferences.service';
 
 type AuthorizedRequest = {
-  user: { sub: string; authorization: OperatorAuthorization };
+  user: {
+    sub: string;
+    principalId: string | null;
+    authorization: OperatorAuthorization;
+  };
 };
+
+function identityFrom(request: AuthorizedRequest): CanonicalIdentity {
+  return {
+    subject: request.user.sub,
+    principalId: request.user.principalId,
+  };
+}
 
 @Controller('operator-preferences')
 @RequirePermission(ALCANTARA_PERMISSIONS.access)
@@ -45,7 +57,7 @@ export class OperatorPreferencesController {
     @Req() request: AuthorizedRequest,
   ) {
     return this.preferences.publish(
-      request.user.sub,
+      identityFrom(request),
       body,
       request.user.authorization,
     );
@@ -58,7 +70,7 @@ export class OperatorPreferencesController {
     @Req() request: AuthorizedRequest,
   ) {
     return this.preferences.load(
-      request.user.sub,
+      identityFrom(request),
       id,
       body,
       request.user.authorization,
@@ -76,7 +88,7 @@ export class OperatorPreferencesController {
     @Param('deviceClass') deviceClass: string,
     @Req() request: AuthorizedRequest,
   ) {
-    return this.preferences.get(request.user.sub, deviceClass);
+    return this.preferences.get(identityFrom(request), deviceClass);
   }
 
   @Put(':deviceClass')
@@ -85,7 +97,7 @@ export class OperatorPreferencesController {
     @Body() body: { version?: unknown; profile?: unknown },
     @Req() request: AuthorizedRequest,
   ) {
-    return this.preferences.save(request.user.sub, deviceClass, body);
+    return this.preferences.save(identityFrom(request), deviceClass, body);
   }
 
   @Delete(':deviceClass')
@@ -93,11 +105,11 @@ export class OperatorPreferencesController {
     @Param('deviceClass') deviceClass: string,
     @Req() request: AuthorizedRequest,
   ) {
-    return this.preferences.reset(request.user.sub, deviceClass);
+    return this.preferences.reset(identityFrom(request), deviceClass);
   }
 
   @Delete()
   resetAll(@Req() request: AuthorizedRequest) {
-    return this.preferences.reset(request.user.sub);
+    return this.preferences.reset(identityFrom(request));
   }
 }

--- a/backend/src/operator-preferences/operator-preferences.service.spec.ts
+++ b/backend/src/operator-preferences/operator-preferences.service.spec.ts
@@ -43,7 +43,7 @@ describe('OperatorPreferencesService authorization boundaries', () => {
     });
   });
 
-  it('prefers one canonical match across pools', async () => {
+  it('finds one canonical match while also checking the current subject', async () => {
     const migrated = {
       deviceClass: 'desktop',
       principalId: 'principal-a',
@@ -61,7 +61,13 @@ describe('OperatorPreferencesService authorization boundaries', () => {
     expect(prisma.operatorPreference.findMany).toHaveBeenCalledWith({
       orderBy: { updatedAt: 'desc' },
       take: 2,
-      where: { deviceClass: 'desktop', principalId: 'principal-a' },
+      where: {
+        deviceClass: 'desktop',
+        OR: [
+          { principalId: 'principal-a' },
+          { subject: 'subject-from-second-pool' },
+        ],
+      },
     });
     expect(prisma.operatorPreference.findUnique).not.toHaveBeenCalled();
   });
@@ -72,12 +78,12 @@ describe('OperatorPreferencesService authorization boundaries', () => {
       'desktop',
     );
 
-    expect(prisma.operatorPreference.findUnique).toHaveBeenCalledWith({
+    expect(prisma.operatorPreference.findMany).toHaveBeenCalledWith({
+      orderBy: { updatedAt: 'desc' },
+      take: 2,
       where: {
-        subject_deviceClass: {
-          subject: 'subject-a',
-          deviceClass: 'desktop',
-        },
+        deviceClass: 'desktop',
+        OR: [{ principalId: 'principal-a' }, { subject: 'subject-a' }],
       },
     });
   });
@@ -94,6 +100,41 @@ describe('OperatorPreferencesService authorization boundaries', () => {
         'desktop',
       ),
     ).rejects.toBeInstanceOf(ConflictException);
+    expect(metrics.recordPreference).toHaveBeenCalledWith('read', 'conflict');
+  });
+
+  it('fails when a canonical row and the current subjects legacy row converge', async () => {
+    prisma.operatorPreference.findMany.mockResolvedValue([
+      {
+        deviceClass: 'desktop',
+        principalId: 'principal-a',
+        subject: 'subject-from-first-pool',
+      },
+      {
+        deviceClass: 'desktop',
+        principalId: null,
+        subject: 'subject-from-second-pool',
+      },
+    ]);
+
+    await expect(
+      service.get(
+        { principalId: 'principal-a', subject: 'subject-from-second-pool' },
+        'desktop',
+      ),
+    ).rejects.toThrow('CANONICAL_IDENTITY_COLLISION');
+
+    expect(prisma.operatorPreference.findMany).toHaveBeenCalledWith({
+      orderBy: { updatedAt: 'desc' },
+      take: 2,
+      where: {
+        deviceClass: 'desktop',
+        OR: [
+          { principalId: 'principal-a' },
+          { subject: 'subject-from-second-pool' },
+        ],
+      },
+    });
     expect(metrics.recordPreference).toHaveBeenCalledWith('read', 'conflict');
   });
 

--- a/backend/src/operator-preferences/operator-preferences.service.spec.ts
+++ b/backend/src/operator-preferences/operator-preferences.service.spec.ts
@@ -3,8 +3,20 @@ import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
 import { OperatorPreferencesService } from './operator-preferences.service';
 
 describe('OperatorPreferencesService authorization boundaries', () => {
-  const prisma = {
+  const transaction = {
     operatorPreference: {
+      create: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  };
+  const prisma = {
+    $transaction: jest.fn(
+      async (callback: (value: typeof transaction) => Promise<unknown>) =>
+        callback(transaction),
+    ),
+    operatorPreference: {
+      deleteMany: jest.fn(),
       findMany: jest.fn(),
       findUnique: jest.fn(),
     },
@@ -26,6 +38,9 @@ describe('OperatorPreferencesService authorization boundaries', () => {
     jest.clearAllMocks();
     prisma.operatorPreference.findMany.mockResolvedValue([]);
     prisma.operatorPreference.findUnique.mockResolvedValue(null);
+    prisma.operatorPreference.deleteMany.mockResolvedValue({ count: 0 });
+    transaction.operatorPreference.updateMany.mockResolvedValue({ count: 1 });
+    transaction.operatorPreference.findUniqueOrThrow.mockResolvedValue({});
   });
 
   it('always scopes private profile reads to the authenticated subject and class', async () => {
@@ -33,12 +48,12 @@ describe('OperatorPreferencesService authorization boundaries', () => {
 
     await service.get({ principalId: null, subject: 'subject-a' }, 'desktop');
 
-    expect(prisma.operatorPreference.findUnique).toHaveBeenCalledWith({
+    expect(prisma.operatorPreference.findMany).toHaveBeenCalledWith({
+      orderBy: { updatedAt: 'desc' },
+      take: 2,
       where: {
-        subject_deviceClass: {
-          subject: 'subject-a',
-          deviceClass: 'desktop',
-        },
+        deviceClass: 'desktop',
+        OR: [{ principalId: null, subject: 'subject-a' }],
       },
     });
   });
@@ -65,7 +80,7 @@ describe('OperatorPreferencesService authorization boundaries', () => {
         deviceClass: 'desktop',
         OR: [
           { principalId: 'principal-a' },
-          { subject: 'subject-from-second-pool' },
+          { principalId: null, subject: 'subject-from-second-pool' },
         ],
       },
     });
@@ -83,7 +98,10 @@ describe('OperatorPreferencesService authorization boundaries', () => {
       take: 2,
       where: {
         deviceClass: 'desktop',
-        OR: [{ principalId: 'principal-a' }, { subject: 'subject-a' }],
+        OR: [
+          { principalId: 'principal-a' },
+          { principalId: null, subject: 'subject-a' },
+        ],
       },
     });
   });
@@ -131,11 +149,85 @@ describe('OperatorPreferencesService authorization boundaries', () => {
         deviceClass: 'desktop',
         OR: [
           { principalId: 'principal-a' },
-          { subject: 'subject-from-second-pool' },
+          { principalId: null, subject: 'subject-from-second-pool' },
         ],
       },
     });
     expect(metrics.recordPreference).toHaveBeenCalledWith('read', 'conflict');
+  });
+
+  it('does not read a current-subject row owned by another principal', async () => {
+    await expect(
+      service.get(
+        { principalId: 'principal-a', subject: 'shared-pool-subject' },
+        'desktop',
+      ),
+    ).resolves.toMatchObject({
+      subject: 'shared-pool-subject',
+      version: 0,
+    });
+
+    expect(prisma.operatorPreference.findMany).toHaveBeenCalledWith({
+      orderBy: { updatedAt: 'desc' },
+      take: 2,
+      where: {
+        deviceClass: 'desktop',
+        OR: [
+          { principalId: 'principal-a' },
+          { principalId: null, subject: 'shared-pool-subject' },
+        ],
+      },
+    });
+  });
+
+  it('does not update a current-subject row owned by another principal', async () => {
+    transaction.operatorPreference.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      service.save(
+        { principalId: 'principal-a', subject: 'shared-pool-subject' },
+        'desktop',
+        {
+          version: 3,
+          profile: {
+            workspace: 'director',
+            dockWidth: 320,
+            touchMode: false,
+            shortcutsEnabled: true,
+            selectedProgramId: 'main',
+            transitions: { main: 'crescendo-prism' },
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(transaction.operatorPreference.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          subject: 'shared-pool-subject',
+          deviceClass: 'desktop',
+          version: 3,
+          OR: [{ principalId: 'principal-a' }, { principalId: null }],
+        },
+      }),
+    );
+  });
+
+  it('does not reset a current-subject row owned by another principal', async () => {
+    await service.reset(
+      { principalId: 'principal-a', subject: 'shared-pool-subject' },
+      'desktop',
+    );
+
+    expect(prisma.operatorPreference.deleteMany).toHaveBeenCalledWith({
+      where: {
+        deviceClass: 'desktop',
+        OR: [
+          { principalId: 'principal-a' },
+          { principalId: null, subject: 'shared-pool-subject' },
+        ],
+      },
+    });
   });
 
   it('rejects discovery for another team before querying layouts', async () => {

--- a/backend/src/operator-preferences/operator-preferences.service.spec.ts
+++ b/backend/src/operator-preferences/operator-preferences.service.spec.ts
@@ -207,7 +207,50 @@ describe('OperatorPreferencesService authorization boundaries', () => {
           subject: 'shared-pool-subject',
           deviceClass: 'desktop',
           version: 3,
-          OR: [{ principalId: 'principal-a' }, { principalId: null }],
+          principalId: null,
+        },
+      }),
+    );
+  });
+
+  it('does not treat a canonical row that concurrently becomes unowned as a legacy fallback', async () => {
+    prisma.operatorPreference.findMany.mockResolvedValue([
+      {
+        deviceClass: 'desktop',
+        principalId: 'principal-a',
+        subject: 'subject-from-first-pool',
+        version: 3,
+      },
+    ]);
+    // Simulates principal-a changing to null after findPreference selected the
+    // canonical row but before the optimistic update runs.
+    transaction.operatorPreference.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      service.save(
+        { principalId: 'principal-a', subject: 'subject-from-second-pool' },
+        'desktop',
+        {
+          version: 3,
+          profile: {
+            workspace: 'director',
+            dockWidth: 320,
+            touchMode: false,
+            shortcutsEnabled: true,
+            selectedProgramId: 'main',
+            transitions: { main: 'crescendo-prism' },
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(transaction.operatorPreference.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          subject: 'subject-from-first-pool',
+          deviceClass: 'desktop',
+          version: 3,
+          principalId: 'principal-a',
         },
       }),
     );

--- a/backend/src/operator-preferences/operator-preferences.service.spec.ts
+++ b/backend/src/operator-preferences/operator-preferences.service.spec.ts
@@ -1,10 +1,11 @@
-import { ForbiddenException } from '@nestjs/common';
+import { ConflictException, ForbiddenException } from '@nestjs/common';
 import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
 import { OperatorPreferencesService } from './operator-preferences.service';
 
 describe('OperatorPreferencesService authorization boundaries', () => {
   const prisma = {
     operatorPreference: {
+      findMany: jest.fn(),
       findUnique: jest.fn(),
     },
     sharedConsoleLayout: {
@@ -21,12 +22,16 @@ describe('OperatorPreferencesService authorization boundaries', () => {
     metrics as never,
   );
 
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.operatorPreference.findMany.mockResolvedValue([]);
+    prisma.operatorPreference.findUnique.mockResolvedValue(null);
+  });
 
   it('always scopes private profile reads to the authenticated subject and class', async () => {
     prisma.operatorPreference.findUnique.mockResolvedValue(null);
 
-    await service.get('subject-a', 'desktop');
+    await service.get({ principalId: null, subject: 'subject-a' }, 'desktop');
 
     expect(prisma.operatorPreference.findUnique).toHaveBeenCalledWith({
       where: {
@@ -36,6 +41,60 @@ describe('OperatorPreferencesService authorization boundaries', () => {
         },
       },
     });
+  });
+
+  it('prefers one canonical match across pools', async () => {
+    const migrated = {
+      deviceClass: 'desktop',
+      principalId: 'principal-a',
+      subject: 'subject-from-first-pool',
+    };
+    prisma.operatorPreference.findMany.mockResolvedValue([migrated]);
+
+    await expect(
+      service.get(
+        { principalId: 'principal-a', subject: 'subject-from-second-pool' },
+        'desktop',
+      ),
+    ).resolves.toBe(migrated);
+
+    expect(prisma.operatorPreference.findMany).toHaveBeenCalledWith({
+      orderBy: { updatedAt: 'desc' },
+      take: 2,
+      where: { deviceClass: 'desktop', principalId: 'principal-a' },
+    });
+    expect(prisma.operatorPreference.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('falls back only to the current subject while a row is unmigrated', async () => {
+    await service.get(
+      { principalId: 'principal-a', subject: 'subject-a' },
+      'desktop',
+    );
+
+    expect(prisma.operatorPreference.findUnique).toHaveBeenCalledWith({
+      where: {
+        subject_deviceClass: {
+          subject: 'subject-a',
+          deviceClass: 'desktop',
+        },
+      },
+    });
+  });
+
+  it('fails visibly when multiple rows claim one canonical device profile', async () => {
+    prisma.operatorPreference.findMany.mockResolvedValue([
+      { principalId: 'principal-a', subject: 'subject-a' },
+      { principalId: 'principal-a', subject: 'subject-b' },
+    ]);
+
+    await expect(
+      service.get(
+        { principalId: 'principal-a', subject: 'subject-a' },
+        'desktop',
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(metrics.recordPreference).toHaveBeenCalledWith('read', 'conflict');
   });
 
   it('rejects discovery for another team before querying layouts', async () => {
@@ -61,7 +120,7 @@ describe('OperatorPreferencesService authorization boundaries', () => {
   it('rejects direct publication without layout management permission', async () => {
     await expect(
       service.publish(
-        'subject-a',
+        { principalId: null, subject: 'subject-a' },
         {
           name: 'Forbidden layout',
           scope: 'team',

--- a/backend/src/operator-preferences/operator-preferences.service.ts
+++ b/backend/src/operator-preferences/operator-preferences.service.ts
@@ -99,6 +99,14 @@ export class OperatorPreferencesService {
     // different pool subject after a migration.
     const existing = await this.findPreference(identity, deviceClass);
     const subject = existing?.subject ?? identity.subject;
+    // Bind the optimistic write to the ownership mode selected above. A
+    // canonical match must remain owned by that principal; it cannot become an
+    // eligible legacy fallback merely by changing to a null principal between
+    // the read and update. A legacy match remains restricted to the caller's
+    // current subject and a null principal.
+    const selectedOwnership = existing?.principalId
+      ? { principalId: existing.principalId }
+      : { principalId: null, subject: identity.subject };
     const version = integerVersion(body.version);
     const profile = parseProfile(
       body.profile,
@@ -123,12 +131,7 @@ export class OperatorPreferencesService {
             subject,
             deviceClass,
             version,
-            OR: [
-              ...(identity.principalId
-                ? [{ principalId: identity.principalId }]
-                : []),
-              { principalId: null },
-            ],
+            ...selectedOwnership,
           },
           data: {
             profile,

--- a/backend/src/operator-preferences/operator-preferences.service.ts
+++ b/backend/src/operator-preferences/operator-preferences.service.ts
@@ -49,16 +49,22 @@ export class OperatorPreferencesService {
     deviceClass: string,
   ) {
     if (identity.principalId) {
-      const byPrincipal = await this.prisma.operatorPreference.findMany({
+      const candidates = await this.prisma.operatorPreference.findMany({
         orderBy: { updatedAt: 'desc' },
         take: 2,
-        where: { principalId: identity.principalId, deviceClass },
+        where: {
+          deviceClass,
+          OR: [
+            { principalId: identity.principalId },
+            { subject: identity.subject },
+          ],
+        },
       });
-      if (byPrincipal.length > 1) {
+      if (candidates.length > 1) {
         this.metrics.recordPreference('read', 'conflict');
         throw new ConflictException('CANONICAL_IDENTITY_COLLISION');
       }
-      if (byPrincipal[0]) return byPrincipal[0];
+      return candidates[0] ?? null;
     }
     return this.prisma.operatorPreference.findUnique({
       where: {

--- a/backend/src/operator-preferences/operator-preferences.service.ts
+++ b/backend/src/operator-preferences/operator-preferences.service.ts
@@ -39,6 +39,13 @@ export class OperatorPreferencesService {
     };
   }
 
+  private ownedPreferenceWhere(identity: CanonicalIdentity) {
+    return [
+      ...(identity.principalId ? [{ principalId: identity.principalId }] : []),
+      { principalId: null, subject: identity.subject },
+    ];
+  }
+
   /**
    * Finds the row for this operator, preferring the canonical principal so a
    * migrated row is still theirs after they move pools, and falling back to the
@@ -48,29 +55,19 @@ export class OperatorPreferencesService {
     identity: CanonicalIdentity,
     deviceClass: string,
   ) {
-    if (identity.principalId) {
-      const candidates = await this.prisma.operatorPreference.findMany({
-        orderBy: { updatedAt: 'desc' },
-        take: 2,
-        where: {
-          deviceClass,
-          OR: [
-            { principalId: identity.principalId },
-            { subject: identity.subject },
-          ],
-        },
-      });
-      if (candidates.length > 1) {
-        this.metrics.recordPreference('read', 'conflict');
-        throw new ConflictException('CANONICAL_IDENTITY_COLLISION');
-      }
-      return candidates[0] ?? null;
-    }
-    return this.prisma.operatorPreference.findUnique({
+    const candidates = await this.prisma.operatorPreference.findMany({
+      orderBy: { updatedAt: 'desc' },
+      take: 2,
       where: {
-        subject_deviceClass: { subject: identity.subject, deviceClass },
+        deviceClass,
+        OR: this.ownedPreferenceWhere(identity),
       },
     });
+    if (candidates.length > 1) {
+      this.metrics.recordPreference('read', 'conflict');
+      throw new ConflictException('CANONICAL_IDENTITY_COLLISION');
+    }
+    return candidates[0] ?? null;
   }
 
   async get(caller: CanonicalIdentity, rawDeviceClass: string) {
@@ -122,7 +119,17 @@ export class OperatorPreferencesService {
           });
         }
         const updated = await transaction.operatorPreference.updateMany({
-          where: { subject, deviceClass, version },
+          where: {
+            subject,
+            deviceClass,
+            version,
+            OR: [
+              ...(identity.principalId
+                ? [{ principalId: identity.principalId }]
+                : []),
+              { principalId: null },
+            ],
+          },
           data: {
             profile,
             version: { increment: 1 },
@@ -160,11 +167,9 @@ export class OperatorPreferencesService {
 
   async reset(caller: CanonicalIdentity, rawDeviceClass?: string) {
     const identity = this.identity(caller);
-    // Both identities are cleared, so a reset after a pool move does not leave
-    // the operator's migrated row behind.
-    const owned = identity.principalId
-      ? [{ subject: identity.subject }, { principalId: identity.principalId }]
-      : [{ subject: identity.subject }];
+    // Clear the canonical row plus an unmigrated current-subject row. A subject
+    // row already owned by another principal is never this caller's fallback.
+    const owned = this.ownedPreferenceWhere(identity);
     if (rawDeviceClass) {
       const deviceClass = parseDeviceClass(rawDeviceClass);
       await this.prisma.operatorPreference.deleteMany({

--- a/backend/src/operator-preferences/operator-preferences.service.ts
+++ b/backend/src/operator-preferences/operator-preferences.service.ts
@@ -15,6 +15,16 @@ import {
   type DeviceClass,
 } from './operator-preferences.types';
 
+/**
+ * The identity a preference or shared layout is recorded against. The canonical
+ * principal is `null` until Pompeii resolves one, which is the expected state
+ * during rollout.
+ */
+export type OperatorIdentity = {
+  principalId: string | null;
+  subject: string;
+};
+
 export interface OperatorAuthorization {
   permissions: string[];
   teamId: number;
@@ -27,11 +37,41 @@ export class OperatorPreferencesService {
     private readonly metrics: ManagedMetricsService,
   ) {}
 
-  async get(subject: string, rawDeviceClass: string) {
-    const deviceClass = parseDeviceClass(rawDeviceClass);
-    const stored = await this.prisma.operatorPreference.findUnique({
-      where: { subject_deviceClass: { subject, deviceClass } },
+  /**
+   * Normalizes a caller identity. A bare subject means "no canonical principal
+   * is known" — the rollout state for an identity Pompeii has not linked yet —
+   * so accepting a plain string is part of the contract, not shorthand.
+   */
+  private identity(value: string | OperatorIdentity): OperatorIdentity {
+    return typeof value === 'string'
+      ? { subject: value, principalId: null }
+      : { subject: value.subject, principalId: value.principalId?.trim() || null };
+  }
+
+  /**
+   * Finds the row for this operator, preferring the canonical principal so a
+   * migrated row is still theirs after they move pools, and falling back to the
+   * pool subject so an unmigrated row stays reachable.
+   */
+  private async findPreference(identity: OperatorIdentity, deviceClass: string) {
+    if (identity.principalId) {
+      const byPrincipal = await this.prisma.operatorPreference.findFirst({
+        where: { principalId: identity.principalId, deviceClass },
+      });
+      if (byPrincipal) return byPrincipal;
+    }
+    return this.prisma.operatorPreference.findUnique({
+      where: {
+        subject_deviceClass: { subject: identity.subject, deviceClass },
+      },
     });
+  }
+
+  async get(caller: string | OperatorIdentity, rawDeviceClass: string) {
+    const identity = this.identity(caller);
+    const subject = identity.subject;
+    const deviceClass = parseDeviceClass(rawDeviceClass);
+    const stored = await this.findPreference(identity, deviceClass);
     this.metrics.recordPreference('read', stored ? 'success' : 'default');
     return (
       stored ?? {
@@ -46,11 +86,16 @@ export class OperatorPreferencesService {
   }
 
   async save(
-    subject: string,
+    caller: string | OperatorIdentity,
     rawDeviceClass: string,
     body: { version?: unknown; profile?: unknown },
   ) {
+    const identity = this.identity(caller);
     const deviceClass = parseDeviceClass(rawDeviceClass);
+    // Writes target whichever row this operator already owns, which may carry a
+    // different pool subject after a migration.
+    const existing = await this.findPreference(identity, deviceClass);
+    const subject = existing?.subject ?? identity.subject;
     const version = integerVersion(body.version);
     const profile = parseProfile(
       body.profile,
@@ -60,12 +105,27 @@ export class OperatorPreferencesService {
       const saved = await this.prisma.$transaction(async (transaction) => {
         if (version === 0) {
           return transaction.operatorPreference.create({
-            data: { subject, deviceClass, profile },
+            // The canonical principal is recorded only once Pompeii resolved
+            // one; it is never guessed from the subject or an email.
+            data: {
+              subject,
+              principalId: identity.principalId,
+              deviceClass,
+              profile,
+            },
           });
         }
         const updated = await transaction.operatorPreference.updateMany({
           where: { subject, deviceClass, version },
-          data: { profile, version: { increment: 1 } },
+          data: {
+            profile,
+            version: { increment: 1 },
+            // Backfills the canonical principal on an existing row the first
+            // time its owner signs in with one resolved.
+            ...(identity.principalId && !existing?.principalId
+              ? { principalId: identity.principalId }
+              : {}),
+          },
         });
         if (updated.count !== 1)
           throw new ConflictException('PROFILE_VERSION_CONFLICT');
@@ -84,7 +144,7 @@ export class OperatorPreferencesService {
         this.metrics.recordPreference('write', 'conflict');
         throw new ConflictException({
           error: 'PROFILE_VERSION_CONFLICT',
-          authoritative: await this.get(subject, deviceClass),
+          authoritative: await this.get(identity, deviceClass),
         });
       }
       this.metrics.recordPreference('write', 'failure');
@@ -92,16 +152,22 @@ export class OperatorPreferencesService {
     }
   }
 
-  async reset(subject: string, rawDeviceClass?: string) {
+  async reset(caller: string | OperatorIdentity, rawDeviceClass?: string) {
+    const identity = this.identity(caller);
+    // Both identities are cleared, so a reset after a pool move does not leave
+    // the operator's migrated row behind.
+    const owned = identity.principalId
+      ? [{ subject: identity.subject }, { principalId: identity.principalId }]
+      : [{ subject: identity.subject }];
     if (rawDeviceClass) {
       const deviceClass = parseDeviceClass(rawDeviceClass);
       await this.prisma.operatorPreference.deleteMany({
-        where: { subject, deviceClass },
+        where: { OR: owned, deviceClass },
       });
       this.metrics.recordPreference('reset-class', 'success');
       return { deviceClass, version: 0, profile: defaultProfile(deviceClass) };
     }
-    await this.prisma.operatorPreference.deleteMany({ where: { subject } });
+    await this.prisma.operatorPreference.deleteMany({ where: { OR: owned } });
     this.metrics.recordPreference('reset-all', 'success');
     return { ok: true };
   }
@@ -119,10 +185,11 @@ export class OperatorPreferencesService {
   }
 
   async publish(
-    subject: string,
+    caller: string | OperatorIdentity,
     body: Record<string, unknown>,
     authorization: OperatorAuthorization,
   ) {
+    const identity = this.identity(caller);
     const scope = parseScope(body.scope);
     const scopeId = boundedText(body.scopeId, 'scopeId', 128);
     await this.assertScopeAccess(scope, scopeId, authorization, true);
@@ -138,7 +205,8 @@ export class OperatorPreferencesService {
     const saved = await this.prisma.sharedConsoleLayout.upsert({
       where: { scope_scopeId_name: { scope, scopeId, name } },
       create: {
-        ownerSubject: subject,
+        ownerSubject: identity.subject,
+        ownerPrincipalId: identity.principalId,
         name,
         description,
         scope,
@@ -147,7 +215,8 @@ export class OperatorPreferencesService {
         profile,
       },
       update: {
-        ownerSubject: subject,
+        ownerSubject: identity.subject,
+        ownerPrincipalId: identity.principalId,
         description,
         sourceDeviceClass,
         profile,
@@ -179,7 +248,7 @@ export class OperatorPreferencesService {
   }
 
   async load(
-    subject: string,
+    caller: string | OperatorIdentity,
     id: string,
     body: { deviceClass?: unknown; version?: unknown },
     authorization: OperatorAuthorization,
@@ -201,7 +270,7 @@ export class OperatorPreferencesService {
         sourceDeviceClass: layout.sourceDeviceClass,
       });
     }
-    const saved = await this.save(subject, deviceClass, {
+    const saved = await this.save(caller, deviceClass, {
       version: body.version,
       profile: layout.profile,
     });

--- a/backend/src/operator-preferences/operator-preferences.service.ts
+++ b/backend/src/operator-preferences/operator-preferences.service.ts
@@ -6,24 +6,14 @@ import {
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
+import type { CanonicalIdentity } from '../identity/principals';
 import { ManagedMetricsService } from '../observability/managed-metrics.service';
 import { PrismaService } from '../prisma.service';
 import {
   defaultProfile,
   parseDeviceClass,
   parseProfile,
-  type DeviceClass,
 } from './operator-preferences.types';
-
-/**
- * The identity a preference or shared layout is recorded against. The canonical
- * principal is `null` until Pompeii resolves one, which is the expected state
- * during rollout.
- */
-export type OperatorIdentity = {
-  principalId: string | null;
-  subject: string;
-};
 
 export interface OperatorAuthorization {
   permissions: string[];
@@ -38,14 +28,15 @@ export class OperatorPreferencesService {
   ) {}
 
   /**
-   * Normalizes a caller identity. A bare subject means "no canonical principal
-   * is known" — the rollout state for an identity Pompeii has not linked yet —
-   * so accepting a plain string is part of the contract, not shorthand.
+   * Normalizes the identity attached by the authorization guard. A null
+   * principal is the explicit rollout state for an identity Pompeii has not
+   * linked yet; callers cannot silently discard a resolved principal.
    */
-  private identity(value: string | OperatorIdentity): OperatorIdentity {
-    return typeof value === 'string'
-      ? { subject: value, principalId: null }
-      : { subject: value.subject, principalId: value.principalId?.trim() || null };
+  private identity(value: CanonicalIdentity): CanonicalIdentity {
+    return {
+      subject: value.subject,
+      principalId: value.principalId?.trim() || null,
+    };
   }
 
   /**
@@ -53,12 +44,21 @@ export class OperatorPreferencesService {
    * migrated row is still theirs after they move pools, and falling back to the
    * pool subject so an unmigrated row stays reachable.
    */
-  private async findPreference(identity: OperatorIdentity, deviceClass: string) {
+  private async findPreference(
+    identity: CanonicalIdentity,
+    deviceClass: string,
+  ) {
     if (identity.principalId) {
-      const byPrincipal = await this.prisma.operatorPreference.findFirst({
+      const byPrincipal = await this.prisma.operatorPreference.findMany({
+        orderBy: { updatedAt: 'desc' },
+        take: 2,
         where: { principalId: identity.principalId, deviceClass },
       });
-      if (byPrincipal) return byPrincipal;
+      if (byPrincipal.length > 1) {
+        this.metrics.recordPreference('read', 'conflict');
+        throw new ConflictException('CANONICAL_IDENTITY_COLLISION');
+      }
+      if (byPrincipal[0]) return byPrincipal[0];
     }
     return this.prisma.operatorPreference.findUnique({
       where: {
@@ -67,7 +67,7 @@ export class OperatorPreferencesService {
     });
   }
 
-  async get(caller: string | OperatorIdentity, rawDeviceClass: string) {
+  async get(caller: CanonicalIdentity, rawDeviceClass: string) {
     const identity = this.identity(caller);
     const subject = identity.subject;
     const deviceClass = parseDeviceClass(rawDeviceClass);
@@ -86,7 +86,7 @@ export class OperatorPreferencesService {
   }
 
   async save(
-    caller: string | OperatorIdentity,
+    caller: CanonicalIdentity,
     rawDeviceClass: string,
     body: { version?: unknown; profile?: unknown },
   ) {
@@ -152,7 +152,7 @@ export class OperatorPreferencesService {
     }
   }
 
-  async reset(caller: string | OperatorIdentity, rawDeviceClass?: string) {
+  async reset(caller: CanonicalIdentity, rawDeviceClass?: string) {
     const identity = this.identity(caller);
     // Both identities are cleared, so a reset after a pool move does not leave
     // the operator's migrated row behind.
@@ -185,7 +185,7 @@ export class OperatorPreferencesService {
   }
 
   async publish(
-    caller: string | OperatorIdentity,
+    caller: CanonicalIdentity,
     body: Record<string, unknown>,
     authorization: OperatorAuthorization,
   ) {
@@ -194,7 +194,7 @@ export class OperatorPreferencesService {
     const scopeId = boundedText(body.scopeId, 'scopeId', 128);
     await this.assertScopeAccess(scope, scopeId, authorization, true);
     const sourceDeviceClass = parseDeviceClass(
-      String(body.sourceDeviceClass ?? ''),
+      stringInput(body.sourceDeviceClass),
     );
     const name = boundedText(body.name, 'name', 120);
     const description = optionalText(body.description, 500);
@@ -248,7 +248,7 @@ export class OperatorPreferencesService {
   }
 
   async load(
-    caller: string | OperatorIdentity,
+    caller: CanonicalIdentity,
     id: string,
     body: { deviceClass?: unknown; version?: unknown },
     authorization: OperatorAuthorization,
@@ -263,7 +263,7 @@ export class OperatorPreferencesService {
       authorization,
       false,
     );
-    const deviceClass = parseDeviceClass(String(body.deviceClass ?? ''));
+    const deviceClass = parseDeviceClass(stringInput(body.deviceClass));
     if (deviceClass !== layout.sourceDeviceClass) {
       throw new ConflictException({
         error: 'DEVICE_CLASS_MISMATCH',
@@ -309,6 +309,10 @@ function integerVersion(value: unknown): number {
   if (!Number.isSafeInteger(version) || version < 0)
     throw new ConflictException('PROFILE_VERSION_REQUIRED');
   return version;
+}
+
+function stringInput(value: unknown): string {
+  return typeof value === 'string' ? value : '';
 }
 
 function parseScope(value: unknown): 'program' | 'team' {

--- a/backend/src/proto/authorization.proto
+++ b/backend/src/proto/authorization.proto
@@ -24,4 +24,8 @@ message AuthorizeResponse {
   string subject = 4;
   repeated string effective_permissions = 5;
   repeated string roles = 6;
+  // Pompeii's canonical principal: stable for one real person across pools.
+  // Empty while an identity has not been resolved to a principal yet, which is
+  // the expected state during rollout.
+  string principal_id = 7;
 }

--- a/backend/src/webrtc/webrtc.controller.spec.ts
+++ b/backend/src/webrtc/webrtc.controller.spec.ts
@@ -1,0 +1,37 @@
+import { WebrtcController } from './webrtc.controller';
+
+describe('WebrtcController canonical audit boundary', () => {
+  const request = {
+    user: {
+      principalId: 'principal-a',
+      sub: 'pool-subject-a',
+    },
+  };
+  const webrtc = {
+    createInvitation: jest.fn(),
+    removeParticipant: jest.fn(),
+  };
+  const controller = new WebrtcController(webrtc as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('passes both identities to invitation audit writes', async () => {
+    const body = { displayName: 'Fixture' };
+    await controller.createInvitation(request, body);
+
+    expect(webrtc.createInvitation).toHaveBeenCalledWith(
+      { principalId: 'principal-a', subject: 'pool-subject-a' },
+      body,
+    );
+  });
+
+  it('passes both identities to participant-removal audit writes', async () => {
+    await controller.removeParticipant(request, 'main', 'guest-fixture');
+
+    expect(webrtc.removeParticipant).toHaveBeenCalledWith(
+      { principalId: 'principal-a', subject: 'pool-subject-a' },
+      'main',
+      'guest-fixture',
+    );
+  });
+});

--- a/backend/src/webrtc/webrtc.controller.ts
+++ b/backend/src/webrtc/webrtc.controller.ts
@@ -12,9 +12,19 @@ import {
 import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
 import { Public } from '../auth/public.decorator';
 import { RequirePermission } from '../auth/require-permission.decorator';
+import type { CanonicalIdentity } from '../identity/principals';
 import { WebrtcService } from './webrtc.service';
 
-type OperatorRequest = { user: { sub: string } };
+type OperatorRequest = {
+  user: { sub: string; principalId: string | null };
+};
+
+function identityFrom(request: OperatorRequest): CanonicalIdentity {
+  return {
+    subject: request.user.sub,
+    principalId: request.user.principalId,
+  };
+}
 
 @Controller('webrtc')
 @RequirePermission(ALCANTARA_PERMISSIONS.webrtc.read)
@@ -38,19 +48,19 @@ export class WebrtcController {
     @Req() request: OperatorRequest,
     @Body() body: Record<string, unknown>,
   ) {
-    return this.webrtc.createInvitation(request.user.sub, body);
+    return this.webrtc.createInvitation(identityFrom(request), body);
   }
 
   @Post('invitations/:id/replace')
   @RequirePermission(ALCANTARA_PERMISSIONS.webrtc.operate)
   replaceInvitation(@Req() request: OperatorRequest, @Param('id') id: string) {
-    return this.webrtc.replaceInvitation(request.user.sub, id);
+    return this.webrtc.replaceInvitation(identityFrom(request), id);
   }
 
   @Delete('invitations/:id')
   @RequirePermission(ALCANTARA_PERMISSIONS.webrtc.operate)
   revokeInvitation(@Req() request: OperatorRequest, @Param('id') id: string) {
-    return this.webrtc.revokeInvitation(request.user.sub, id);
+    return this.webrtc.revokeInvitation(identityFrom(request), id);
   }
 
   @Patch('invitations/:id/return')
@@ -60,7 +70,7 @@ export class WebrtcController {
     @Param('id') id: string,
     @Body() body: Record<string, unknown>,
   ) {
-    return this.webrtc.updateReturn(request.user.sub, id, body);
+    return this.webrtc.updateReturn(identityFrom(request), id, body);
   }
 
   @Post('join')
@@ -99,7 +109,10 @@ export class WebrtcController {
     @Req() request: OperatorRequest,
     @Body() body: Record<string, unknown>,
   ) {
-    return this.webrtc.createOperatorToken(request.user.sub, body.programId);
+    return this.webrtc.createOperatorToken(
+      identityFrom(request),
+      body.programId,
+    );
   }
 
   @Post('rooms/:programId/participants/:identity/control')
@@ -119,7 +132,11 @@ export class WebrtcController {
     @Param('programId') programId: string,
     @Param('identity') identity: string,
   ) {
-    return this.webrtc.removeParticipant(request.user.sub, programId, identity);
+    return this.webrtc.removeParticipant(
+      identityFrom(request),
+      programId,
+      identity,
+    );
   }
 
   @Post('renderer-token')

--- a/backend/src/webrtc/webrtc.service.spec.ts
+++ b/backend/src/webrtc/webrtc.service.spec.ts
@@ -9,6 +9,10 @@ import { createHash } from 'node:crypto';
 import { WebrtcService } from './webrtc.service';
 
 describe('WebrtcService', () => {
+  const operator = {
+    principalId: 'principal-1',
+    subject: 'operator-1',
+  };
   const invitation = {
     id: '11111111-1111-4111-8111-111111111111',
     tokenHash: '',
@@ -22,6 +26,7 @@ describe('WebrtcService', () => {
     activeSessionId: null as string | null,
     activeSessionUntil: null as Date | null,
     createdByIdentity: 'operator-1',
+    createdByPrincipalId: 'principal-1',
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -80,7 +85,7 @@ describe('WebrtcService', () => {
 
   it('persists a default 24-hour invitation in the first reusable slot', async () => {
     const { service, prisma, livekit } = setup();
-    const created = await service.createInvitation('operator-1', {
+    const created = await service.createInvitation(operator, {
       programId: 'MAIN',
       displayName: ' Fictional Guest ',
     });
@@ -96,6 +101,16 @@ describe('WebrtcService', () => {
         data: expect.objectContaining({
           tokenHash: expect.stringMatching(/^[a-f0-9]{64}$/),
           createdByIdentity: 'operator-1',
+          createdByPrincipalId: 'principal-1',
+          events: {
+            create: {
+              type: 'created',
+              details: expect.objectContaining({
+                operatorIdentity: 'operator-1',
+                operatorPrincipalId: 'principal-1',
+              }),
+            },
+          },
         }),
       }),
     );
@@ -157,7 +172,7 @@ describe('WebrtcService', () => {
   it('revokes persistence and removes an active participant', async () => {
     const { service, prisma, livekit } = setup();
     await expect(
-      service.revokeInvitation('operator-1', invitation.id),
+      service.revokeInvitation(operator, invitation.id),
     ).resolves.toEqual({ id: invitation.id, status: 'revoked' });
     expect(prisma.guestInvitation.update).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -165,6 +180,15 @@ describe('WebrtcService', () => {
         data: expect.objectContaining({
           revokedAt: expect.any(Date),
           activeSessionId: null,
+          events: {
+            create: {
+              type: 'revoked',
+              details: {
+                operatorIdentity: 'operator-1',
+                operatorPrincipalId: 'principal-1',
+              },
+            },
+          },
         }),
       }),
     );

--- a/backend/src/webrtc/webrtc.service.ts
+++ b/backend/src/webrtc/webrtc.service.ts
@@ -22,6 +22,7 @@ import {
   RoomServiceClient,
   TrackSource,
 } from 'livekit-server-sdk';
+import type { CanonicalIdentity } from '../identity/principals';
 import { PrismaService } from '../prisma.service';
 
 type ReturnVideo = 'program' | 'preview' | 'none';
@@ -59,7 +60,7 @@ export class WebrtcService {
   }
 
   async createInvitation(
-    operatorIdentity: string,
+    operator: CanonicalIdentity,
     body: Record<string, unknown>,
   ) {
     this.requireConfiguration();
@@ -91,9 +92,17 @@ export class WebrtcService {
         sourceMuted,
         sourceDelayMs,
         expiresAt,
-        createdByIdentity: operatorIdentity,
+        createdByIdentity: operator.subject,
+        createdByPrincipalId: operator.principalId,
         events: {
-          create: { type: 'created', details: { expiresInHours, slotNumber } },
+          create: {
+            type: 'created',
+            details: {
+              ...this.operatorAudit(operator),
+              expiresInHours,
+              slotNumber,
+            },
+          },
         },
       },
     });
@@ -104,10 +113,10 @@ export class WebrtcService {
     };
   }
 
-  async replaceInvitation(operatorIdentity: string, id: string) {
+  async replaceInvitation(operator: CanonicalIdentity, id: string) {
     const existing = await this.requireInvitation(id);
-    await this.revokeInvitation(operatorIdentity, id);
-    return this.createInvitation(operatorIdentity, {
+    await this.revokeInvitation(operator, id);
+    return this.createInvitation(operator, {
       programId: existing.programId,
       displayName: existing.displayName,
       expiresInHours: Math.max(
@@ -123,7 +132,7 @@ export class WebrtcService {
     });
   }
 
-  async revokeInvitation(operatorIdentity: string, id: string) {
+  async revokeInvitation(operator: CanonicalIdentity, id: string) {
     const invitation = await this.requireInvitation(id);
     if (!invitation.revokedAt) {
       await this.prisma.guestInvitation.update({
@@ -134,7 +143,10 @@ export class WebrtcService {
           activeSessionId: null,
           activeSessionUntil: null,
           events: {
-            create: { type: 'revoked', details: { operatorIdentity } },
+            create: {
+              type: 'revoked',
+              details: this.operatorAudit(operator),
+            },
           },
         },
       });
@@ -147,7 +159,7 @@ export class WebrtcService {
   }
 
   async updateReturn(
-    operatorIdentity: string,
+    operator: CanonicalIdentity,
     id: string,
     body: Record<string, unknown>,
   ) {
@@ -169,7 +181,7 @@ export class WebrtcService {
           create: {
             type: 'return_changed',
             details: {
-              operatorIdentity,
+              ...this.operatorAudit(operator),
               returnVideo,
               returnAudioBus,
               sourceGain,
@@ -429,7 +441,7 @@ export class WebrtcService {
   }
 
   async removeParticipant(
-    operatorIdentity: string,
+    operator: CanonicalIdentity,
     programIdValue: unknown,
     identityValue: unknown,
   ) {
@@ -442,7 +454,12 @@ export class WebrtcService {
       data: {
         activeSessionId: null,
         activeSessionUntil: null,
-        events: { create: { type: 'removed', details: { operatorIdentity } } },
+        events: {
+          create: {
+            type: 'removed',
+            details: this.operatorAudit(operator),
+          },
+        },
       },
     });
     return { identity, status: 'removed' };
@@ -535,11 +552,17 @@ export class WebrtcService {
     };
   }
 
-  async createOperatorToken(operatorIdentity: string, programIdValue: unknown) {
+  async createOperatorToken(
+    operator: CanonicalIdentity,
+    programIdValue: unknown,
+  ) {
     this.requireConfiguration();
     const programId = this.normalizeProgramId(programIdValue);
     const token = new AccessToken(this.apiKey, this.apiSecret, {
-      identity: `operator-${createHash('sha256').update(operatorIdentity).digest('hex').slice(0, 20)}-${randomUUID()}`,
+      identity: `operator-${createHash('sha256')
+        .update(operator.principalId ?? operator.subject)
+        .digest('hex')
+        .slice(0, 20)}-${randomUUID()}`,
       name: 'Alcantara operator',
       ttl: '5m',
       metadata: JSON.stringify({ role: 'operator' }),
@@ -932,6 +955,15 @@ export class WebrtcService {
 
   private hash(value: string) {
     return createHash('sha256').update(value).digest('hex');
+  }
+
+  private operatorAudit(operator: CanonicalIdentity) {
+    return {
+      // Keep the historical pool subject for display and add the verified
+      // canonical principal beside it. Neither value is derived from email.
+      operatorIdentity: operator.subject,
+      operatorPrincipalId: operator.principalId,
+    };
   }
 
   private safeEqual(left: string, right: string) {

--- a/docs/canonical-principals.md
+++ b/docs/canonical-principals.md
@@ -46,10 +46,12 @@ row has none         ->  caller's subject must match
 together, so an operator who moves pools still finds their own profile without
 hiding an unmigrated row for the new pool subject. A write targets the single row
 they already own and backfills the canonical principal on it the first time they
-sign in with one resolved. If those two identities find distinct rows, or two
-pool-specific rows claim the same principal and device class, reads fail with
-`CANONICAL_IDENTITY_COLLISION` until an operator reconciles them; Alcantara never
-picks one nondeterministically.
+sign in with one resolved. Subject fallback is limited to rows whose canonical
+principal is still null; a row already owned by another principal cannot be read,
+updated, or reset through a matching legacy subject. If those two identities find
+distinct owned rows, or two pool-specific rows claim the same principal and
+device class, reads fail with `CANONICAL_IDENTITY_COLLISION` until an operator
+reconciles them; Alcantara never picks one nondeterministically.
 
 New shared layouts and guest invitations record both identities immediately.
 Guest lifecycle audit events retain `operatorIdentity` and add

--- a/docs/canonical-principals.md
+++ b/docs/canonical-principals.md
@@ -1,0 +1,105 @@
+# Canonical Pompeii principals
+
+A Cognito pool subject is not portable. The same operator signing in through a
+different pool gets a different subject, so their preferences, their shared
+console layouts, and their audit trail all fragment. Pompeii now returns a
+canonical `principal_id` that is stable for one real person across pools, and
+Alcantara records it beside the subject.
+
+## Inventory
+
+Every field in the schema that carries a pool-local subject:
+
+| Model | Subject column | Canonical column | Kind |
+| --- | --- | --- | --- |
+| `OperatorPreference` | `subject` | `principalId` | ownership |
+| `SharedConsoleLayout` | `ownerSubject` | `ownerPrincipalId` | ownership |
+| `GuestInvitation` | `createdByIdentity` | `createdByPrincipalId` | audit |
+
+`SUBJECT_BEARING_FIELDS` in `backend/src/identity/principals.ts` is that list in
+code, and a test asserts it matches. A new subject-bearing column that is not
+added there would silently escape both the dry run and the migration.
+
+Every canonical column is **nullable and additive**. No subject column is ever
+rewritten, and `OperatorPreference`'s primary key stays `[subject, deviceClass]`
+so no existing row moves.
+
+## Reads during the migration window
+
+A caller carrying a canonical principal reads migrated rows by principal and
+unmigrated rows by subject, so both stay reachable. A caller without one reads
+by subject only — it must never fall through to another person's rows.
+
+```
+row has principalId  ->  caller's principalId must match
+row has none         ->  caller's subject must match
+```
+
+`OperatorPreference` lookups try the principal first and fall back to the
+subject, so an operator who moves pools still finds their own profile. A write
+targets whichever row they already own, and backfills the canonical principal on
+it the first time they sign in with one resolved.
+
+## Migrating
+
+`prisma migrate deploy` applies
+`20260906180000_canonical_principals`, which adds the three nullable columns and
+two indexes and **backfills nothing** — mapping a legacy subject to a canonical
+principal requires Pompeii and must never be inferred locally. Every statement is
+`IF NOT EXISTS`, so a restart part-way through re-runs safely.
+
+The backfill is a separate, explicit step driven by a verified mapping file — a
+JSON array of `{"subject": "...", "principalId": "..."}` pairs from Pompeii:
+
+```bash
+cd backend
+pnpm principals:report ./mapping.json   # dry run; changes nothing
+pnpm principals:apply  ./mapping.json
+```
+
+The report classifies every row:
+
+| Classification | Meaning | Applied |
+| --- | --- | --- |
+| `mapped` | a verified mapping exists and the row can move | ✅ |
+| `already-migrated` | already carries that canonical principal | — |
+| `missing` | no mapping supplied; the row stays usable on its subject | — |
+| `conflicting` | the row already names a **different** principal | ❌ |
+| `ambiguous` | the subject maps to more than one principal | ❌ |
+| `orphan` | the row carries no subject at all | ❌ |
+
+`apply` runs in one transaction, writes only `mapped` rows, and makes each write
+conditional on the canonical column still being null — so it is safe to re-run
+and a crash resumes cleanly. It refuses to run while conflicts remain unless
+`--allow-conflicts` is passed, and even then migrates only the clean rows.
+
+The report contains counts and opaque row ids only: **no subject, principal, or
+email ever appears in it**.
+
+## The two guarantees
+
+- **Identities are never joined by email.** The only accepted input is a mapping
+  Pompeii verified. `readMappingFile` refuses an entry that even *contains* an
+  `email` field.
+- **Audit attribution is never rewritten.** `GuestInvitation.createdByIdentity`
+  keeps its original value forever; the canonical principal is recorded beside
+  it. A historical actor still displays when no mapping exists, and no link is
+  fabricated.
+
+## Rollback and reconciliation
+
+`down.sql` drops only the added columns and indexes. Because the migration never
+touched a subject column, reverting cannot lose an ownership or audit value: an
+operator's preferences, layouts, and invitation history all remain keyed by the
+pool subject exactly as before.
+
+Reconciling after a partial or aborted rollout:
+
+1. Re-run `pnpm principals:report ./mapping.json`. Rows already applied come
+   back as `already-migrated`; nothing needs undoing.
+2. Resolve any `conflicting` or `ambiguous` rows by hand — those are decisions
+   about who a record belongs to, which is why the tool refuses to make them.
+3. Re-run `pnpm principals:apply`. It is idempotent.
+
+Unresolved legacy records stay usable and visible throughout; they are never
+hidden or orphaned while awaiting remediation.

--- a/docs/canonical-principals.md
+++ b/docs/canonical-principals.md
@@ -42,11 +42,12 @@ row has principalId  ->  caller's principalId must match
 row has none         ->  caller's subject must match
 ```
 
-`OperatorPreference` lookups try the principal first and fall back to the
-subject, so an operator who moves pools still finds their own profile. A write
-targets whichever row they already own, and backfills the canonical principal on
-it the first time they sign in with one resolved. If two pool-specific rows would
-claim the same principal and device class, reads fail with
+`OperatorPreference` lookups query the canonical principal and current subject
+together, so an operator who moves pools still finds their own profile without
+hiding an unmigrated row for the new pool subject. A write targets the single row
+they already own and backfills the canonical principal on it the first time they
+sign in with one resolved. If those two identities find distinct rows, or two
+pool-specific rows claim the same principal and device class, reads fail with
 `CANONICAL_IDENTITY_COLLISION` until an operator reconciles them; Alcantara never
 picks one nondeterministically.
 
@@ -62,14 +63,25 @@ two indexes and **backfills nothing** — mapping a legacy subject to a canonica
 principal requires Pompeii and must never be inferred locally. Every statement is
 `IF NOT EXISTS`, so a restart part-way through re-runs safely.
 
-The backfill is a separate, explicit step driven by a verified mapping file — a
-JSON array of `{"subject": "...", "principalId": "..."}` pairs from Pompeii:
+The backfill is a separate, explicit exchange with Pompeii. Alcantara first
+exports the exact consumer/reference/subject inventory; Pompeii resolves that
+file and produces its native `{references, collisions, missing}` report, which
+Alcantara consumes directly without hand-editing or identity reshaping:
 
 ```bash
 cd backend
-pnpm principals:report ./mapping.json   # dry run; changes nothing
-pnpm principals:apply  ./mapping.json
+pnpm principals:export ./alcantara-references.json
+# Run Pompeii's principal-migration-dry-run using that file and capture its JSON.
+pnpm principals:report ./pompeii-report.json   # changes nothing
+pnpm principals:apply  ./pompeii-report.json
 ```
+
+The export is created with mode `0600` and refuses to overwrite an existing file.
+It contains identity references: keep it out of Git and logs, transfer it only
+through an approved protected channel, and delete it after the migration window.
+Every entry must use consumer `alcantara` and the deterministic model/reference
+key Alcantara exported. Report/apply reject another consumer, an unknown or
+changed reference, or a report that does not cover the current inventory.
 
 The report classifies every row:
 
@@ -83,19 +95,28 @@ The report classifies every row:
 | `colliding`        | multiple preference rows would claim one principal/device key | ❌      |
 | `orphan`           | the row carries no subject at all                             | ❌      |
 
-`apply` runs in one transaction, writes only `mapped` rows, and makes each write
-conditional on the canonical column still being null — so it is safe to re-run
-and a crash resumes cleanly. It refuses to run while conflicts remain unless
-`--allow-conflicts` is passed, and even then migrates only the clean rows.
+Before any export, report, or apply database access, the CLI runs the canonical
+Arauco secret bootstrap; production therefore resolves `DATABASE_URL` from
+`ARAUCO_SECRET_ID` before constructing Prisma. Bootstrap failure performs no
+database work.
+
+`apply` re-collects and re-plans inside one serializable transaction, writes only
+`mapped` rows, and compare-and-sets every legacy owner and canonical-null field.
+GuestEvent compares the complete original JSON before adding the principal, so a
+concurrent audit update cannot be overwritten. Every affected count must equal
+one or the whole transaction aborts. It is safe to re-run and a crash resumes
+cleanly. Any collision or missing reference in the Pompeii report always blocks
+apply. Alcantara conflicts also block unless `--allow-conflicts` is passed, and
+even then only clean rows migrate.
 
 The report contains counts only: **no subject, principal, email, or raw mapping
 value ever appears in it**.
 
 ## The two guarantees
 
-- **Identities are never joined by email.** The only accepted input is a mapping
-  Pompeii verified. `readMappingFile` refuses an entry that even _contains_ an
-  `email` field.
+- **Identities are never joined by email.** The only accepted input is Pompeii's
+  native verified report. The importer refuses a reference that even _contains_
+  an `email` field.
 - **Audit attribution is never rewritten.** `GuestInvitation.createdByIdentity`
   keeps its original value forever; the canonical principal is recorded beside
   it. A historical actor still displays when no mapping exists, and no link is
@@ -117,12 +138,13 @@ and are ignored by legacy code.
 
 Reconciling after a partial or aborted rollout:
 
-1. Re-run `pnpm principals:report ./mapping.json`. Rows already applied come
+1. Re-export the current inventory, regenerate the Pompeii report, and run
+   `pnpm principals:report ./pompeii-report.json`. Rows already applied come
    back as `already-migrated`; nothing needs undoing.
 2. Resolve any `conflicting`, `ambiguous`, or `colliding` rows by hand — those
    are decisions about who a record belongs to, which is why the tool refuses to
    make them.
-3. Re-run `pnpm principals:apply`. It is idempotent.
+3. Re-run `pnpm principals:apply ./pompeii-report.json`. It is idempotent.
 
 Unresolved legacy records stay usable and visible throughout; they are never
 hidden or orphaned while awaiting remediation.

--- a/docs/canonical-principals.md
+++ b/docs/canonical-principals.md
@@ -10,19 +10,26 @@ Alcantara records it beside the subject.
 
 Every field in the schema that carries a pool-local subject:
 
-| Model | Subject column | Canonical column | Kind |
-| --- | --- | --- | --- |
-| `OperatorPreference` | `subject` | `principalId` | ownership |
-| `SharedConsoleLayout` | `ownerSubject` | `ownerPrincipalId` | ownership |
-| `GuestInvitation` | `createdByIdentity` | `createdByPrincipalId` | audit |
+| Model                 | Subject column             | Canonical column              | Kind      |
+| --------------------- | -------------------------- | ----------------------------- | --------- |
+| `OperatorPreference`  | `subject`                  | `principalId`                 | ownership |
+| `SharedConsoleLayout` | `ownerSubject`             | `ownerPrincipalId`            | ownership |
+| `GuestInvitation`     | `createdByIdentity`        | `createdByPrincipalId`        | audit     |
+| `GuestEvent`          | `details.operatorIdentity` | `details.operatorPrincipalId` | audit     |
 
 `SUBJECT_BEARING_FIELDS` in `backend/src/identity/principals.ts` is that list in
 code, and a test asserts it matches. A new subject-bearing column that is not
 added there would silently escape both the dry run and the migration.
 
-Every canonical column is **nullable and additive**. No subject column is ever
+Every canonical reference is **nullable and additive**. No subject value is ever
 rewritten, and `OperatorPreference`'s primary key stays `[subject, deviceClass]`
-so no existing row moves.
+so no existing row moves. `GuestEvent` retains the historical subject inside its
+JSON details and adds the canonical principal beside it.
+
+`ProgramState` and the related program tables have no operator ownership or
+actor-subject field; their `programId` values identify broadcasts, not people.
+The in-memory RxJS `Subject` used for event fan-out is likewise not identity
+data. They therefore need no identity migration.
 
 ## Reads during the migration window
 
@@ -38,7 +45,14 @@ row has none         ->  caller's subject must match
 `OperatorPreference` lookups try the principal first and fall back to the
 subject, so an operator who moves pools still finds their own profile. A write
 targets whichever row they already own, and backfills the canonical principal on
-it the first time they sign in with one resolved.
+it the first time they sign in with one resolved. If two pool-specific rows would
+claim the same principal and device class, reads fail with
+`CANONICAL_IDENTITY_COLLISION` until an operator reconciles them; Alcantara never
+picks one nondeterministically.
+
+New shared layouts and guest invitations record both identities immediately.
+Guest lifecycle audit events retain `operatorIdentity` and add
+`operatorPrincipalId`; no historical subject is replaced.
 
 ## Migrating
 
@@ -59,46 +73,55 @@ pnpm principals:apply  ./mapping.json
 
 The report classifies every row:
 
-| Classification | Meaning | Applied |
-| --- | --- | --- |
-| `mapped` | a verified mapping exists and the row can move | ✅ |
-| `already-migrated` | already carries that canonical principal | — |
-| `missing` | no mapping supplied; the row stays usable on its subject | — |
-| `conflicting` | the row already names a **different** principal | ❌ |
-| `ambiguous` | the subject maps to more than one principal | ❌ |
-| `orphan` | the row carries no subject at all | ❌ |
+| Classification     | Meaning                                                       | Applied |
+| ------------------ | ------------------------------------------------------------- | ------- |
+| `mapped`           | a verified mapping exists and the row can move                | ✅      |
+| `already-migrated` | already carries that canonical principal                      | —       |
+| `missing`          | no mapping supplied; the row stays usable on its subject      | —       |
+| `conflicting`      | the row already names a **different** principal               | ❌      |
+| `ambiguous`        | the subject maps to more than one principal                   | ❌      |
+| `colliding`        | multiple preference rows would claim one principal/device key | ❌      |
+| `orphan`           | the row carries no subject at all                             | ❌      |
 
 `apply` runs in one transaction, writes only `mapped` rows, and makes each write
 conditional on the canonical column still being null — so it is safe to re-run
 and a crash resumes cleanly. It refuses to run while conflicts remain unless
 `--allow-conflicts` is passed, and even then migrates only the clean rows.
 
-The report contains counts and opaque row ids only: **no subject, principal, or
-email ever appears in it**.
+The report contains counts only: **no subject, principal, email, or raw mapping
+value ever appears in it**.
 
 ## The two guarantees
 
 - **Identities are never joined by email.** The only accepted input is a mapping
-  Pompeii verified. `readMappingFile` refuses an entry that even *contains* an
+  Pompeii verified. `readMappingFile` refuses an entry that even _contains_ an
   `email` field.
 - **Audit attribution is never rewritten.** `GuestInvitation.createdByIdentity`
   keeps its original value forever; the canonical principal is recorded beside
   it. A historical actor still displays when no mapping exists, and no link is
   fabricated.
 
+Canonical resolution adds no identity-bearing metric labels. Preference reads
+continue using the bounded
+`alcantara_operator_preference_operations_total{action,result}` family; a
+runtime canonical collision records the existing `read`/`conflict` result.
+
 ## Rollback and reconciliation
 
 `down.sql` drops only the added columns and indexes. Because the migration never
-touched a subject column, reverting cannot lose an ownership or audit value: an
-operator's preferences, layouts, and invitation history all remain keyed by the
-pool subject exactly as before.
+touches a subject value, reverting cannot lose an ownership or audit value: an
+operator's preferences, layouts, invitation history, and event history all
+retain the pool subject exactly as before. Nested `operatorPrincipalId` audit
+values may remain after a schema rollback; they are additive historical context
+and are ignored by legacy code.
 
 Reconciling after a partial or aborted rollout:
 
 1. Re-run `pnpm principals:report ./mapping.json`. Rows already applied come
    back as `already-migrated`; nothing needs undoing.
-2. Resolve any `conflicting` or `ambiguous` rows by hand — those are decisions
-   about who a record belongs to, which is why the tool refuses to make them.
+2. Resolve any `conflicting`, `ambiguous`, or `colliding` rows by hand — those
+   are decisions about who a record belongs to, which is why the tool refuses to
+   make them.
 3. Re-run `pnpm principals:apply`. It is idempotent.
 
 Unresolved legacy records stay usable and visible throughout; they are never

--- a/docs/operator-preferences.md
+++ b/docs/operator-preferences.md
@@ -3,9 +3,11 @@
 Alcantara owns console UI preferences. Pompeii supplies both the authenticated
 pool subject and, when verified, its canonical principal; Pompeii does not store
 these preferences. The legacy primary key remains `(subject, deviceClass)`, but
-reads prefer one matching `(principalId, deviceClass)` row and otherwise fall
-back to the current subject. Two linked pool identities therefore reach the same
-migrated profile, while an unresolved identity can reach only its legacy row.
+reads query both `(principalId, deviceClass)` and the current
+`(subject, deviceClass)` together. Two linked pool identities therefore reach
+one migrated profile, while an unresolved identity can reach only its legacy
+row. Distinct matches fail with `CANONICAL_IDENTITY_COLLISION`; a canonical row
+must never hide a separate legacy profile for the current subject.
 
 ## Device classification and override
 
@@ -45,8 +47,10 @@ never silently overwrites the other session.
 
 The last acknowledged profile is cached locally under the canonical principal
 when the backend returns one, with the current subject as the rollout fallback.
-If the backend is unavailable, Alcantara starts with the available cache or safe
-defaults, marks synchronization degraded, and leaves broadcast controls usable.
+On the first upgraded session, Alcantara prefers an existing principal cache,
+then copies a valid legacy subject cache to the principal key when needed. If the
+backend is unavailable, Alcantara therefore starts with the available cache or
+safe defaults, marks synchronization degraded, and leaves broadcast controls usable.
 Dirty writes and clean reads retry every five seconds. Tokens are not stored in
 that preference cache.
 

--- a/docs/operator-preferences.md
+++ b/docs/operator-preferences.md
@@ -45,7 +45,10 @@ authentication. A missing row returns safe class defaults at version zero.
 Changes are sent after a bounded 700 ms debounce with the last acknowledged
 version. The backend update is atomic. A stale version returns HTTP 409 with
 the authoritative value, and the UI offers “Use server” or “Retry mine”; it
-never silently overwrites the other session.
+never silently overwrites the other session. The optimistic update also binds
+the ownership mode selected by the read: a canonical row must still have the
+same principal, while a legacy row must still have the current subject and a
+null principal.
 
 The last acknowledged profile is cached locally under the canonical principal
 when the backend returns one, with the current subject as the rollout fallback.

--- a/docs/operator-preferences.md
+++ b/docs/operator-preferences.md
@@ -6,8 +6,10 @@ these preferences. The legacy primary key remains `(subject, deviceClass)`, but
 reads query both `(principalId, deviceClass)` and the current
 `(subject, deviceClass)` together. Two linked pool identities therefore reach
 one migrated profile, while an unresolved identity can reach only its legacy
-row. Distinct matches fail with `CANONICAL_IDENTITY_COLLISION`; a canonical row
-must never hide a separate legacy profile for the current subject.
+row whose canonical owner is still null. A matching subject cannot access a row
+already owned by another principal. Distinct owned matches fail with
+`CANONICAL_IDENTITY_COLLISION`; a canonical row must never hide a separate legacy
+profile for the current subject.
 
 ## Device classification and override
 
@@ -54,10 +56,11 @@ safe defaults, marks synchronization degraded, and leaves broadcast controls usa
 Dirty writes and clean reads retry every five seconds. Tokens are not stored in
 that preference cache.
 
-“Reset class” deletes the caller's matching subject/canonical server row and
-local cache. “Reset all” deletes that caller's subject and canonical preference
-rows for all three classes and clears both forms of local cache. Neither
-operation affects shared layouts or another operator.
+“Reset class” deletes the caller's canonical row and any still-unmigrated current
+subject row, plus local cache. “Reset all” does the same for all three classes and
+clears both forms of local cache. A subject row already owned by another
+principal is never a reset target. Neither operation affects shared layouts or
+another operator.
 
 ## Shared program and team layouts
 

--- a/docs/operator-preferences.md
+++ b/docs/operator-preferences.md
@@ -1,10 +1,11 @@
 # Operator console preferences
 
-Alcantara owns console UI preferences. Pompeii supplies the authenticated
-subject and authorization decision, but it does not store these preferences.
-Private profiles are keyed by `(subject, deviceClass)`, so two laptops for the
-same operator share the desktop profile while tablet and phone remain isolated.
-Another subject cannot address or overwrite that row through the API.
+Alcantara owns console UI preferences. Pompeii supplies both the authenticated
+pool subject and, when verified, its canonical principal; Pompeii does not store
+these preferences. The legacy primary key remains `(subject, deviceClass)`, but
+reads prefer one matching `(principalId, deviceClass)` row and otherwise fall
+back to the current subject. Two linked pool identities therefore reach the same
+migrated profile, while an unresolved identity can reach only its legacy row.
 
 ## Device classification and override
 
@@ -42,23 +43,25 @@ version. The backend update is atomic. A stale version returns HTTP 409 with
 the authoritative value, and the UI offers “Use server” or “Retry mine”; it
 never silently overwrites the other session.
 
-The last acknowledged `(subject, class)` profile is cached locally. If the
-backend is unavailable, Alcantara starts with that cache or safe defaults,
-marks synchronization degraded, and leaves broadcast controls usable. Dirty
-writes and clean reads retry every five seconds. Tokens are not stored in that
-preference cache.
+The last acknowledged profile is cached locally under the canonical principal
+when the backend returns one, with the current subject as the rollout fallback.
+If the backend is unavailable, Alcantara starts with the available cache or safe
+defaults, marks synchronization degraded, and leaves broadcast controls usable.
+Dirty writes and clean reads retry every five seconds. Tokens are not stored in
+that preference cache.
 
-“Reset class” deletes only the current server row and local cache. “Reset all”
-deletes the authenticated subject's three server rows and all three local
-caches. Neither operation affects shared layouts or another operator.
+“Reset class” deletes the caller's matching subject/canonical server row and
+local cache. “Reset all” deletes that caller's subject and canonical preference
+rows for all three classes and clears both forms of local cache. Neither
+operation affects shared layouts or another operator.
 
 ## Shared program and team layouts
 
 Publication is an explicit action in the preferences panel. A layout stores a
-name, optional description, owner subject, `program` or `team` scope and ID,
-source device class, version, timestamps, and the normalized profile. Publishing
-the same name in the same scope creates a new version; retiring also increments
-the version and removes it from discovery.
+name, optional description, owner subject, nullable canonical owner, `program`
+or `team` scope and ID, source device class, version, timestamps, and the
+normalized profile. Publishing the same name in the same scope creates a new
+version; retiring also increments the version and removes it from discovery.
 
 Discovery and load require access to the referenced program or team. Publish,
 replace, and retire additionally require `alcantara:layout:manage`. Those checks

--- a/frontend/app/components/common/AuthListener.tsx
+++ b/frontend/app/components/common/AuthListener.tsx
@@ -6,6 +6,7 @@ import type { ReduxAction } from "../../state/dispatchers/base";
 import { useAuthStatus } from "../../hooks/useAuth";
 import { SESSION_INVALID_EVENT } from "../../services/session-events";
 import { getAppSession } from "../../services/session";
+import { getApiBaseUrl } from "../../utils/apiBaseUrl";
 
 export default function AuthListener() {
   const dispatch = useDispatch<Dispatch<ReduxAction>>();
@@ -20,8 +21,21 @@ export default function AuthListener() {
         const session = await getAppSession();
         if (session.userSub && session.token) {
           const payload = session.payload;
+          const response = await fetch(`${getApiBaseUrl()}/auth/me`, {
+            headers: { Authorization: `Bearer ${session.token}` },
+          });
+          if (!response.ok)
+            throw new Error(`Authorization failed (${response.status})`);
+          const authorized = (await response.json()) as {
+            principalId?: unknown;
+          };
           const user = {
             id: session.userSub,
+            principalId:
+              typeof authorized.principalId === "string" &&
+              authorized.principalId.trim()
+                ? authorized.principalId.trim()
+                : null,
             email: (payload?.email as string) || "",
             name: payload?.name as string,
             picture: payload?.picture as string,

--- a/frontend/app/contexts/ConsolePreferencesContext.test.tsx
+++ b/frontend/app/contexts/ConsolePreferencesContext.test.tsx
@@ -1,7 +1,13 @@
-import { describe, expect, it } from "vitest";
-import { preferenceCacheIdentity } from "./ConsolePreferencesContext";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  defaultConsoleProfile,
+  preferenceCacheIdentity,
+  readPreferenceCache,
+} from "./ConsolePreferencesContext";
 
 describe("canonical preference cache identity", () => {
+  beforeEach(() => window.localStorage.clear());
+
   it("uses the verified principal across pool subjects", () => {
     expect(
       preferenceCacheIdentity({
@@ -21,5 +27,50 @@ describe("canonical preference cache identity", () => {
     expect(
       preferenceCacheIdentity({ id: "legacy-subject", principalId: null }),
     ).toBe("legacy-subject");
+  });
+
+  it("migrates a legacy subject cache when a principal first becomes available", () => {
+    const cached = { version: 4, profile: defaultConsoleProfile("desktop") };
+    window.localStorage.setItem(
+      "alcantara.console.acknowledged.legacy-subject.desktop",
+      JSON.stringify(cached),
+    );
+
+    expect(
+      readPreferenceCache(
+        { id: "legacy-subject", principalId: "principal-a" },
+        "desktop",
+      ),
+    ).toEqual(cached);
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(
+          "alcantara.console.acknowledged.principal-a.desktop",
+        ) ?? "null",
+      ),
+    ).toEqual(cached);
+  });
+
+  it("prefers an existing principal cache over the legacy subject cache", () => {
+    const canonical = {
+      version: 5,
+      profile: { ...defaultConsoleProfile("desktop"), workspace: "audio" },
+    };
+    const legacy = { version: 4, profile: defaultConsoleProfile("desktop") };
+    window.localStorage.setItem(
+      "alcantara.console.acknowledged.principal-a.desktop",
+      JSON.stringify(canonical),
+    );
+    window.localStorage.setItem(
+      "alcantara.console.acknowledged.legacy-subject.desktop",
+      JSON.stringify(legacy),
+    );
+
+    expect(
+      readPreferenceCache(
+        { id: "legacy-subject", principalId: "principal-a" },
+        "desktop",
+      ),
+    ).toEqual(canonical);
   });
 });

--- a/frontend/app/contexts/ConsolePreferencesContext.test.tsx
+++ b/frontend/app/contexts/ConsolePreferencesContext.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { preferenceCacheIdentity } from "./ConsolePreferencesContext";
+
+describe("canonical preference cache identity", () => {
+  it("uses the verified principal across pool subjects", () => {
+    expect(
+      preferenceCacheIdentity({
+        id: "pool-subject-a",
+        principalId: " principal-a ",
+      }),
+    ).toBe("principal-a");
+    expect(
+      preferenceCacheIdentity({
+        id: "pool-subject-b",
+        principalId: "principal-a",
+      }),
+    ).toBe("principal-a");
+  });
+
+  it("falls back to the current subject while no principal is resolved", () => {
+    expect(
+      preferenceCacheIdentity({ id: "legacy-subject", principalId: null }),
+    ).toBe("legacy-subject");
+  });
+});

--- a/frontend/app/contexts/ConsolePreferencesContext.tsx
+++ b/frontend/app/contexts/ConsolePreferencesContext.tsx
@@ -48,6 +48,13 @@ interface ConsolePreferencesValue {
 const Context = createContext<ConsolePreferencesValue | null>(null);
 const OVERRIDE_KEY = "alcantara.console.deviceClassOverride";
 
+export function preferenceCacheIdentity(user?: {
+  id: string;
+  principalId?: string | null;
+}): string | undefined {
+  return user?.principalId?.trim() || user?.id;
+}
+
 export function detectDeviceClass(
   scope?: Pick<Window, "innerWidth" | "navigator">,
 ): DeviceClass {
@@ -123,6 +130,7 @@ export function ConsolePreferencesProvider({
 }) {
   const user = useSelector(currentUser);
   const authLoaded = useSelector(isAuthLoaded);
+  const preferenceIdentity = preferenceCacheIdentity(user);
   const detectedDeviceClass = useMemo(() => detectDeviceClass(), []);
   const [deviceClass, setDeviceClass] = useState<DeviceClass>(
     () => readOverride() ?? detectedDeviceClass,
@@ -152,11 +160,11 @@ export function ConsolePreferencesProvider({
   );
 
   useEffect(() => {
-    if (!authLoaded || !user?.id) return;
+    if (!authLoaded || !preferenceIdentity) return;
     dirty.current = false;
     setConflict(null);
-    const cached = readCache(user.id, deviceClass);
-    if (cached) acknowledge(user.id, cached.version, cached.profile);
+    const cached = readCache(preferenceIdentity, deviceClass);
+    if (cached) acknowledge(preferenceIdentity, cached.version, cached.profile);
     else {
       setProfile(defaultConsoleProfile(deviceClass));
       setVersion(0);
@@ -171,14 +179,14 @@ export function ConsolePreferencesProvider({
         }>;
       })
       .then((payload) => {
-        acknowledge(user.id, payload.version, payload.profile);
+        acknowledge(preferenceIdentity, payload.version, payload.profile);
         setSyncState("synced");
       })
       .catch(() => setSyncState("degraded"));
-  }, [acknowledge, authLoaded, deviceClass, user?.id]);
+  }, [acknowledge, authLoaded, deviceClass, preferenceIdentity]);
 
   const save = useCallback(async () => {
-    if (!user?.id || !dirty.current || conflict) return;
+    if (!preferenceIdentity || !dirty.current || conflict) return;
     dirty.current = false;
     const local = profileRef.current;
     setSyncState("saving");
@@ -208,13 +216,13 @@ export function ConsolePreferencesProvider({
         version: number;
         profile: ConsoleProfile;
       };
-      acknowledge(user.id, saved.version, saved.profile);
+      acknowledge(preferenceIdentity, saved.version, saved.profile);
       setSyncState("synced");
     } catch {
       dirty.current = true;
       setSyncState("degraded");
     }
-  }, [acknowledge, conflict, deviceClass, user?.id]);
+  }, [acknowledge, conflict, deviceClass, preferenceIdentity]);
 
   useEffect(() => {
     if (!dirty.current || conflict) return;
@@ -233,7 +241,7 @@ export function ConsolePreferencesProvider({
       syncState !== "degraded" ||
       dirty.current ||
       conflict ||
-      !user?.id
+      !preferenceIdentity
     )
       return;
     const timer = window.setInterval(() => {
@@ -246,13 +254,13 @@ export function ConsolePreferencesProvider({
           }>;
         })
         .then((payload) => {
-          acknowledge(user.id, payload.version, payload.profile);
+          acknowledge(preferenceIdentity, payload.version, payload.profile);
           setSyncState("synced");
         })
         .catch(() => setSyncState("degraded"));
     }, 5_000);
     return () => window.clearInterval(timer);
-  }, [acknowledge, conflict, deviceClass, syncState, user?.id]);
+  }, [acknowledge, conflict, deviceClass, preferenceIdentity, syncState]);
 
   const updateProfile = useCallback((update: Partial<ConsoleProfile>) => {
     dirty.current = true;
@@ -270,7 +278,7 @@ export function ConsolePreferencesProvider({
 
   const reset = useCallback(
     async (all: boolean) => {
-      if (!user?.id) return;
+      if (!user?.id || !preferenceIdentity) return;
       const response = await fetch(
         `${getApiBaseUrl()}/operator-preferences${all ? "" : `/${deviceClass}`}`,
         { method: "DELETE" },
@@ -278,16 +286,20 @@ export function ConsolePreferencesProvider({
       if (!response.ok) throw new Error(`Reset failed (${response.status})`);
       if (all) {
         (["desktop", "tablet", "phone"] as DeviceClass[]).forEach((target) =>
-          window.localStorage.removeItem(cacheKey(user.id, target)),
+          [user.id, preferenceIdentity].forEach((identity) =>
+            window.localStorage.removeItem(cacheKey(identity, target)),
+          ),
         );
       } else {
-        window.localStorage.removeItem(cacheKey(user.id, deviceClass));
+        [user.id, preferenceIdentity].forEach((identity) =>
+          window.localStorage.removeItem(cacheKey(identity, deviceClass)),
+        );
       }
-      acknowledge(user.id, 0, defaultConsoleProfile(deviceClass));
+      acknowledge(preferenceIdentity, 0, defaultConsoleProfile(deviceClass));
       dirty.current = false;
       setSyncState("synced");
     },
-    [acknowledge, deviceClass, user?.id],
+    [acknowledge, deviceClass, preferenceIdentity, user?.id],
   );
 
   const value: ConsolePreferencesValue = {
@@ -302,8 +314,8 @@ export function ConsolePreferencesProvider({
     resetCurrent: () => reset(false),
     resetAll: () => reset(true),
     useAuthoritative: () => {
-      if (!conflict || !user?.id) return;
-      acknowledge(user.id, conflict.version, conflict.authoritative);
+      if (!conflict || !preferenceIdentity) return;
+      acknowledge(preferenceIdentity, conflict.version, conflict.authoritative);
       setConflict(null);
       setSyncState("synced");
     },
@@ -316,9 +328,9 @@ export function ConsolePreferencesProvider({
       setSyncState("degraded");
     },
     adoptAcknowledged: (nextVersion, nextProfile) => {
-      if (!user?.id) return;
+      if (!preferenceIdentity) return;
       dirty.current = false;
-      acknowledge(user.id, nextVersion, nextProfile);
+      acknowledge(preferenceIdentity, nextVersion, nextProfile);
       setConflict(null);
       setSyncState("synced");
     },

--- a/frontend/app/contexts/ConsolePreferencesContext.tsx
+++ b/frontend/app/contexts/ConsolePreferencesContext.tsx
@@ -105,10 +105,11 @@ function cacheKey(subject: string, deviceClass: DeviceClass): string {
 function readCache(
   subject: string,
   deviceClass: DeviceClass,
+  storage: Pick<Storage, "getItem"> = window.localStorage,
 ): { version: number; profile: ConsoleProfile } | null {
   try {
     const value = JSON.parse(
-      window.localStorage.getItem(cacheKey(subject, deviceClass)) ?? "null",
+      storage.getItem(cacheKey(subject, deviceClass)) ?? "null",
     ) as { version?: unknown; profile?: unknown } | null;
     if (
       !value ||
@@ -121,6 +122,26 @@ function readCache(
   } catch {
     return null;
   }
+}
+
+export function readPreferenceCache(
+  user: { id: string; principalId?: string | null } | undefined,
+  deviceClass: DeviceClass,
+  storage: Pick<Storage, "getItem" | "setItem"> = window.localStorage,
+): { version: number; profile: ConsoleProfile } | null {
+  const preferredIdentity = preferenceCacheIdentity(user);
+  if (!preferredIdentity) return null;
+
+  const preferred = readCache(preferredIdentity, deviceClass, storage);
+  if (preferred || !user?.id || preferredIdentity === user.id) return preferred;
+
+  const legacy = readCache(user.id, deviceClass, storage);
+  if (!legacy) return null;
+  storage.setItem(
+    cacheKey(preferredIdentity, deviceClass),
+    JSON.stringify(legacy),
+  );
+  return legacy;
 }
 
 export function ConsolePreferencesProvider({
@@ -163,7 +184,7 @@ export function ConsolePreferencesProvider({
     if (!authLoaded || !preferenceIdentity) return;
     dirty.current = false;
     setConflict(null);
-    const cached = readCache(preferenceIdentity, deviceClass);
+    const cached = readPreferenceCache(user, deviceClass);
     if (cached) acknowledge(preferenceIdentity, cached.version, cached.profile);
     else {
       setProfile(defaultConsoleProfile(deviceClass));
@@ -183,7 +204,7 @@ export function ConsolePreferencesProvider({
         setSyncState("synced");
       })
       .catch(() => setSyncState("degraded"));
-  }, [acknowledge, authLoaded, deviceClass, preferenceIdentity]);
+  }, [acknowledge, authLoaded, deviceClass, preferenceIdentity, user]);
 
   const save = useCallback(async () => {
     if (!preferenceIdentity || !dirty.current || conflict) return;

--- a/frontend/app/models/user.ts
+++ b/frontend/app/models/user.ts
@@ -1,5 +1,6 @@
 export interface User {
   id: string;
+  principalId?: string | null;
   email: string;
   name?: string;
   picture?: string;


### PR DESCRIPTION
## Summary

- consume the landed Pompeii canonical-principal report without manual identity reshaping, with a deterministic Alcantara reference exporter and strict consumer/reference validation
- inventory and migrate operator preferences, shared layouts, guest invitations, and GuestEvent audit actors with count-only reporting, producer collision/missing refusal, idempotent apply, and rollback SQL
- bootstrap the canonical ARAUCO database secret before Prisma access and run apply planning plus compare-and-set writes in one serializable transaction
- propagate canonical identities through authorization, preference, invitation, audit, and operator-token writes
- preserve migration-window ownership safely: canonical and legacy candidates are checked together, subject fallback is limited to canonical-null rows, and saves remain bound to the ownership mode selected before the optimistic write
- migrate a valid legacy browser preference cache to its canonical key while preserving canonical-key precedence
- document the producer/consumer exchange, rollout, conflict handling, metrics, and rollback

## Validation

- `pnpm --dir backend exec jest --runInBand --silent` — 28 suites, 148 tests passed
- `pnpm --dir backend run build`
- `pnpm --dir backend run test:deployment` — 6 tests passed
- `pnpm --dir frontend test` — 11 files, 46 tests passed before the final backend/docs-only repair
- `pnpm --dir frontend build` before the final backend/docs-only repair
- changed-file backend ESLint, Prettier, and `git diff --check`
- PostgreSQL 17 drill from an empty database: all 7 migrations applied; export produced exactly 3 Alcantara references at mode 0600; native producer report applied 3 rows; reapply changed 0 and classified all 3 as migrated; GuestEvent auxiliary JSON and all legacy subject/audit values survived; rollback removed all 3 canonical columns while retaining the 3 legacy values
- exact-head Backend CI, including the authenticated metrics scrape: https://github.com/gaulatti/alcantara/actions/runs/34096991521
- independent exact-head review of `9b43e1a77101b1cdb7507d57449085b0dd89f3d2` found the producer contract, secret bootstrap, transaction/CAS, collision handling, cache migration, and preference read/save/reset ownership boundaries clear

## Boundaries

- No production database, identity, deployment, merge, or production credential action was performed.
- Frontend typecheck still reports unrelated pre-existing errors outside the changed files; tests and the production build pass.
- The repository wiki remote was unavailable, so the equivalent committed in-repository documentation was updated.
- The inherited scoped work was preserved in commit `aa52c62` before merging current `origin/main`.

Closes #57
