### PR TITLE
feat(program): register external renderer templates

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -213,7 +213,7 @@ jobs:
             -e ALCANTARA_BUILD_VERSION="${{ github.sha }}" \
             -e METRICS_TOKEN_FILE=/run/secrets/alcantara-metrics-token \
             -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
-            -e ALLOWED_ORIGINS="${{ vars.FQDN }}" \
+            -e ALLOWED_ORIGINS="${{ vars.FQDN }},https://fifthbell.com,https://cdn.fifthbell.com" \
             -e AWS_REGION="${{ vars.AWS_REGION }}" \
             -e ALCANTARA_CONFIG_SECRET_ID="${{ env.ALCANTARA_CONFIG_SECRET_ID }}" \
             -e PALAZZO_CONTROL_TOKEN_FILE=/run/secrets/palazzo-control-token \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ alcantara/
 ├── frontend/          # React Router v7 application
 │   ├── app/
 │   │   ├── routes/
-│   │   │   ├── program.tsx    # TV display page (1920x1080 fixed)
+│   │   │   ├── programs.tsx   # Program and template registration
 │   │   │   └── control.tsx    # Admin control panel
 │   │   └── hooks/
 │   │       └── useSSE.ts      # SSE client with auto-reconnect
@@ -41,6 +41,8 @@ alcantara/
 
 - Per-song recorded intro assignment, validation, and stable sequence identity
   are documented in [Song intro editorial model](docs/song-intros.md).
+- External renderer registration and the versioned manifest boundary are
+  documented in [Program template contracts](docs/program-templates.md).
 - The proposed managed RTMP/WHIP/HLS/SRT source boundary, local measurements,
   security findings, and phased rollout are documented in
   [ADR 001: LiveKit external-source ingress](docs/adr-001-livekit-external-source-ingress.md).
@@ -143,17 +145,16 @@ across retries and is also used by telemetry reconnect and startup recovery.
 See [`docs/radio-telemetry.md`](docs/radio-telemetry.md) for the contract,
 Secrets Manager bootstrap, allowlisted URLs, failure behavior, and metrics.
 
-### Program Page (`/program`)
+### Program output
 
-- Fixed 1920x1080 Full HD resolution (hardcoded, not responsive)
-- Real-time updates via SSE
-- Auto-reconnecting SSE client
-- Frontend deploys invalidate every CloudFront SPA route; the HTML shell is never
-  cached as immutable, while content-hashed assets retain long-lived caching
-- Supports multiple layout types:
-  - Lower Third
-  - Full Screen
-  - Corner Bug
+Alcantara is the program control plane. A program can reference an immutable
+template manifest published by Cronkite; the operator UI opens that external
+renderer with the program ID and Alcantara API origin from the manifest's
+runtime-parameter contract. The legacy `/program/:programId` renderer remains
+only as a temporary rollback path until the Fifthbell registration and live
+cutover have been verified. See
+[Program template contracts](docs/program-templates.md) for registration,
+security, state/SSE projection, metrics, and removal gates.
 
 ### Control Page (`/control`)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,6 @@
 # Copy to .env and fill values
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/alcantara?schema=public"
-ALLOWED_ORIGINS="http://localhost:5173,https://alcantara.gaulatti.com,https://alcantara.dev,https://alcantara.gt"
+ALLOWED_ORIGINS="http://localhost:5173,https://alcantara.gaulatti.com,https://alcantara.dev,https://alcantara.gt,https://fifthbell.com,https://cdn.fifthbell.com"
 PORT=3000
 AWS_REGION=us-east-1
 ALCANTARA_BUILD_VERSION=dev

--- a/backend/prisma/migrations/20260908190000_program_template_registry/migration.sql
+++ b/backend/prisma/migrations/20260908190000_program_template_registry/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "ProgramState"
+ADD COLUMN "templateUrl" TEXT,
+ADD COLUMN "templateManifest" JSONB,
+ADD COLUMN "templateVerifiedAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -36,6 +36,9 @@ model ProgramState {
   id                     Int                  @id @default(autoincrement())
   programId              String               @unique
   type                   String               @default("tv")
+  templateUrl            String?
+  templateManifest       Json?
+  templateVerifiedAt     DateTime?
   activeSceneId          Int?
   activeScene            Scene?               @relation(fields: [activeSceneId], references: [id])
   stagedSceneId          Int?

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -26,6 +26,8 @@ function getAllowedOrigins(): Set<string> {
     'https://alcantara.gaulatti.com',
     'https://alcantara.dev',
     'https://alcantara.gt',
+    'https://fifthbell.com',
+    'https://cdn.fifthbell.com',
     ...configuredOrigins,
   ]);
 }

--- a/backend/src/observability/managed-metrics.service.spec.ts
+++ b/backend/src/observability/managed-metrics.service.spec.ts
@@ -10,6 +10,7 @@ describe('ManagedMetricsService program SSE metrics', () => {
     metrics.recordProgramSseSnapshot('success');
     metrics.recordProgramSseSnapshot('failure');
     metrics.recordProgramSseSnapshot('unbounded-value');
+    metrics.recordDependency('program-template', 'fetch', 'success', 0.25);
     metrics.recordRecordingCommand('start', 'accepted');
     metrics.recordRecordingCommand('private-action', 'private-result');
     metrics.recordRecordingStatus('finalizing', 'success');
@@ -27,6 +28,9 @@ describe('ManagedMetricsService program SSE metrics', () => {
       'alcantara_program_sse_snapshots_total{result="unknown"} 1',
     );
     expect(output).not.toContain('result="unbounded-value"');
+    expect(output).toContain(
+      'alcantara_dependency_operations_total{dependency="program-template",operation="fetch",result="success"} 1',
+    );
     expect(output).toContain(
       'alcantara_recording_commands_total{action="start",result="accepted"} 1',
     );

--- a/backend/src/observability/managed-metrics.service.ts
+++ b/backend/src/observability/managed-metrics.service.ts
@@ -44,6 +44,7 @@ const DEPENDENCIES = new Set([
   's3',
   'livekit',
   'alana',
+  'program-template',
   'unknown',
 ]);
 const DEPENDENCY_OPERATIONS = new Set([

--- a/backend/src/program/program-template.service.spec.ts
+++ b/backend/src/program/program-template.service.spec.ts
@@ -1,0 +1,250 @@
+import {
+  ProgramTemplateService,
+  isPublicNetworkAddress,
+  projectProgramTemplateSignal,
+  projectProgramTemplateState,
+  validateProgramTemplateManifest,
+} from './program-template.service';
+
+const manifest = {
+  kind: 'alcantara.program-template',
+  contractVersion: 1,
+  id: 'fifthbell.live-program',
+  name: 'Fifthbell Live Program',
+  package: '@fifthbell/brokaw',
+  bundleVersion: '0.1.65',
+  schemaVersion: 1,
+  entrypoint: 'index.html',
+  capabilities: ['audio.playback', 'scene.configuration'],
+  control: {
+    protocol: 'alcantara.program.v1',
+    transport: 'server-sent-events',
+    snapshotPath: 'state',
+    eventsPath: 'events',
+    runtimeParameters: {
+      programId: 'programId',
+      apiBaseUrl: 'apiBaseUrl',
+    },
+    signals: ['program_state_snapshot', 'scene_change'],
+  },
+};
+
+type TestableProgramTemplateService = ProgramTemplateService & {
+  resolveHost: (
+    hostname: string,
+    options: { all: true; verbatim: true },
+  ) => Promise<Array<{ address: string; family: number }>>;
+  fetchManifest: typeof fetch;
+};
+
+describe('ProgramTemplateService', () => {
+  it('normalizes the entrypoint and declared capabilities', () => {
+    expect(
+      validateProgramTemplateManifest(
+        manifest,
+        new URL(
+          'https://cdn.fifthbell.com/html/program-releases/0.1.65/live-program-manifest.json',
+        ),
+      ),
+    ).toMatchObject({
+      id: 'fifthbell.live-program',
+      entrypointUrl:
+        'https://cdn.fifthbell.com/html/program-releases/0.1.65/index.html',
+      capabilities: ['audio.playback', 'scene.configuration'],
+    });
+  });
+
+  it('rejects missing capabilities and server-unknown signals', () => {
+    expect(() =>
+      validateProgramTemplateManifest(
+        { ...manifest, capabilities: [] },
+        new URL('https://cdn.example.test/manifest.json'),
+      ),
+    ).toThrow('capabilities must be a non-empty array');
+    expect(() =>
+      validateProgramTemplateManifest(
+        {
+          ...manifest,
+          control: { ...manifest.control, signals: ['dump_operator_state'] },
+        },
+        new URL('https://cdn.example.test/manifest.json'),
+      ),
+    ).toThrow('requests unsupported signal dump_operator_state');
+    expect(() =>
+      validateProgramTemplateManifest(
+        {
+          ...manifest,
+          control: { ...manifest.control, signals: ['scene_change'] },
+        },
+        new URL('https://cdn.example.test/manifest.json'),
+      ),
+    ).toThrow('must accept program_state_snapshot');
+  });
+
+  it('classifies private, loopback, documentation, and public addresses', () => {
+    expect(isPublicNetworkAddress('127.0.0.1')).toBe(false);
+    expect(isPublicNetworkAddress('10.0.0.8')).toBe(false);
+    expect(isPublicNetworkAddress('169.254.169.254')).toBe(false);
+    expect(isPublicNetworkAddress('203.0.113.8')).toBe(false);
+    expect(isPublicNetworkAddress('::1')).toBe(false);
+    expect(isPublicNetworkAddress('2001:db8::1')).toBe(false);
+    expect(isPublicNetworkAddress('1.1.1.1')).toBe(true);
+    expect(isPublicNetworkAddress('2606:4700:4700::1111')).toBe(true);
+  });
+
+  it('fetches a bounded JSON manifest after validating the destination', async () => {
+    const metrics = { recordDependency: jest.fn() };
+    const service = new ProgramTemplateService(metrics as never);
+    const testable = service as TestableProgramTemplateService;
+    testable.resolveHost = jest
+      .fn()
+      .mockResolvedValue([{ address: '1.1.1.1', family: 4 }]);
+    const fetchManifest = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify(manifest), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    testable.fetchManifest = fetchManifest as unknown as typeof fetch;
+
+    const result = await service.inspect(
+      'https://cdn.fifthbell.com/templates/live-program-manifest.json',
+    );
+
+    expect(result.templateManifest.entrypointUrl).toBe(
+      'https://cdn.fifthbell.com/templates/index.html',
+    );
+    expect(fetchManifest).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({ redirect: 'manual' }),
+    );
+    expect(metrics.recordDependency).toHaveBeenCalledWith(
+      'program-template',
+      'fetch',
+      'success',
+      expect.any(Number),
+    );
+  });
+
+  it('rejects private manifest destinations before fetching', async () => {
+    const metrics = { recordDependency: jest.fn() };
+    const service = new ProgramTemplateService(metrics as never);
+    const testable = service as TestableProgramTemplateService;
+    const fetchManifest = jest.fn();
+    testable.fetchManifest = fetchManifest as unknown as typeof fetch;
+
+    await expect(
+      service.inspect('https://169.254.169.254/template.json'),
+    ).rejects.toThrow('public network address');
+    expect(fetchManifest).not.toHaveBeenCalled();
+    expect(metrics.recordDependency).toHaveBeenCalledWith(
+      'program-template',
+      'fetch',
+      'failure',
+      expect.any(Number),
+    );
+  });
+
+  it('stops reading a manifest that exceeds the response limit', async () => {
+    const service = new ProgramTemplateService();
+    const testable = service as TestableProgramTemplateService;
+    testable.resolveHost = jest
+      .fn()
+      .mockResolvedValue([{ address: '1.1.1.1', family: 4 }]);
+    testable.fetchManifest = jest.fn().mockResolvedValue(
+      new Response(Buffer.alloc(256 * 1024 + 1), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      service.inspect('https://cdn.fifthbell.com/templates/manifest.json'),
+    ).rejects.toThrow('too large');
+  });
+
+  it('accepts only the Cronkite CDN publisher in production', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const service = new ProgramTemplateService();
+    const testable = service as TestableProgramTemplateService;
+    const fetchManifest = jest.fn();
+    testable.fetchManifest = fetchManifest as unknown as typeof fetch;
+
+    try {
+      await expect(
+        service.inspect('https://templates.example.test/manifest.json'),
+      ).rejects.toThrow('not an approved program-template publisher');
+      expect(fetchManifest).not.toHaveBeenCalled();
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
+  it('projects only renderer state and manifest-approved signal fields', () => {
+    const validated = validateProgramTemplateManifest(
+      manifest,
+      new URL('https://cdn.fifthbell.com/template/manifest.json'),
+    );
+    const state = projectProgramTemplateState({
+      id: 7,
+      programId: 'fifthbell',
+      activeSceneId: 34,
+      activeScene: {
+        id: 34,
+        name: 'Live',
+        layoutId: 4,
+        layout: {
+          id: 4,
+          name: 'Fifthbell',
+          componentType: 'fifthbell',
+          settings: '{}',
+          internalOnly: 'hidden',
+        },
+        chyronText: null,
+        metadata: '{}',
+        internalOnly: 'hidden',
+      },
+      stagedSceneId: null,
+      stagedScene: null,
+      fadeToBlack: false,
+      updatedAt: '2026-09-08T18:00:00.000Z',
+      version: 8,
+      songSequence: { privateQueue: true },
+      templateManifest: validated,
+    });
+
+    expect(state).not.toHaveProperty('songSequence');
+    expect(state).not.toHaveProperty('templateManifest');
+    expect(state.activeScene).not.toHaveProperty('internalOnly');
+    const activeScene = state.activeScene as {
+      layout: Record<string, unknown>;
+    };
+    expect(activeScene.layout).not.toHaveProperty('internalOnly');
+
+    expect(
+      projectProgramTemplateSignal(
+        {
+          type: 'scene_change',
+          programId: 'fifthbell',
+          version: 9,
+          transitionId: 'cut',
+          state: { ...state, secret: 'hidden' },
+          secret: 'hidden',
+        },
+        validated,
+      ),
+    ).toMatchObject({
+      type: 'scene_change',
+      schemaVersion: 1,
+      version: 9,
+      transitionId: 'cut',
+    });
+    expect(
+      projectProgramTemplateSignal(
+        { type: 'operator_snapshot', secret: 'hidden' },
+        validated,
+      ),
+    ).toBeNull();
+  });
+});

--- a/backend/src/program/program-template.service.ts
+++ b/backend/src/program/program-template.service.ts
@@ -1,0 +1,601 @@
+import { BadRequestException, Injectable, Optional } from '@nestjs/common';
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+import { ManagedMetricsService } from '../observability/managed-metrics.service';
+
+export const PROGRAM_TEMPLATE_KIND = 'alcantara.program-template';
+export const PROGRAM_TEMPLATE_CONTRACT_VERSION = 1;
+export const PROGRAM_TEMPLATE_PROTOCOL = 'alcantara.program.v1';
+
+const MAX_MANIFEST_BYTES = 256 * 1024;
+const MAX_REDIRECTS = 3;
+const MANIFEST_TIMEOUT_MS = 5_000;
+const PRODUCTION_TEMPLATE_ORIGINS = new Set(['https://cdn.fifthbell.com']);
+const TOKEN_PATTERN = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/;
+const PARAMETER_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/;
+const SIGNAL_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+export const PROGRAM_TEMPLATE_SIGNALS = new Set([
+  'audio_bus_update',
+  'broadcast_settings_update',
+  'heartbeat',
+  'instant_play',
+  'instant_stop_all',
+  'program_media_groups_changed',
+  'program_reload',
+  'program_scenes_changed',
+  'program_state_snapshot',
+  'program_stingers_changed',
+  'scene_change',
+  'scene_cleared',
+  'scene_instant_state',
+  'scene_instant_stop',
+  'scene_instant_take',
+  'scene_staged',
+  'scene_update',
+  'song_off_air',
+]);
+
+export interface ProgramTemplateManifest {
+  kind: typeof PROGRAM_TEMPLATE_KIND;
+  contractVersion: typeof PROGRAM_TEMPLATE_CONTRACT_VERSION;
+  id: string;
+  name: string;
+  package: string;
+  bundleVersion: string;
+  schemaVersion: number;
+  entrypoint: string;
+  entrypointUrl: string;
+  capabilities: string[];
+  control: {
+    protocol: typeof PROGRAM_TEMPLATE_PROTOCOL;
+    transport: 'server-sent-events';
+    snapshotPath: string;
+    eventsPath: string;
+    runtimeParameters: {
+      programId: string;
+      apiBaseUrl: string;
+    };
+    signals: string[];
+  };
+}
+
+export interface ProgramTemplateRegistration {
+  templateUrl: string;
+  templateManifest: ProgramTemplateManifest;
+  templateVerifiedAt: Date;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requiredString(
+  value: unknown,
+  field: string,
+  pattern?: RegExp,
+): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new BadRequestException(`Template manifest ${field} is required`);
+  }
+  const normalized = value.trim();
+  if (normalized.length > 200 || (pattern && !pattern.test(normalized))) {
+    throw new BadRequestException(`Template manifest ${field} is invalid`);
+  }
+  return normalized;
+}
+
+function uniqueStringList(
+  value: unknown,
+  field: string,
+  pattern: RegExp,
+  maximum: number,
+): string[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > maximum) {
+    throw new BadRequestException(
+      `Template manifest ${field} must be a non-empty array`,
+    );
+  }
+  const normalized = value.map((entry) =>
+    requiredString(entry, field, pattern),
+  );
+  if (new Set(normalized).size !== normalized.length) {
+    throw new BadRequestException(
+      `Template manifest ${field} contains duplicates`,
+    );
+  }
+  return normalized;
+}
+
+function safeRelativePath(value: unknown, field: string): string {
+  const path = requiredString(value, field);
+  if (
+    path.startsWith('/') ||
+    path.includes('\\') ||
+    path.includes('?') ||
+    path.includes('#') ||
+    path.split('/').some((segment) => segment === '.' || segment === '..')
+  ) {
+    throw new BadRequestException(`Template manifest ${field} is invalid`);
+  }
+  return path;
+}
+
+async function readBoundedManifestBody(response: Response): Promise<Buffer> {
+  if (!response.body) return Buffer.alloc(0);
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      bytes += next.value.byteLength;
+      if (bytes > MAX_MANIFEST_BYTES) {
+        await reader.cancel();
+        throw new BadRequestException('Template manifest is too large');
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(
+    chunks.map((chunk) => Buffer.from(chunk)),
+    bytes,
+  );
+}
+
+export function validateProgramTemplateManifest(
+  value: unknown,
+  manifestUrl: URL,
+): ProgramTemplateManifest {
+  if (!isRecord(value)) {
+    throw new BadRequestException('Template manifest must be a JSON object');
+  }
+  if (value.kind !== PROGRAM_TEMPLATE_KIND) {
+    throw new BadRequestException(
+      `Template manifest kind must be ${PROGRAM_TEMPLATE_KIND}`,
+    );
+  }
+  if (value.contractVersion !== PROGRAM_TEMPLATE_CONTRACT_VERSION) {
+    throw new BadRequestException(
+      `Unsupported template contract version ${String(value.contractVersion)}`,
+    );
+  }
+  if (value.schemaVersion !== 1) {
+    throw new BadRequestException(
+      `Unsupported program state schema version ${String(value.schemaVersion)}`,
+    );
+  }
+
+  const entrypoint = safeRelativePath(value.entrypoint, 'entrypoint');
+  const entrypointUrl = new URL(entrypoint, manifestUrl);
+  if (entrypointUrl.origin !== manifestUrl.origin) {
+    throw new BadRequestException(
+      'Template manifest entrypoint must remain on the manifest origin',
+    );
+  }
+  const capabilities = uniqueStringList(
+    value.capabilities,
+    'capabilities',
+    TOKEN_PATTERN,
+    64,
+  );
+
+  if (!isRecord(value.control)) {
+    throw new BadRequestException('Template manifest control is required');
+  }
+  if (value.control.protocol !== PROGRAM_TEMPLATE_PROTOCOL) {
+    throw new BadRequestException(
+      `Template manifest control protocol must be ${PROGRAM_TEMPLATE_PROTOCOL}`,
+    );
+  }
+  if (value.control.transport !== 'server-sent-events') {
+    throw new BadRequestException(
+      'Template manifest control transport must be server-sent-events',
+    );
+  }
+  if (!isRecord(value.control.runtimeParameters)) {
+    throw new BadRequestException(
+      'Template manifest control.runtimeParameters is required',
+    );
+  }
+  const snapshotPath = safeRelativePath(
+    value.control.snapshotPath,
+    'control.snapshotPath',
+  );
+  const eventsPath = safeRelativePath(
+    value.control.eventsPath,
+    'control.eventsPath',
+  );
+  if (snapshotPath !== 'state' || eventsPath !== 'events') {
+    throw new BadRequestException(
+      'Template manifest control paths are unsupported',
+    );
+  }
+  const signals = uniqueStringList(
+    value.control.signals,
+    'control.signals',
+    SIGNAL_PATTERN,
+    64,
+  );
+  const unsupportedSignal = signals.find(
+    (signal) => !PROGRAM_TEMPLATE_SIGNALS.has(signal),
+  );
+  if (unsupportedSignal) {
+    throw new BadRequestException(
+      `Template manifest requests unsupported signal ${unsupportedSignal}`,
+    );
+  }
+  if (!signals.includes('program_state_snapshot')) {
+    throw new BadRequestException(
+      'Template manifest must accept program_state_snapshot',
+    );
+  }
+
+  return {
+    kind: PROGRAM_TEMPLATE_KIND,
+    contractVersion: PROGRAM_TEMPLATE_CONTRACT_VERSION,
+    id: requiredString(value.id, 'id', TOKEN_PATTERN),
+    name: requiredString(value.name, 'name'),
+    package: requiredString(value.package, 'package'),
+    bundleVersion: requiredString(value.bundleVersion, 'bundleVersion'),
+    schemaVersion: 1,
+    entrypoint,
+    entrypointUrl: entrypointUrl.toString(),
+    capabilities,
+    control: {
+      protocol: PROGRAM_TEMPLATE_PROTOCOL,
+      transport: 'server-sent-events',
+      snapshotPath,
+      eventsPath,
+      runtimeParameters: {
+        programId: requiredString(
+          value.control.runtimeParameters.programId,
+          'control.runtimeParameters.programId',
+          PARAMETER_PATTERN,
+        ),
+        apiBaseUrl: requiredString(
+          value.control.runtimeParameters.apiBaseUrl,
+          'control.runtimeParameters.apiBaseUrl',
+          PARAMETER_PATTERN,
+        ),
+      },
+      signals,
+    },
+  };
+}
+
+function isBlockedIpv4(address: string): boolean {
+  const octets = address.split('.').map((part) => Number(part));
+  if (
+    octets.length !== 4 ||
+    octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+  ) {
+    return true;
+  }
+  const [a, b, c] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0 && (c === 0 || c === 2)) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224
+  );
+}
+
+export function isPublicNetworkAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 4) return !isBlockedIpv4(address);
+  if (family !== 6) return false;
+
+  const normalized = address.toLowerCase();
+  if (normalized.startsWith('::ffff:')) {
+    return isPublicNetworkAddress(normalized.slice('::ffff:'.length));
+  }
+  return !(
+    normalized === '::' ||
+    normalized === '::1' ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    /^fe[89ab]/.test(normalized) ||
+    normalized.startsWith('ff') ||
+    normalized.startsWith('2001:db8:')
+  );
+}
+
+export function readProgramTemplateManifest(
+  value: unknown,
+): ProgramTemplateManifest | null {
+  if (
+    !isRecord(value) ||
+    value.kind !== PROGRAM_TEMPLATE_KIND ||
+    value.contractVersion !== PROGRAM_TEMPLATE_CONTRACT_VERSION ||
+    typeof value.entrypointUrl !== 'string' ||
+    !Array.isArray(value.capabilities) ||
+    !isRecord(value.control) ||
+    !Array.isArray(value.control.signals)
+  ) {
+    return null;
+  }
+  return value as unknown as ProgramTemplateManifest;
+}
+
+function projectScene(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value) || !isRecord(value.layout)) return null;
+  return {
+    id: value.id,
+    name: value.name,
+    layoutId: value.layoutId,
+    layout: {
+      id: value.layout.id,
+      name: value.layout.name,
+      componentType: value.layout.componentType,
+      settings: value.layout.settings,
+    },
+    chyronText: value.chyronText ?? null,
+    metadata: value.metadata ?? null,
+  };
+}
+
+export function projectProgramTemplateState(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    id: value.id,
+    programId: value.programId,
+    activeSceneId: value.activeSceneId ?? null,
+    activeScene: projectScene(value.activeScene),
+    stagedSceneId: value.stagedSceneId ?? null,
+    stagedScene: projectScene(value.stagedScene),
+    fadeToBlack: value.fadeToBlack === true,
+    updatedAt: value.updatedAt,
+    version: value.version,
+  };
+}
+
+function copyFields(
+  source: Record<string, unknown>,
+  fields: string[],
+): Record<string, unknown> {
+  return Object.fromEntries(
+    fields
+      .filter((field) => source[field] !== undefined)
+      .map((field) => [field, source[field]]),
+  );
+}
+
+export function projectProgramTemplateSignal(
+  value: unknown,
+  manifest: ProgramTemplateManifest,
+): Record<string, unknown> | null {
+  if (!isRecord(value) || typeof value.type !== 'string') return null;
+  if (!manifest.control.signals.includes(value.type)) return null;
+
+  const common = {
+    type: value.type,
+    programId: value.programId,
+    schemaVersion: 1,
+    version: value.version,
+  };
+  if (
+    value.type === 'scene_change' ||
+    value.type === 'program_scenes_changed' ||
+    value.type === 'program_media_groups_changed' ||
+    value.type === 'program_stingers_changed'
+  ) {
+    if (!isRecord(value.state)) return null;
+    return {
+      ...common,
+      ...copyFields(value, ['transitionId']),
+      state: projectProgramTemplateState({
+        ...value.state,
+        version: value.version,
+      }),
+    };
+  }
+
+  const fieldsBySignal: Record<string, string[]> = {
+    audio_bus_update: ['settings', 'updatedAt'],
+    broadcast_settings_update: ['settings', 'updatedAt'],
+    heartbeat: ['sentAt'],
+    instant_play: ['instant', 'triggeredAt'],
+    instant_stop_all: ['triggeredAt'],
+    program_reload: ['triggeredAt'],
+    scene_cleared: ['updatedAt'],
+    scene_instant_state: ['playback'],
+    scene_instant_stop: ['sceneId', 'instantId', 'triggeredAt', 'fadeMs'],
+    scene_instant_take: ['sceneId', 'instant', 'loop', 'triggeredAt'],
+    scene_staged: ['stagedSceneId', 'updatedAt'],
+    scene_update: ['updatedAt'],
+    song_off_air: ['triggeredAt'],
+  };
+  const projected: Record<string, unknown> = {
+    ...common,
+    ...copyFields(value, fieldsBySignal[value.type] ?? []),
+  };
+  if (value.type === 'scene_staged' || value.type === 'scene_update') {
+    projected.scene = projectScene(value.scene);
+  }
+  return projected;
+}
+
+@Injectable()
+export class ProgramTemplateService {
+  protected readonly resolveHost = lookup;
+  protected readonly fetchManifest = globalThis.fetch;
+
+  constructor(@Optional() private readonly metrics?: ManagedMetricsService) {}
+
+  async inspect(templateUrl: string): Promise<ProgramTemplateRegistration> {
+    const startedAt = Date.now();
+    try {
+      const registration = await this.inspectManifest(templateUrl);
+      this.metrics?.recordDependency(
+        'program-template',
+        'fetch',
+        'success',
+        (Date.now() - startedAt) / 1000,
+      );
+      return registration;
+    } catch (error) {
+      this.metrics?.recordDependency(
+        'program-template',
+        'fetch',
+        'failure',
+        (Date.now() - startedAt) / 1000,
+      );
+      throw error;
+    }
+  }
+
+  private async inspectManifest(
+    templateUrl: string,
+  ): Promise<ProgramTemplateRegistration> {
+    let currentUrl = this.parseTemplateUrl(templateUrl);
+
+    for (
+      let redirectCount = 0;
+      redirectCount <= MAX_REDIRECTS;
+      redirectCount += 1
+    ) {
+      await this.assertSafeDestination(currentUrl);
+      let response: Response;
+      try {
+        response = await this.fetchManifest(currentUrl, {
+          headers: { Accept: 'application/json' },
+          redirect: 'manual',
+          signal: AbortSignal.timeout(MANIFEST_TIMEOUT_MS),
+        });
+      } catch {
+        throw new BadRequestException('Template manifest could not be fetched');
+      }
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location');
+        if (!location || redirectCount === MAX_REDIRECTS) {
+          throw new BadRequestException(
+            'Template manifest redirect could not be followed safely',
+          );
+        }
+        currentUrl = this.parseTemplateUrl(
+          new URL(location, currentUrl).toString(),
+        );
+        continue;
+      }
+      if (!response.ok) {
+        throw new BadRequestException(
+          `Template manifest returned HTTP ${response.status}`,
+        );
+      }
+      const contentType = response.headers.get('content-type') ?? '';
+      if (!/(?:application\/json|\+json)(?:;|$)/i.test(contentType)) {
+        throw new BadRequestException(
+          'Template manifest must use a JSON content type',
+        );
+      }
+      const declaredSize = Number(response.headers.get('content-length'));
+      if (Number.isFinite(declaredSize) && declaredSize > MAX_MANIFEST_BYTES) {
+        throw new BadRequestException('Template manifest is too large');
+      }
+      let body: Buffer;
+      try {
+        body = await readBoundedManifestBody(response);
+      } catch (error) {
+        if (error instanceof BadRequestException) throw error;
+        throw new BadRequestException('Template manifest could not be read');
+      }
+
+      let decoded: unknown;
+      try {
+        decoded = JSON.parse(body.toString('utf8')) as unknown;
+      } catch {
+        throw new BadRequestException('Template manifest is not valid JSON');
+      }
+      return {
+        templateUrl: currentUrl.toString(),
+        templateManifest: validateProgramTemplateManifest(decoded, currentUrl),
+        templateVerifiedAt: new Date(),
+      };
+    }
+
+    throw new BadRequestException('Template manifest could not be fetched');
+  }
+
+  private parseTemplateUrl(value: string): URL {
+    let parsed: URL;
+    try {
+      parsed = new URL(value.trim());
+    } catch {
+      throw new BadRequestException('Template URL must be an absolute URL');
+    }
+    const localHttp =
+      process.env.NODE_ENV !== 'production' &&
+      parsed.protocol === 'http:' &&
+      (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1');
+    if (parsed.protocol !== 'https:' && !localHttp) {
+      throw new BadRequestException(
+        'Template URL must use HTTPS outside local development',
+      );
+    }
+    if (
+      process.env.NODE_ENV === 'production' &&
+      !PRODUCTION_TEMPLATE_ORIGINS.has(parsed.origin)
+    ) {
+      throw new BadRequestException(
+        'Template URL origin is not an approved program-template publisher',
+      );
+    }
+    if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+      throw new BadRequestException(
+        'Template URL cannot contain credentials, query parameters, or a fragment',
+      );
+    }
+    return parsed;
+  }
+
+  private async assertSafeDestination(url: URL): Promise<void> {
+    const localDevelopment =
+      process.env.NODE_ENV !== 'production' &&
+      url.protocol === 'http:' &&
+      (url.hostname === 'localhost' || url.hostname === '127.0.0.1');
+    if (localDevelopment) return;
+    if (url.hostname === 'localhost' || url.hostname.endsWith('.local')) {
+      throw new BadRequestException(
+        'Template URL must resolve to a public network address',
+      );
+    }
+    if (isIP(url.hostname) && !isPublicNetworkAddress(url.hostname)) {
+      throw new BadRequestException(
+        'Template URL must resolve to a public network address',
+      );
+    }
+
+    let addresses: Array<{ address: string }>;
+    try {
+      addresses = await this.resolveHost(url.hostname, {
+        all: true,
+        verbatim: true,
+      });
+    } catch {
+      throw new BadRequestException('Template URL host could not be resolved');
+    }
+    if (
+      addresses.length === 0 ||
+      addresses.some(({ address }) => !isPublicNetworkAddress(address))
+    ) {
+      throw new BadRequestException(
+        'Template URL must resolve only to public network addresses',
+      );
+    }
+  }
+}

--- a/backend/src/program/program.controller.spec.ts
+++ b/backend/src/program/program.controller.spec.ts
@@ -1,0 +1,67 @@
+import { ProgramController } from './program.controller';
+
+describe('ProgramController template registration', () => {
+  const registration = {
+    templateUrl: 'https://cdn.fifthbell.com/templates/manifest.json',
+    templateManifest: {
+      kind: 'alcantara.program-template',
+      contractVersion: 1,
+      id: 'fifthbell.live-program',
+    },
+    templateVerifiedAt: new Date('2026-09-08T18:00:00.000Z'),
+  };
+
+  it('inspects and persists a supplied template URL when creating a program', async () => {
+    const programService = {
+      createProgram: jest.fn().mockResolvedValue({ programId: 'fifthbell' }),
+    };
+    const templateService = {
+      inspect: jest.fn().mockResolvedValue(registration),
+    };
+    const controller = new ProgramController(
+      programService as never,
+      {} as never,
+      templateService as never,
+    );
+
+    await controller.createProgram({
+      programId: 'fifthbell',
+      type: 'tv',
+      templateUrl: registration.templateUrl,
+    });
+
+    expect(templateService.inspect).toHaveBeenCalledWith(
+      registration.templateUrl,
+    );
+    expect(programService.createProgram).toHaveBeenCalledWith(
+      'fifthbell',
+      'tv',
+      registration,
+    );
+  });
+
+  it('clears a template explicitly without performing a network request', async () => {
+    const programService = {
+      renameProgram: jest.fn().mockResolvedValue({ programId: 'main' }),
+    };
+    const templateService = { inspect: jest.fn() };
+    const controller = new ProgramController(
+      programService as never,
+      {} as never,
+      templateService as never,
+    );
+
+    await controller.renameProgram('main', {
+      nextProgramId: 'main',
+      templateUrl: null,
+    });
+
+    expect(templateService.inspect).not.toHaveBeenCalled();
+    expect(programService.renameProgram).toHaveBeenCalledWith(
+      'main',
+      'main',
+      undefined,
+      null,
+    );
+  });
+});

--- a/backend/src/program/program.controller.ts
+++ b/backend/src/program/program.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Get,
   Header,
@@ -17,6 +18,10 @@ import { FlightService } from './flight.service';
 import { ALCANTARA_PERMISSIONS } from '../auth/permissions';
 import { Public } from '../auth/public.decorator';
 import { RequirePermission } from '../auth/require-permission.decorator';
+import {
+  ProgramTemplateService,
+  type ProgramTemplateRegistration,
+} from './program-template.service';
 
 @Controller('program')
 @RequirePermission(ALCANTARA_PERMISSIONS.program.read)
@@ -24,6 +29,7 @@ export class ProgramController {
   constructor(
     private readonly programService: ProgramService,
     private readonly flightService: FlightService,
+    private readonly programTemplateService: ProgramTemplateService,
   ) {}
 
   @Get()
@@ -31,22 +37,50 @@ export class ProgramController {
     return this.programService.listPrograms();
   }
 
+  @Post('template/inspect')
+  @RequirePermission(ALCANTARA_PERMISSIONS.program.manage)
+  async inspectTemplate(@Body() data: { templateUrl?: string }) {
+    if (typeof data?.templateUrl !== 'string' || !data.templateUrl.trim()) {
+      throw new BadRequestException('templateUrl is required');
+    }
+    return this.programTemplateService.inspect(data.templateUrl);
+  }
+
   @Post()
   @RequirePermission(ALCANTARA_PERMISSIONS.program.manage)
-  async createProgram(@Body() data: { programId: string; type?: string }) {
-    return this.programService.createProgram(data.programId, data.type);
+  async createProgram(
+    @Body()
+    data: {
+      programId: string;
+      type?: string;
+      templateUrl?: string | null;
+    },
+  ) {
+    const template = await this.resolveTemplateRegistration(data.templateUrl);
+    return this.programService.createProgram(
+      data.programId,
+      data.type,
+      template,
+    );
   }
 
   @Put(':programId')
   @RequirePermission(ALCANTARA_PERMISSIONS.program.manage)
   async renameProgram(
     @Param('programId') programId: string,
-    @Body() data: { nextProgramId: string; type?: string },
+    @Body()
+    data: {
+      nextProgramId: string;
+      type?: string;
+      templateUrl?: string | null;
+    },
   ) {
+    const template = await this.resolveTemplateRegistration(data.templateUrl);
     return this.programService.renameProgram(
       programId,
       data.nextProgramId,
       data.type,
+      template,
     );
   }
 
@@ -95,7 +129,7 @@ export class ProgramController {
   @Get(':programId/state')
   @Public()
   async getStateById(@Param('programId') programId: string) {
-    return this.programService.getState(programId);
+    return this.programService.getPublicState(programId);
   }
 
   @Get(':programId/audio-bus')
@@ -470,5 +504,13 @@ export class ProgramController {
   @Header('X-Accel-Buffering', 'no')
   events(): Observable<{ data: string }> {
     return this.programService.getEventStream();
+  }
+
+  private async resolveTemplateRegistration(
+    templateUrl: string | null | undefined,
+  ): Promise<ProgramTemplateRegistration | null | undefined> {
+    if (templateUrl === undefined) return undefined;
+    if (templateUrl === null || !templateUrl.trim()) return null;
+    return this.programTemplateService.inspect(templateUrl);
   }
 }

--- a/backend/src/program/program.module.ts
+++ b/backend/src/program/program.module.ts
@@ -4,6 +4,7 @@ import { ProgramService } from './program.service';
 import { ProgramRealtimeService } from './program.realtime.service';
 import { FlightService } from './flight.service';
 import { PrismaService } from '../prisma.service';
+import { ProgramTemplateService } from './program-template.service';
 
 @Global()
 @Module({
@@ -12,6 +13,7 @@ import { PrismaService } from '../prisma.service';
     ProgramService,
     ProgramRealtimeService,
     FlightService,
+    ProgramTemplateService,
     PrismaService,
   ],
   exports: [ProgramService, ProgramRealtimeService, FlightService],

--- a/backend/src/program/program.service.spec.ts
+++ b/backend/src/program/program.service.spec.ts
@@ -259,4 +259,95 @@ describe('ProgramService switcher state', () => {
     firstSubscription.unsubscribe();
     secondSubscription.unsubscribe();
   });
+
+  it('projects registered template snapshots and forwards only declared signals', async () => {
+    const { service } = buildService({
+      id: 1,
+      programId: 'fifthbell',
+      activeSceneId: scene.id,
+      stagedSceneId: null,
+      fadeToBlack: false,
+    });
+    const templateManifest = {
+      kind: 'alcantara.program-template',
+      contractVersion: 1,
+      id: 'fifthbell.live-program',
+      name: 'Fifthbell Live Program',
+      package: '@fifthbell/brokaw',
+      bundleVersion: '0.1.65',
+      schemaVersion: 1,
+      entrypoint: 'index.html',
+      entrypointUrl:
+        'https://cdn.fifthbell.com/html/program-releases/0.1.65/index.html',
+      capabilities: ['scene.configuration'],
+      control: {
+        protocol: 'alcantara.program.v1',
+        transport: 'server-sent-events',
+        snapshotPath: 'state',
+        eventsPath: 'events',
+        runtimeParameters: {
+          programId: 'programId',
+          apiBaseUrl: 'apiBaseUrl',
+        },
+        signals: ['program_state_snapshot', 'scene_change'],
+      },
+    };
+    jest.spyOn(service, 'getState').mockResolvedValue({
+      id: 1,
+      programId: 'fifthbell',
+      activeSceneId: scene.id,
+      activeScene: scene,
+      stagedSceneId: null,
+      stagedScene: null,
+      fadeToBlack: false,
+      updatedAt: '2026-09-08T18:00:00.000Z',
+      version: 0,
+      templateManifest,
+      operatorQueue: [{ secret: true }],
+    } as never);
+
+    const events: Array<Record<string, unknown>> = [];
+    const subscription = service
+      .getEventStream('fifthbell')
+      .subscribe((event) => events.push(JSON.parse(event.data)));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    service.broadcastUpdate('fifthbell', {
+      type: 'operator_snapshot',
+      secret: true,
+    });
+    service.broadcastUpdate('fifthbell', {
+      type: 'scene_change',
+      programId: 'fifthbell',
+      state: {
+        id: 1,
+        programId: 'fifthbell',
+        activeSceneId: scene.id,
+        activeScene: scene,
+        stagedSceneId: null,
+        stagedScene: null,
+        fadeToBlack: false,
+        updatedAt: '2026-09-08T18:01:00.000Z',
+        secret: true,
+      },
+      secret: true,
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      type: 'program_state_snapshot',
+      schemaVersion: 1,
+      state: { programId: 'fifthbell', activeSceneId: scene.id },
+    });
+    expect(events[0].state).not.toHaveProperty('operatorQueue');
+    expect(events[1]).toMatchObject({
+      type: 'scene_change',
+      schemaVersion: 1,
+      state: { programId: 'fifthbell', activeSceneId: scene.id },
+    });
+    expect(events[1]).not.toHaveProperty('secret');
+    expect(events[1].state).not.toHaveProperty('secret');
+
+    subscription.unsubscribe();
+  });
 });

--- a/backend/src/program/program.service.ts
+++ b/backend/src/program/program.service.ts
@@ -17,6 +17,13 @@ import {
   SongExecutionEngine,
   type SongEngineEvent,
 } from '../radio/song-execution.engine';
+import {
+  projectProgramTemplateSignal,
+  projectProgramTemplateState,
+  readProgramTemplateManifest,
+  type ProgramTemplateManifest,
+  type ProgramTemplateRegistration,
+} from './program-template.service';
 
 export interface ProgramAudioMeterChannel {
   vu: number;
@@ -1045,6 +1052,23 @@ export class ProgramService implements OnModuleInit {
     return normalized;
   }
 
+  private programTemplateUpdateData(
+    template: ProgramTemplateRegistration | null,
+  ): Record<string, unknown> {
+    if (!template) {
+      return {
+        templateUrl: null,
+        templateManifest: null,
+        templateVerifiedAt: null,
+      };
+    }
+    return {
+      templateUrl: template.templateUrl,
+      templateManifest: template.templateManifest as any,
+      templateVerifiedAt: template.templateVerifiedAt,
+    };
+  }
+
   private async getProgramStateRecord(programId: string) {
     const normalizedProgramId = this.normalizeProgramId(programId);
     let state = await this.prisma.programState.findUnique({
@@ -1199,7 +1223,11 @@ export class ProgramService implements OnModuleInit {
     };
   }
 
-  async createProgram(programId: string, type?: string) {
+  async createProgram(
+    programId: string,
+    type?: string,
+    template?: ProgramTemplateRegistration | null,
+  ) {
     const normalized = this.normalizeProgramId(programId);
     const programType =
       type === 'radio' || type === 'both' || type === 'tv' ? type : 'tv';
@@ -1217,6 +1245,7 @@ export class ProgramService implements OnModuleInit {
       data: {
         programId: normalized,
         type: programType,
+        ...this.programTemplateUpdateData(template ?? null),
         activeSceneId: null,
         audioMixer: this.createDefaultProgramAudioMixerSettings() as any,
       },
@@ -1224,10 +1253,15 @@ export class ProgramService implements OnModuleInit {
     return this.getProgramStateWithScenes(normalized);
   }
 
-  async renameProgram(programId: string, nextProgramId: string, type?: string) {
+  async renameProgram(
+    programId: string,
+    nextProgramId: string,
+    type?: string,
+    template?: ProgramTemplateRegistration | null,
+  ) {
     const current = this.normalizeProgramId(programId);
     const next = this.normalizeProgramId(nextProgramId);
-    if (current === next && type === undefined) {
+    if (current === next && type === undefined && template === undefined) {
       return this.getProgramStateWithScenes(current);
     }
 
@@ -1238,10 +1272,15 @@ export class ProgramService implements OnModuleInit {
         : undefined;
 
     if (current === next) {
-      if (programType) {
+      if (programType || template !== undefined) {
         await this.prisma.programState.update({
           where: { programId: current },
-          data: { type: programType },
+          data: {
+            ...(programType ? { type: programType } : {}),
+            ...(template !== undefined
+              ? this.programTemplateUpdateData(template)
+              : {}),
+          },
         });
       }
       return this.getProgramStateWithScenes(current);
@@ -1266,6 +1305,9 @@ export class ProgramService implements OnModuleInit {
     const updateData: Record<string, unknown> = { programId: next };
     if (programType) {
       updateData.type = programType;
+    }
+    if (template !== undefined) {
+      Object.assign(updateData, this.programTemplateUpdateData(template));
     }
 
     await this.prisma.programState.update({
@@ -1377,6 +1419,14 @@ export class ProgramService implements OnModuleInit {
       ...state,
       version: this.getProgramTopicVersion(normalizedProgramId, 'state'),
     };
+  }
+
+  async getPublicState(programId: string = ProgramService.DEFAULT_PROGRAM_ID) {
+    const state = await this.getState(programId);
+    const manifest = readProgramTemplateManifest(state.templateManifest);
+    return manifest
+      ? projectProgramTemplateState(state as Record<string, unknown>)
+      : state;
   }
 
   async getStagedScene(programId: string = ProgramService.DEFAULT_PROGRAM_ID) {
@@ -3207,14 +3257,22 @@ export class ProgramService implements OnModuleInit {
     return new Observable<{ data: string }>((subscriber) => {
       let snapshotDelivered = false;
       let closed = false;
+      let templateManifest: ProgramTemplateManifest | null = null;
+      let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
       const pendingEvents: unknown[] = [];
       const serialize = (data: unknown) => ({ data: JSON.stringify(data) });
+      const sendEvent = (data: unknown) => {
+        const projected = templateManifest
+          ? projectProgramTemplateSignal(data, templateManifest)
+          : data;
+        if (projected) subscriber.next(serialize(projected));
+      };
 
       this.metrics?.recordProgramSseConnection(1);
       const liveSubscription = subject.subscribe({
         next: (data) => {
           if (snapshotDelivered) {
-            subscriber.next(serialize(data));
+            sendEvent(data);
             return;
           }
           pendingEvents.push(data);
@@ -3225,19 +3283,41 @@ export class ProgramService implements OnModuleInit {
       void this.getState(normalizedProgramId)
         .then((state) => {
           if (closed) return;
+          templateManifest = readProgramTemplateManifest(
+            state.templateManifest,
+          );
+          const publicState = templateManifest
+            ? projectProgramTemplateState(
+                state as unknown as Record<string, unknown>,
+              )
+            : state;
           subscriber.next(
             serialize({
               type: 'program_state_snapshot',
               programId: normalizedProgramId,
-              state,
+              ...(templateManifest ? { schemaVersion: 1 } : {}),
+              state: publicState,
               version: state.version,
             }),
           );
           snapshotDelivered = true;
           for (const event of pendingEvents) {
-            subscriber.next(serialize(event));
+            sendEvent(event);
           }
           pendingEvents.length = 0;
+          if (templateManifest?.control.signals.includes('heartbeat')) {
+            heartbeatTimer = setInterval(() => {
+              sendEvent({
+                type: 'heartbeat',
+                programId: normalizedProgramId,
+                version: this.getProgramTopicVersion(
+                  normalizedProgramId,
+                  'state',
+                ),
+                sentAt: new Date().toISOString(),
+              });
+            }, 15_000);
+          }
           this.metrics?.recordProgramSseSnapshot('success');
         })
         .catch((error: unknown) => {
@@ -3248,6 +3328,7 @@ export class ProgramService implements OnModuleInit {
 
       return () => {
         closed = true;
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
         liveSubscription.unsubscribe();
         this.metrics?.recordProgramSseConnection(-1);
       };

--- a/deploy/cumulus.sh
+++ b/deploy/cumulus.sh
@@ -74,7 +74,7 @@ if ! docker run -d --name alcantara-backend \
   -e ARAUCO_SECRET_ID="$database_secret_id" \
   -e ALCANTARA_BUILD_VERSION="${image##*:}" \
   -e ALCANTARA_CONFIG_SECRET_ID="$broadcast_secret_id" \
-  -e ALLOWED_ORIGINS=https://alcantara.gaulatti.com \
+  -e ALLOWED_ORIGINS=https://alcantara.gaulatti.com,https://fifthbell.com,https://cdn.fifthbell.com \
   -e POMPEII_TEAM_ID=1 \
   -e MEDIA_S3_BUCKET="$media_bucket" \
   -e CONTAINERIZED=true \

--- a/docs/program-templates.md
+++ b/docs/program-templates.md
@@ -1,0 +1,98 @@
+# Program template contracts
+
+Alcantara owns program state and control. It does not own the Fifthbell visual
+template. Brokaw builds the renderer and its machine-readable contract;
+Cronkite validates that package and publishes an immutable release to the CDN.
+Alcantara registers the release manifest against a program and opens the
+manifest's entrypoint with its declared runtime query parameters.
+
+## Published contract
+
+The initial contract is `kind: alcantara.program-template`,
+`contractVersion: 1`, and state `schemaVersion: 1`. A manifest declares:
+
+- template identity, package, bundle version, and relative HTML entrypoint;
+- bounded capabilities such as `audio.playback`, `media.groups`,
+  `scene.configuration`, and `stinger.transitions`;
+- the `alcantara.program.v1` control protocol over server-sent events;
+- relative snapshot and event paths;
+- query-parameter names for `programId` and `apiBaseUrl`;
+- the exact signal types accepted by the renderer; and
+- release files, content types, byte counts, and SHA-256 digests.
+
+For Brokaw `0.1.65`, Cronkite publishes the immutable registration URL at:
+
+```text
+https://cdn.fifthbell.com/html/program-releases/0.1.65/live-program-manifest.json
+```
+
+The manifest entrypoint resolves within that same release prefix. The rendered
+page runs on `https://cdn.fifthbell.com`, so Alcantara's API permits that exact
+browser origin. `https://fifthbell.com` is also allowed for a later public-route
+alias; wildcard origins are not used.
+
+## Register a program
+
+Open **Programs**, create or edit a program, paste the immutable JSON manifest
+URL into **Template URL**, and choose **Inspect**. Alcantara fetches the URL on
+the server, verifies the contract, and displays its capabilities. Saving repeats
+the inspection so a stale preview cannot bypass validation. Program list cards
+and the global **Open Program Output** action then open the external entrypoint
+with the selected program ID and the configured Alcantara API origin.
+
+The production registration endpoint accepts only HTTPS manifests from the
+code-owned Cronkite publisher origin `https://cdn.fifthbell.com`. Local
+development additionally permits `http://localhost` and `http://127.0.0.1`.
+Manifest requests reject credentials, query strings, fragments, unsafe
+relative paths, non-JSON responses, bodies larger than 256 KiB, more than three
+redirects, and hosts resolving to private, loopback, link-local, multicast, or
+documentation networks. Each redirect is checked again.
+
+Registration stores the final manifest URL, the normalized contract, its
+same-origin entrypoint URL, and the verification time. It does not load or
+execute template JavaScript inside the Alcantara application.
+
+## Public state and signals
+
+For a registered program, `GET /program/:programId/state` returns only schema
+version, program identity, active/staged scene projections, fade-to-black state,
+timestamps, and version. It omits operator queues, assignments, stored template
+metadata, and unrelated persistence fields.
+
+`GET /program/:programId/events` begins with the bounded snapshot, forwards only
+signal types declared by the stored manifest, projects each signal to its
+renderer fields, and emits a 15-second heartbeat when declared. Existing
+unregistered programs keep the legacy response during migration so the current
+renderer remains a rollback path.
+
+The private authenticated `/metrics` collector includes:
+
+- `alcantara_dependency_operations_total{dependency="program-template",operation="fetch",result}`;
+- `alcantara_dependency_duration_seconds{dependency="program-template",operation="fetch"}`;
+- `alcantara_program_sse_connections`; and
+- `alcantara_program_sse_snapshots_total{result}`.
+
+Template URLs and identities never appear in metric labels. A successful
+inspection records `success`; any rejected or failed inspection records the
+bounded `failure` result. HTTP route metrics continue to cover response status
+and latency for registration and public state/SSE requests.
+
+## Release and cutover
+
+Release in dependency order:
+
+1. Publish the tagged Brokaw package.
+2. Configure Cronkite with that exact package version and let startup publish
+   the immutable release before its canonical HTML pointer.
+3. Deploy the Alcantara schema migration and application.
+4. Register the Fifthbell program with the immutable manifest URL.
+5. Verify the CDN manifest and entrypoint, browser CORS, initial state, live SSE
+   scene changes, audio control, and reconnect heartbeat.
+6. Remove `frontend/app/programs/fifthbell/**`,
+   `frontend/public/fifthbell/**`, and the legacy Alcantara output route only
+   after the external renderer has passed those production checks.
+
+Rollback is data-only until step 6: clear the program's Template URL to return
+to the legacy Alcantara renderer. After step 6, roll back by redeploying the
+last frontend version containing that route or register a previously verified
+immutable Brokaw release. Never overwrite an immutable release prefix.

--- a/frontend/app/routes/layout.tsx
+++ b/frontend/app/routes/layout.tsx
@@ -33,8 +33,9 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, Outlet, useLocation, useNavigate } from 'react-router';
-import { apiUrl } from '../utils/apiBaseUrl';
+import { apiUrl, getApiBaseUrl } from '../utils/apiBaseUrl';
 import { useGlobalProgramId } from '../utils/globalProgram';
+import { resolveProgramOutputUrl, type ProgramTemplateManifest } from '../utils/programTemplate';
 import { useGlobalTransitionId } from '../utils/globalTransition';
 import { SCENE_TRANSITIONS, getSceneTransitionPreset } from '../utils/sceneTransitions';
 import { useLogout } from '../hooks/useAuth';
@@ -44,6 +45,7 @@ const GITHUB_REPO_URL = 'https://github.com/gaulatti/alcantara';
 interface ProgramSummary {
   programId: string;
   type?: 'tv' | 'radio' | 'both';
+  templateManifest?: ProgramTemplateManifest | null;
 }
 
 interface SceneSummary {
@@ -344,7 +346,8 @@ export default function Layout() {
     />
   );
 
-  const openProgramUrl = `/program/${encodeURIComponent(selectedProgramId)}`;
+  const selectedProgram = knownPrograms.find((program) => program.programId === selectedProgramId) ?? { programId: selectedProgramId };
+  const openProgramUrl = resolveProgramOutputUrl(selectedProgram, getApiBaseUrl());
   const triggerProgramReload = useCallback(async () => {
     if (!selectedProgramId.trim()) {
       return;
@@ -402,7 +405,6 @@ export default function Layout() {
   );
 
   const commandActions = useMemo<CommandSpotlightAction[]>(() => {
-    const selectedProgramPath = `/program/${encodeURIComponent(selectedProgramId)}`;
     const selectedProgramTitle = `Open Program Output (${selectedProgramId})`;
     const selectedProgramQuery = `programId=${encodeURIComponent(selectedProgramId)}`;
 
@@ -498,7 +500,7 @@ export default function Layout() {
         icon: <Radio size={16} />,
         onSelect: () => {
           if (typeof window === 'undefined') return;
-          window.open(selectedProgramPath, '_blank', 'noopener,noreferrer');
+          window.open(openProgramUrl, '_blank', 'noopener,noreferrer');
         }
       },
       {
@@ -645,6 +647,7 @@ export default function Layout() {
     clearBroadcastTimeOverride,
     loadBroadcastSettings,
     navigate,
+    openProgramUrl,
     programOptions,
     selectedProgramId,
     selectedTransition,

--- a/frontend/app/routes/programs.test.tsx
+++ b/frontend/app/routes/programs.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ProgramsAdmin from "./programs";
+import type { ProgramTemplateManifest } from "../utils/programTemplate";
+
+const { setSelectedProgramId } = vi.hoisted(() => ({
+  setSelectedProgramId: vi.fn(),
+}));
+
+vi.mock("../utils/globalProgram", () => ({
+  useGlobalProgramId: () => ["fifthbell", setSelectedProgramId],
+}));
+
+const templateUrl =
+  "https://cdn.fifthbell.com/html/program-releases/0.1.65/live-program-manifest.json";
+const manifest: ProgramTemplateManifest = {
+  kind: "alcantara.program-template",
+  contractVersion: 1,
+  id: "fifthbell.live-program",
+  name: "Fifthbell Live Program",
+  package: "@fifthbell/brokaw",
+  bundleVersion: "0.1.65",
+  schemaVersion: 1,
+  entrypoint: "index.html",
+  entrypointUrl:
+    "https://cdn.fifthbell.com/html/program-releases/0.1.65/index.html",
+  capabilities: ["audio.playback", "scene.configuration"],
+  control: {
+    protocol: "alcantara.program.v1",
+    transport: "server-sent-events",
+    snapshotPath: "state",
+    eventsPath: "events",
+    runtimeParameters: { programId: "programId", apiBaseUrl: "apiBaseUrl" },
+    signals: ["program_state_snapshot", "scene_change"],
+  },
+};
+
+describe("Programs template registration", () => {
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = function showModal() {
+      this.open = true;
+    };
+    HTMLDialogElement.prototype.close = function close() {
+      this.open = false;
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/program")) {
+          return Response.json([
+            {
+              id: 1,
+              programId: "fifthbell",
+              type: "tv",
+              activeSceneId: null,
+              scenes: [],
+              mediaGroups: [],
+              stingers: [],
+              templateUrl,
+              templateManifest: manifest,
+              templateVerifiedAt: "2026-09-08T18:00:00.000Z",
+            },
+          ]);
+        }
+        if (url.includes("/media-groups")) {
+          return Response.json({ data: [] });
+        }
+        return Response.json([]);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("opens the registered renderer and gates editor sections by capabilities", async () => {
+    render(
+      <MemoryRouter>
+        <ProgramsAdmin />
+      </MemoryRouter>,
+    );
+
+    const outputLink = await screen.findByRole("link", {
+      name: /open renderer/i,
+    });
+    expect(outputLink).toHaveAttribute(
+      "href",
+      "https://cdn.fifthbell.com/html/program-releases/0.1.65/index.html?programId=fifthbell&apiBaseUrl=http%3A%2F%2Flocalhost%3A3000",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit fifthbell" }));
+    expect(screen.getByDisplayValue(templateUrl)).toBeInTheDocument();
+    expect(screen.getByText("Program Scenes")).toBeInTheDocument();
+    expect(screen.queryByText("Program Media Groups")).not.toBeInTheDocument();
+    expect(screen.queryByText("Program Stingers")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/app/routes/programs.tsx
+++ b/frontend/app/routes/programs.tsx
@@ -1,10 +1,11 @@
 import { AlertContainer, Button, Card, Checkbox, Empty, IconButton, Input, LoadingSpinner, Modal, SectionHeader, showAlert } from '@gaulatti/bleecker';
-import { Pencil, Plus, Trash2, Radio, Tv } from 'lucide-react';
+import { ExternalLink, Link2, Pencil, Plus, Trash2, Radio, Tv } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import type { Route } from './+types/programs';
-import { apiUrl } from '../utils/apiBaseUrl';
+import { apiUrl, getApiBaseUrl } from '../utils/apiBaseUrl';
 import { useGlobalProgramId } from '../utils/globalProgram';
+import { hasProgramCapability, resolveProgramOutputUrl, type ProgramTemplateManifest } from '../utils/programTemplate';
 
 interface SceneSummary {
   id: number;
@@ -13,7 +14,6 @@ interface SceneSummary {
     name?: string;
   } | null;
 }
-
 interface ProgramSceneEntry {
   id: number;
   sceneId: number;
@@ -54,6 +54,9 @@ interface ProgramState {
   scenes: ProgramSceneEntry[];
   mediaGroups: ProgramMediaGroupEntry[];
   stingers: ProgramStingerEntry[];
+  templateUrl?: string | null;
+  templateManifest?: ProgramTemplateManifest | null;
+  templateVerifiedAt?: string | null;
 }
 
 export function meta({}: Route.MetaArgs) {
@@ -73,6 +76,10 @@ export default function ProgramsAdmin() {
   const [showModal, setShowModal] = useState(false);
   const [editingProgramId, setEditingProgramId] = useState<string | null>(null);
   const [programIdInput, setProgramIdInput] = useState('');
+  const [templateUrlInput, setTemplateUrlInput] = useState('');
+  const [templatePreview, setTemplatePreview] = useState<ProgramTemplateManifest | null>(null);
+  const [isInspectingTemplate, setIsInspectingTemplate] = useState(false);
+  const [templateError, setTemplateError] = useState('');
   const [selectedSceneIds, setSelectedSceneIds] = useState<number[]>([]);
   const [selectedMediaGroupIds, setSelectedMediaGroupIds] = useState<number[]>(
     [],
@@ -170,6 +177,9 @@ export default function ProgramsAdmin() {
   const openCreateModal = () => {
     setEditingProgramId(null);
     setProgramIdInput('');
+    setTemplateUrlInput('');
+    setTemplatePreview(null);
+    setTemplateError('');
     setSelectedSceneIds([]);
     setSelectedMediaGroupIds([]);
     setSelectedStingerIds([]);
@@ -183,6 +193,9 @@ export default function ProgramsAdmin() {
   const openEditModal = (program: ProgramState) => {
     setEditingProgramId(program.programId);
     setProgramIdInput(program.programId);
+    setTemplateUrlInput(program.templateUrl || '');
+    setTemplatePreview(program.templateManifest || null);
+    setTemplateError('');
     setSelectedSceneIds(program.scenes.map((entry) => entry.sceneId));
     setSelectedMediaGroupIds(
       (program.mediaGroups || []).map((entry) => entry.mediaGroupId),
@@ -201,6 +214,9 @@ export default function ProgramsAdmin() {
     setShowModal(false);
     setEditingProgramId(null);
     setProgramIdInput('');
+    setTemplateUrlInput('');
+    setTemplatePreview(null);
+    setTemplateError('');
     setSelectedSceneIds([]);
     setSelectedMediaGroupIds([]);
     setSelectedStingerIds([]);
@@ -363,6 +379,39 @@ export default function ProgramsAdmin() {
     }
   };
 
+  const inspectTemplate = async () => {
+    const templateUrl = templateUrlInput.trim();
+    if (!templateUrl) {
+      setTemplatePreview(null);
+      setTemplateError('Enter a template manifest URL to inspect.');
+      return;
+    }
+
+    setIsInspectingTemplate(true);
+    setTemplateError('');
+    try {
+      const response = await fetch(apiUrl('/program/template/inspect'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ templateUrl }),
+      });
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || `HTTP ${response.status}`);
+      }
+      const registration = (await response.json()) as {
+        templateManifest: ProgramTemplateManifest;
+      };
+      setTemplatePreview(registration.templateManifest);
+    } catch (inspectionError) {
+      console.error('Failed to inspect program template:', inspectionError);
+      setTemplatePreview(null);
+      setTemplateError('The template contract could not be verified.');
+    } finally {
+      setIsInspectingTemplate(false);
+    }
+  };
+
   const saveProgram = async () => {
     const nextProgramId = programIdInput.trim();
     if (!nextProgramId) {
@@ -374,61 +423,62 @@ export default function ProgramsAdmin() {
     try {
       const isEditing = !!editingProgramId;
       const editingProgram = isEditing ? programs.find((program) => program.programId === editingProgramId) || null : null;
+      let savedProgram: ProgramState;
+      const templateUrl = templateUrlInput.trim() || null;
 
       if (isEditing) {
-        const needsRename = editingProgramId !== nextProgramId;
-        if (needsRename) {
-          const renameBody: Record<string, unknown> = { nextProgramId };
-          if (selectedType !== (editingProgram?.type || 'tv')) {
-            renameBody.type = selectedType;
-          }
-          const res = await fetch(apiUrl(`/program/${encodeURIComponent(editingProgramId)}`), {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(renameBody)
-          });
-          if (!res.ok) {
-            const text = await res.text();
-            throw new Error(text || `HTTP ${res.status}`);
-          }
-        } else if (selectedType !== (editingProgram?.type || 'tv')) {
-          const res = await fetch(apiUrl(`/program/${encodeURIComponent(editingProgramId)}`), {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ nextProgramId, type: selectedType })
-          });
-          if (!res.ok) {
-            const text = await res.text();
-            throw new Error(text || `HTTP ${res.status}`);
-          }
+        const res = await fetch(apiUrl(`/program/${encodeURIComponent(editingProgramId)}`), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            nextProgramId,
+            type: selectedType,
+            templateUrl,
+          }),
+        });
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || `HTTP ${res.status}`);
         }
+        savedProgram = (await res.json()) as ProgramState;
 
         const currentSceneIds = editingProgram?.scenes.map((entry) => entry.sceneId) || [];
-        const currentMediaGroupIds =
-          editingProgram?.mediaGroups.map((entry) => entry.mediaGroupId) || [];
-        const currentStingerIds =
-          editingProgram?.stingers.map((entry) => entry.stingerId) || [];
-        await syncProgramScenes(nextProgramId, currentSceneIds, selectedSceneIds);
-        await syncProgramMediaGroups(
-          nextProgramId,
-          currentMediaGroupIds,
-          selectedMediaGroupIds,
-        );
-        await syncProgramStingers(nextProgramId, currentStingerIds, selectedStingerIds);
+        const currentMediaGroupIds = editingProgram?.mediaGroups.map((entry) => entry.mediaGroupId) || [];
+        const currentStingerIds = editingProgram?.stingers.map((entry) => entry.stingerId) || [];
+        if (!savedProgram.templateManifest || hasProgramCapability(savedProgram.templateManifest, 'scene.configuration')) {
+          await syncProgramScenes(nextProgramId, currentSceneIds, selectedSceneIds);
+        }
+        if (!savedProgram.templateManifest || hasProgramCapability(savedProgram.templateManifest, 'media.groups')) {
+          await syncProgramMediaGroups(nextProgramId, currentMediaGroupIds, selectedMediaGroupIds);
+        }
+        if (!savedProgram.templateManifest || hasProgramCapability(savedProgram.templateManifest, 'stinger.transitions')) {
+          await syncProgramStingers(nextProgramId, currentStingerIds, selectedStingerIds);
+        }
       } else {
         const createRes = await fetch(apiUrl('/program'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ programId: nextProgramId, type: selectedType })
+          body: JSON.stringify({
+            programId: nextProgramId,
+            type: selectedType,
+            templateUrl,
+          }),
         });
         if (!createRes.ok) {
           const text = await createRes.text();
           throw new Error(text || `HTTP ${createRes.status}`);
         }
+        savedProgram = (await createRes.json()) as ProgramState;
 
-        await syncProgramScenes(nextProgramId, [], selectedSceneIds);
-        await syncProgramMediaGroups(nextProgramId, [], selectedMediaGroupIds);
-        await syncProgramStingers(nextProgramId, [], selectedStingerIds);
+        if (!savedProgram.templateManifest || hasProgramCapability(savedProgram.templateManifest, 'scene.configuration')) {
+          await syncProgramScenes(nextProgramId, [], selectedSceneIds);
+        }
+        if (!savedProgram.templateManifest || hasProgramCapability(savedProgram.templateManifest, 'media.groups')) {
+          await syncProgramMediaGroups(nextProgramId, [], selectedMediaGroupIds);
+        }
+        if (!savedProgram.templateManifest || hasProgramCapability(savedProgram.templateManifest, 'stinger.transitions')) {
+          await syncProgramStingers(nextProgramId, [], selectedStingerIds);
+        }
       }
 
       if (isEditing && editingProgramId === selectedProgramId) {
@@ -448,6 +498,10 @@ export default function ProgramsAdmin() {
       setIsSaving(false);
     }
   };
+
+  const supportsSceneConfiguration = !templatePreview || hasProgramCapability(templatePreview, 'scene.configuration');
+  const supportsMediaGroups = !templatePreview || hasProgramCapability(templatePreview, 'media.groups');
+  const supportsStingers = !templatePreview || hasProgramCapability(templatePreview, 'stinger.transitions');
 
   const deleteProgram = async (programId: string) => {
     if (!confirm(`Delete program "${programId}"? This removes its scene assignments and active scene state.`)) return;
@@ -533,6 +587,20 @@ export default function ProgramsAdmin() {
                           Scenes assigned: {program.scenes.length} · Media groups assigned: {(program.mediaGroups || []).length} · Stingers assigned: {(program.stingers || []).length} · Active scene:{' '}
                           {program.activeSceneId ?? 'none'}
                         </p>
+                        {program.templateManifest ? (
+                          <div className='mt-3 flex flex-wrap items-center gap-2 text-xs text-text-secondary'>
+                            <Link2 size={13} />
+                            <span>
+                              {program.templateManifest.name} · {program.templateManifest.bundleVersion}
+                            </span>
+                            <a href={resolveProgramOutputUrl(program, getApiBaseUrl())} target='_blank' rel='noopener noreferrer' className='inline-flex items-center gap-1 font-medium text-sea underline-offset-2 hover:underline'>
+                              Open renderer <ExternalLink size={12} />
+                            </a>
+                          </div>
+                        ) : (
+                          <p className='mt-3 text-xs text-terracotta'>Transitional Alcantara renderer · no external template registered</p>
+                        )}
+
                       </div>
                       <div className='flex items-start gap-2'>
                         <Button size='sm' variant={isSelected ? 'secondary' : 'ghost'} onClick={() => setSelectedProgramId(program.programId)} className='px-3'>
@@ -584,6 +652,49 @@ export default function ProgramsAdmin() {
             </div>
 
             <div>
+              <label className='mb-2 block text-sm font-medium text-text-primary dark:text-text-primary'>Template URL</label>
+              <div className='flex items-start gap-2'>
+                <Input
+                  type='url'
+                  value={templateUrlInput}
+                  onChange={(event) => {
+                    setTemplateUrlInput(event.target.value);
+                    setTemplatePreview(null);
+                    setTemplateError('');
+                  }}
+                  placeholder='https://cdn.fifthbell.com/html/program-releases/0.1.65/live-program-manifest.json'
+                  aria-describedby='template-url-help'
+                  error={!!templateError}
+                />
+                <Button type='button' variant='secondary' onClick={() => void inspectTemplate()} disabled={isInspectingTemplate || !templateUrlInput.trim()}>
+                  {isInspectingTemplate ? 'Inspecting…' : 'Inspect'}
+                </Button>
+              </div>
+              <p id='template-url-help' className='mt-2 text-xs text-text-secondary'>
+                Reference the immutable JSON manifest published with the template. Alcantara verifies its contract before saving.
+              </p>
+              {templateError ? (
+                <p className='mt-2 text-sm text-terracotta' role='alert'>
+                  {templateError}
+                </p>
+              ) : null}
+              {templatePreview ? (
+                <div className='mt-3 rounded-xl border border-sea/20 bg-sea/5 p-3'>
+                  <p className='text-sm font-medium text-text-primary'>
+                    {templatePreview.name} · {templatePreview.bundleVersion}
+                  </p>
+                  <div className='mt-2 flex flex-wrap gap-1.5'>
+                    {templatePreview.capabilities.map((capability) => (
+                      <span key={capability} className='rounded-full border border-sea/20 bg-white/70 px-2 py-0.5 text-xs text-sea dark:bg-dark-sand/70'>
+                        {capability}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+
+            <div>
               <label className='mb-2 block text-sm font-medium text-text-primary dark:text-text-primary'>Program Type</label>
               <div className='flex gap-2'>
                 {(['tv', 'radio', 'both'] as const).map((type) => (
@@ -604,121 +715,97 @@ export default function ProgramsAdmin() {
               </div>
             </div>
 
-            <div>
-              <div className='mb-2 flex items-center justify-between'>
-                <label className='block text-sm font-medium text-text-primary dark:text-text-primary'>Program Scenes</label>
-                <Button size='sm' variant='ghost' onClick={() => navigate('/scenes')}>
-                  Manage Scenes
-                </Button>
-              </div>
-              {sortedScenes.length === 0 ? (
-                <p className='text-sm text-text-secondary dark:text-text-secondary'>No scenes available. Create scenes first.</p>
-              ) : (
-                <div className='max-h-64 space-y-2 overflow-y-auto rounded-xl border border-sand/20 bg-white/70 p-3 dark:border-sand/40 dark:bg-dark-sand/50'>
-                  <Input
-                    type='search'
-                    value={sceneSearch}
-                    onChange={(event) => setSceneSearch(event.target.value)}
-                    placeholder='Search scenes by name or layout…'
-                    aria-label='Search program scenes'
-                    className='sticky top-0 z-10 w-full border-sand/30 bg-white/95 px-3 py-2 text-sm dark:bg-dark-sand/95'
-                  />
-                  {filteredScenes.map((scene) => {
-                    const checked = selectedSceneIds.includes(scene.id);
-                    return (
-                      <label key={scene.id} className='flex cursor-pointer items-start gap-3 rounded-lg px-2 py-1.5 hover:bg-sand/10 dark:hover:bg-sand/15'>
-                        <Checkbox checked={checked} onChange={() => toggleSceneSelection(scene.id)} />
-                        <span className='min-w-0'>
-                          <span className='block text-sm font-medium text-text-primary dark:text-text-primary'>{scene.name}</span>
-                          <span className='block text-xs text-text-secondary dark:text-text-secondary'>{scene.layout?.name || 'No layout'}</span>
-                        </span>
-                      </label>
-                    );
-                  })}
-                  {filteredScenes.length === 0 ? (
-                    <p className='px-2 py-4 text-center text-sm text-text-secondary'>No scenes match “{sceneSearch}”.</p>
-                  ) : null}
+            {supportsSceneConfiguration ? (
+              <div>
+                <div className='mb-2 flex items-center justify-between'>
+                  <label className='block text-sm font-medium text-text-primary dark:text-text-primary'>Program Scenes</label>
+                  <Button size='sm' variant='ghost' onClick={() => navigate('/scenes')}>
+                    Manage Scenes
+                  </Button>
                 </div>
-              )}
-            </div>
-
-            <div>
-              <div className='mb-2 flex items-center justify-between'>
-                <label className='block text-sm font-medium text-text-primary dark:text-text-primary'>Program Media Groups</label>
-                <Button size='sm' variant='ghost' onClick={() => navigate('/media')}>
-                  Manage Media
-                </Button>
-              </div>
-              {sortedMediaGroups.length === 0 ? (
-                <p className='text-sm text-text-secondary dark:text-text-secondary'>No media groups available. Create media groups first.</p>
-              ) : (
-                <div className='max-h-64 space-y-2 overflow-y-auto rounded-xl border border-sand/20 bg-white/70 p-3 dark:border-sand/40 dark:bg-dark-sand/50'>
-                  <Input
-                    type='search'
-                    value={mediaGroupSearch}
-                    onChange={(event) => setMediaGroupSearch(event.target.value)}
-                    placeholder='Search media groups by name or description…'
-                    aria-label='Search program media groups'
-                    className='sticky top-0 z-10 w-full border-sand/30 bg-white/95 px-3 py-2 text-sm dark:bg-dark-sand/95'
-                  />
-                  {filteredMediaGroups.map((mediaGroup) => {
-                    const checked = selectedMediaGroupIds.includes(mediaGroup.id);
-                    return (
-                      <label
-                        key={mediaGroup.id}
-                        className='flex cursor-pointer items-start gap-3 rounded-lg px-2 py-1.5 hover:bg-sand/10 dark:hover:bg-sand/15'
-                      >
-                        <Checkbox
-                          checked={checked}
-                          onChange={() => toggleMediaGroupSelection(mediaGroup.id)}
-                        />
-                        <span className='min-w-0'>
-                          <span className='block text-sm font-medium text-text-primary dark:text-text-primary'>{mediaGroup.name}</span>
-                          <span className='block text-xs text-text-secondary dark:text-text-secondary'>
-                            {mediaGroup.description || 'No description'}
+                {sortedScenes.length === 0 ? (
+                  <p className='text-sm text-text-secondary dark:text-text-secondary'>No scenes available. Create scenes first.</p>
+                ) : (
+                  <div className='max-h-64 space-y-2 overflow-y-auto rounded-xl border border-sand/20 bg-white/70 p-3 dark:border-sand/40 dark:bg-dark-sand/50'>
+                    <Input type='search' value={sceneSearch} onChange={(event) => setSceneSearch(event.target.value)} placeholder='Search scenes by name or layout…' aria-label='Search program scenes' className='sticky top-0 z-10 w-full border-sand/30 bg-white/95 px-3 py-2 text-sm dark:bg-dark-sand/95' />
+                    {filteredScenes.map((scene) => {
+                      const checked = selectedSceneIds.includes(scene.id);
+                      return (
+                        <label key={scene.id} className='flex cursor-pointer items-start gap-3 rounded-lg px-2 py-1.5 hover:bg-sand/10 dark:hover:bg-sand/15'>
+                          <Checkbox checked={checked} onChange={() => toggleSceneSelection(scene.id)} />
+                          <span className='min-w-0'>
+                            <span className='block text-sm font-medium text-text-primary dark:text-text-primary'>{scene.name}</span>
+                            <span className='block text-xs text-text-secondary dark:text-text-secondary'>{scene.layout?.name || 'No layout'}</span>
                           </span>
-                        </span>
-                      </label>
-                    );
-                  })}
-                  {filteredMediaGroups.length === 0 ? (
-                    <p className='px-2 py-4 text-center text-sm text-text-secondary'>No media groups match “{mediaGroupSearch}”.</p>
-                  ) : null}
-                </div>
-              )}
-            </div>
-
-            <div>
-              <div className='mb-2 flex items-center justify-between'>
-                <label className='block text-sm font-medium text-text-primary dark:text-text-primary'>Program Stingers</label>
-                <Button size='sm' variant='ghost' onClick={() => navigate('/stingers')}>
-                  Manage Stingers
-                </Button>
+                        </label>
+                      );
+                    })}
+                    {filteredScenes.length === 0 ? <p className='px-2 py-4 text-center text-sm text-text-secondary'>No scenes match “{sceneSearch}”.</p> : null}
+                  </div>
+                )}
               </div>
-              {sortedStingers.length === 0 ? (
-                <p className='text-sm text-text-secondary dark:text-text-secondary'>No stingers available. Create stingers first.</p>
-              ) : (
-                <div className='max-h-64 space-y-2 overflow-y-auto rounded-xl border border-sand/20 bg-white/70 p-3 dark:border-sand/40 dark:bg-dark-sand/50'>
-                  {sortedStingers.map((stinger) => {
-                    const checked = selectedStingerIds.includes(stinger.id);
-                    return (
-                      <label
-                        key={stinger.id}
-                        className='flex cursor-pointer items-start gap-3 rounded-lg px-2 py-1.5 hover:bg-sand/10 dark:hover:bg-sand/15'
-                      >
-                        <Checkbox
-                          checked={checked}
-                          onChange={() => toggleStingerSelection(stinger.id)}
-                        />
-                        <span className='min-w-0'>
-                          <span className='block text-sm font-medium text-text-primary dark:text-text-primary'>{stinger.name}</span>
-                        </span>
-                      </label>
-                    );
-                  })}
+            ) : (
+              <p className='rounded-xl border border-sand/20 bg-white/60 p-3 text-sm text-text-secondary dark:bg-dark-sand/50'>Scene assignment is unavailable because this template does not declare scene configuration.</p>
+            )}
+
+            {supportsMediaGroups ? (
+              <div>
+                <div className='mb-2 flex items-center justify-between'>
+                  <label className='block text-sm font-medium text-text-primary dark:text-text-primary'>Program Media Groups</label>
+                  <Button size='sm' variant='ghost' onClick={() => navigate('/media')}>
+                    Manage Media
+                  </Button>
                 </div>
-              )}
-            </div>
+                {sortedMediaGroups.length === 0 ? (
+                  <p className='text-sm text-text-secondary dark:text-text-secondary'>No media groups available. Create media groups first.</p>
+                ) : (
+                  <div className='max-h-64 space-y-2 overflow-y-auto rounded-xl border border-sand/20 bg-white/70 p-3 dark:border-sand/40 dark:bg-dark-sand/50'>
+                    <Input type='search' value={mediaGroupSearch} onChange={(event) => setMediaGroupSearch(event.target.value)} placeholder='Search media groups by name or description…' aria-label='Search program media groups' className='sticky top-0 z-10 w-full border-sand/30 bg-white/95 px-3 py-2 text-sm dark:bg-dark-sand/95' />
+                    {filteredMediaGroups.map((mediaGroup) => {
+                      const checked = selectedMediaGroupIds.includes(mediaGroup.id);
+                      return (
+                        <label key={mediaGroup.id} className='flex cursor-pointer items-start gap-3 rounded-lg px-2 py-1.5 hover:bg-sand/10 dark:hover:bg-sand/15'>
+                          <Checkbox checked={checked} onChange={() => toggleMediaGroupSelection(mediaGroup.id)} />
+                          <span className='min-w-0'>
+                            <span className='block text-sm font-medium text-text-primary dark:text-text-primary'>{mediaGroup.name}</span>
+                            <span className='block text-xs text-text-secondary dark:text-text-secondary'>{mediaGroup.description || 'No description'}</span>
+                          </span>
+                        </label>
+                      );
+                    })}
+                    {filteredMediaGroups.length === 0 ? <p className='px-2 py-4 text-center text-sm text-text-secondary'>No media groups match “{mediaGroupSearch}”.</p> : null}
+                  </div>
+                )}
+              </div>
+            ) : null}
+
+            {supportsStingers ? (
+              <div>
+                <div className='mb-2 flex items-center justify-between'>
+                  <label className='block text-sm font-medium text-text-primary dark:text-text-primary'>Program Stingers</label>
+                  <Button size='sm' variant='ghost' onClick={() => navigate('/stingers')}>
+                    Manage Stingers
+                  </Button>
+                </div>
+                {sortedStingers.length === 0 ? (
+                  <p className='text-sm text-text-secondary dark:text-text-secondary'>No stingers available. Create stingers first.</p>
+                ) : (
+                  <div className='max-h-64 space-y-2 overflow-y-auto rounded-xl border border-sand/20 bg-white/70 p-3 dark:border-sand/40 dark:bg-dark-sand/50'>
+                    {sortedStingers.map((stinger) => {
+                      const checked = selectedStingerIds.includes(stinger.id);
+                      return (
+                        <label key={stinger.id} className='flex cursor-pointer items-start gap-3 rounded-lg px-2 py-1.5 hover:bg-sand/10 dark:hover:bg-sand/15'>
+                          <Checkbox checked={checked} onChange={() => toggleStingerSelection(stinger.id)} />
+                          <span className='min-w-0'>
+                            <span className='block text-sm font-medium text-text-primary dark:text-text-primary'>{stinger.name}</span>
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            ) : null}
 
             {error ? <p className='text-sm text-terracotta'>{error}</p> : null}
 

--- a/frontend/app/utils/programTemplate.test.tsx
+++ b/frontend/app/utils/programTemplate.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasProgramCapability,
+  resolveProgramOutputUrl,
+  type ProgramTemplateManifest,
+} from "./programTemplate";
+
+const manifest: ProgramTemplateManifest = {
+  kind: "alcantara.program-template",
+  contractVersion: 1,
+  id: "fifthbell.live-program",
+  name: "Fifthbell Live Program",
+  package: "@fifthbell/brokaw",
+  bundleVersion: "0.1.65",
+  schemaVersion: 1,
+  entrypoint: "index.html",
+  entrypointUrl:
+    "https://cdn.fifthbell.com/html/program-releases/0.1.65/index.html",
+  capabilities: ["audio.playback", "scene.configuration"],
+  control: {
+    protocol: "alcantara.program.v1",
+    transport: "server-sent-events",
+    snapshotPath: "state",
+    eventsPath: "events",
+    runtimeParameters: {
+      programId: "programId",
+      apiBaseUrl: "apiBaseUrl",
+    },
+    signals: ["program_state_snapshot", "scene_change"],
+  },
+};
+
+describe("program template URLs", () => {
+  it("opens a registered renderer with its declared runtime parameters", () => {
+    expect(
+      resolveProgramOutputUrl(
+        { programId: "fifthbell", templateManifest: manifest },
+        "https://api.alcantara.gaulatti.com/",
+      ),
+    ).toBe(
+      "https://cdn.fifthbell.com/html/program-releases/0.1.65/index.html?programId=fifthbell&apiBaseUrl=https%3A%2F%2Fapi.alcantara.gaulatti.com",
+    );
+  });
+
+  it("retains the transitional Alcantara renderer for unregistered programs", () => {
+    expect(
+      resolveProgramOutputUrl(
+        { programId: "modo italiano" },
+        "https://api.test",
+      ),
+    ).toBe("/program/modo%20italiano");
+  });
+
+  it("reports only capabilities declared by the template", () => {
+    expect(hasProgramCapability(manifest, "audio.playback")).toBe(true);
+    expect(hasProgramCapability(manifest, "media.groups")).toBe(false);
+  });
+});

--- a/frontend/app/utils/programTemplate.ts
+++ b/frontend/app/utils/programTemplate.ts
@@ -1,0 +1,58 @@
+export interface ProgramTemplateManifest {
+  kind: "alcantara.program-template";
+  contractVersion: 1;
+  id: string;
+  name: string;
+  package: string;
+  bundleVersion: string;
+  schemaVersion: number;
+  entrypoint: string;
+  entrypointUrl: string;
+  capabilities: string[];
+  control: {
+    protocol: "alcantara.program.v1";
+    transport: "server-sent-events";
+    snapshotPath: string;
+    eventsPath: string;
+    runtimeParameters: {
+      programId: string;
+      apiBaseUrl: string;
+    };
+    signals: string[];
+  };
+}
+
+export interface ProgramWithTemplate {
+  programId: string;
+  templateUrl?: string | null;
+  templateManifest?: ProgramTemplateManifest | null;
+  templateVerifiedAt?: string | null;
+}
+
+export function hasProgramCapability(
+  manifest: ProgramTemplateManifest | null | undefined,
+  capability: string,
+): boolean {
+  return manifest?.capabilities.includes(capability) === true;
+}
+
+export function resolveProgramOutputUrl(
+  program: ProgramWithTemplate,
+  apiBaseUrl: string,
+): string {
+  const manifest = program.templateManifest;
+  if (!manifest?.entrypointUrl) {
+    return `/program/${encodeURIComponent(program.programId)}`;
+  }
+
+  const output = new URL(manifest.entrypointUrl);
+  output.searchParams.set(
+    manifest.control.runtimeParameters.programId,
+    program.programId,
+  );
+  output.searchParams.set(
+    manifest.control.runtimeParameters.apiBaseUrl,
+    apiBaseUrl.replace(/\/$/, ""),
+  );
+  return output.toString();
+}


### PR DESCRIPTION
## Summary
- add verified, persisted program-template registration by immutable manifest URL
- expose capability-aware registration/output controls in Programs and the global shell
- project registered-program snapshot/SSE payloads to a versioned allowlist with optional heartbeat
- allow exact Fifthbell renderer origins, add bounded template-fetch metrics, and document cutover/rollback
- keep the legacy renderer as a temporary rollback path until production registration is proven

Part of #25. The issue should close only after the production cutover and legacy Fifthbell renderer removal.

## Verification
- backend: 31 suites / 162 tests, build, deployment contract (14 tests)
- focused template/controller/service/metrics: 18 tests
- frontend: 13 files / 50 tests and production build
- empty PostgreSQL: all 8 migrations applied, deterministic seed completed
- built Brokaw `0.1.65` manifest accepted by Alcantara validator

## Known baseline
`pnpm --dir frontend run typecheck` still reports existing errors in unrelated files; the production build and all frontend tests pass, and none of those diagnostics point to this change.

## Deployment dependency
Merge/deploy after Brokaw `0.1.65` is published and Cronkite has published its immutable CDN release.

## Summary by Sourcery

Register externally hosted program renderers through verified immutable manifests while preserving a capability-aware, secure control-plane contract and legacy fallback.

New Features:
- Add verified registration of external program renderer templates from immutable manifests.
- Expose registered renderer output links and capability-aware program configuration in the Programs interface and global shell.
- Project registered-program state and SSE events through a versioned, allowlisted renderer contract with optional heartbeats.

Bug Fixes:
- Restrict template fetching to approved, public destinations with bounded responses, redirects, and production publisher origins.
- Prevent private program and operator data from being exposed through registered renderer state and event payloads.

Enhancements:
- Persist template URLs, normalized manifests, and verification timestamps on program state.
- Preserve the legacy Alcantara renderer as a rollback path for unregistered programs.
- Add bounded template-fetch dependency metrics and exact Fifthbell CORS origins.

Deployment:
- Update deployment environments to allow Fifthbell and its CDN origins.
- Document immutable template release, production cutover, and rollback procedures.

Documentation:
- Document the external renderer manifest contract, registration flow, security boundary, public state/SSE projection, metrics, and migration gates.

Tests:
- Add backend and frontend coverage for manifest validation, secure fetching, capability handling, renderer URL generation, state projection, and SSE filtering.

Chores:
- Add the database migration and schema fields required for program template registrations.